### PR TITLE
Fixed FMDB Podspec

### DIFF
--- a/FMDB/1.5/FMDB.podspec
+++ b/FMDB/1.5/FMDB.podspec
@@ -7,5 +7,5 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/ccgus/fmdb.git',
                  :tag => 'v1.5' }
 
-  s.source_files = 'src'
+  s.source_files = 'src/FM*.*'
 end


### PR DESCRIPTION
FMDB example file (fmdb.m) contains `main` function which will cause
compile error when including FMDB to a project as a dependency
