### PR TITLE
Fixed issue with JSONKit categories

### DIFF
--- a/JSONKit/1.4/JSONKit.podspec
+++ b/JSONKit/1.4/JSONKit.podspec
@@ -8,4 +8,6 @@ Pod::Spec.new do
            :commit => 'v1.4'
 
   source_files 'JSONKit.*'
+
+  xcconfig 'OTHER_LDFLAGS' => '-ObjC'
 end


### PR DESCRIPTION
Hi there! Thanks for starting this project, I think it's meeting a real need in the iOS and Mac communities.

This is a little change that allows JSONKit to load categories from the static library. Without this flag, trying to use any of those categories raises a `NSInvalidArgumentException` because the class doesn't recognize the selector.
