### PR TITLE
Added OCHamcrest 1.6 Pod

### DIFF
--- a/OCHamcrest/1.6/OCHamcrest.podspec
+++ b/OCHamcrest/1.6/OCHamcrest.podspec
@@ -1,0 +1,22 @@
+
+Pod::Spec.new do |s|
+  s.name     = 'OCHamcrest'
+  s.version  = '1.6'
+  s.license  = 'BSD'
+  s.summary  = 'Unit test assertions on steroids: Hamcrest matchers for Objective-C'
+  s.homepage = 'https://github.com/jonreid/OCHamcrest'
+  s.author   = { 'Jon Reid' => 'jon.reid@mac.com' }
+
+  s.source   = { :git => 'https://github.com/jonreid/OCHamcrest.git', :tag => 'V1.6' }
+
+  s.description = %{
+      OCHamcrest is a framework for writing matcher objects, allowing you to
+      declaratively define "match" rules. There are a number of situations
+      where matchers are invaluable, such as UI validation, or data 
+      filtering, but it is in the area of writing flexible tests that
+      matchers are most commonly used.
+  }
+
+  s.source_files = 'Source/OCHamcrest.h', 'Source/Core/**/*.{h,m,mm}', 'Source/Library/**/*.{h,m,mm}'
+  s.clean_paths = "Examples", "Documentation", "Source/Tests", "Source/TestSupport"
+end


### PR DESCRIPTION
OCHamcrest is a framework for writing matcher objects, allowing you to declaratively define "match" rules.
