### PR TITLE
Add ISO8601DateFormatter 0.6 Podspec

### DIFF
--- a/ISO8601DateFormatter/0.6/ISO8601DateFormatter.podspec
+++ b/ISO8601DateFormatter/0.6/ISO8601DateFormatter.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name     = 'ISO8601DateFormatter'
+  s.version  = '0.6'
+  s.license  = 'BSD'
+  s.summary  = 'A Cocoa NSFormatter subclass to convert dates to and from ISO-8601-formatted strings. Supports calendar, week, and ordinal formats.'
+  s.homepage = 'https://bitbucket.org/boredzo/iso-8601-parser-unparser/'
+  s.author   = 'Peter Hosey'
+  s.source   = { :git => 'https://github.com/ISO8601DateFormatter/ISO8601DateFormatter.git', :tag => '0.6' }
+
+  s.source_files = 'ISO8601DateFormatter.{h,m}'
+end


### PR DESCRIPTION
Every time I start a new Objective-C project, I inevitably come to a point where I need to parse dates, and every time, I have to resort to searching "objective-c parse iso 8601 dates", clicking a few times, downloading the source code, and manually adding it to my project.

"Enough is enough", I thought to myself, "I'm going to fix this."

With raw determination flowing through my veins, I used `hg-git` to push the mercurial repository where this project normally lives to https://github.com/ISO8601DateFormatter/ISO8601DateFormatter. Now with a proper git mirror, I created this spec, so that we may all rejoice in the simple pleasures of automatic dependency management.

Any feedback regarding mirroring or the spec itself, I'm all ears. I just wanted to have a few others sign off on this before adding this in.
