### PR TITLE
Add RestKit frameworks for OSX

### DIFF
--- a/RestKit/0.9.3/RestKit.podspec
+++ b/RestKit/0.9.3/RestKit.podspec
@@ -20,7 +20,11 @@ Pod::Spec.new do |s|
     ns.description = 'The network layer provides a request/response abstraction on top of NSURLConnection.'
     ns.dependency 'LibComponentLogging-NSLog'
     ns.source_files = 'Code/RestKit.h', 'Code/{Network,Support}/*.{h,m}'
-    ns.frameworks = 'CFNetwork', 'Security', 'MobileCoreServices', 'SystemConfiguration'
+    if config.ios?
+        ns.frameworks = 'CFNetwork', 'Security', 'MobileCoreServices', 'SystemConfiguration'
+    else
+        ns.frameworks = 'CoreServices', 'Security', 'SystemConfiguration'
+    end
   end
 
   # Like before, this creates a new spec with the name: RestKit/ObjectMapping and is a part of RestKit


### PR DESCRIPTION
Edited podspec to use different frameworks on OSX and iOS as suggested by alloy https://github.com/CocoaPods/Specs/pull/34#issuecomment-3618186
