### PR TITLE
Expecta and ConciseKit

### DIFF
--- a/ConciseKit/0.1.0/ConciseKit.podspec
+++ b/ConciseKit/0.1.0/ConciseKit.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name     = 'ConciseKit'
+  s.version  = '0.1.0'
+  s.license  = 'MIT'
+  s.summary  = 'A set of Objective-C additions and macros that lets you write code more quickly.'
+  s.homepage = 'http://github.com/petejkim/ConciseKit'
+  s.author   = { 'Peter Jihoon Kim' => 'raingrove@gmail.com' }
+
+  s.source   = { :git => 'http://github.com/petejkim/ConciseKit.git', :tag => 'v0.1.0' }
+
+  s.source_files = 'src/**/*.{h,m}'
+
+  s.clean_paths = 'ConciseKitSpecs'
+
+  s.frameworks = 'Foundation'
+end
+

--- a/Expecta/0.1.0/Expecta.podspec
+++ b/Expecta/0.1.0/Expecta.podspec
@@ -1,0 +1,27 @@
+Pod::Spec.new do |s|
+  s.name     = 'Expecta'
+  s.version  = '0.1.0'
+  s.license  = 'MIT'
+  s.summary  = 'A matcher framework for Objective-C & Cocoa'
+  s.homepage = 'http://github.com/petejkim/expecta'
+  s.author   = { 'Peter Jihoon Kim' => 'raingrove@gmail.com' }
+
+  s.source   = { :git => 'http://github.com/petejkim/expecta.git', :tag => 'v0.1.0' }
+
+  s.description = %{
+    Expecta is a matcher framework for Objective-C and Cocoa. The main
+    advantage of using Expecta over other matcher frameworks is that you do not
+    have to specify the data types. Also, the syntax of Expecta matchers is
+    much more readable and does not suffer from parenthesitis. If you have used
+    Jasmine before, you will feel right at home!
+  }
+
+  s.source_files = 'src/**/*.{h,m}'
+
+  s.clean_paths = "Rakefile", "RDD.md", "products", "test", "*.xcodeproj"
+
+  s.frameworks = 'Foundation'
+
+  s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
+end
+


### PR DESCRIPTION
## Expecta

https://github.com/petejkim/expecta

Expecta is a matcher framework for Objective-C and Cocoa. The main advantage of using Expecta over other matcher frameworks is that you do not have to specify the data types. Also, the syntax of Expecta matchers is much more readable and does not suffer from parenthesitis. If you have used Jasmine before, you will feel right at home!
## ConciseKit

https://github.com/petejkim/ConciseKit

ConciseKit is a set of Objective-C additions and macros that lets you write code more quickly.
