### PR TITLE
AFNetworking 0.5.1 depends on JSONKit.

### DIFF
--- a/AFNetworking/0.5.1/AFNetworking.podspec
+++ b/AFNetworking/0.5.1/AFNetworking.podspec
@@ -12,4 +12,5 @@ Pod::Spec.new do
   xcconfig 'OTHER_LDFLAGS' => '-ObjC ' \
                               '-all_load ' \
                               '-l z'
+  dependency 'JSONKit'
 end


### PR DESCRIPTION
Add JSONKit as a dependency for AFNetworking. Without it, it fails to build.
