### PR TITLE
NSLogger: CFNetwork is included in CoreFoundation.

### DIFF
--- a/NSLogger/1.0/NSLogger.podspec
+++ b/NSLogger/1.0/NSLogger.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
                   'filtering, image and binary logging, traces buffering, timing information, etc.'
 
   s.source_files = 'Client Logger/iOS/*.{h,m}'
-  s.frameworks   = 'CFNetwork', 'SystemConfiguration'
+  s.frameworks   = 'CoreFoundation', 'SystemConfiguration'
 
   s.clean_paths  = 'Docs', 'Screenshots', 'Desktop Viewer', 'Client Logger/iOS/*Test App*'
 end


### PR DESCRIPTION
Build failed with NSLogger, because CFNetwork.framework does not exist :)
