### PR TITLE
The path to developer frameworks

### DIFF
--- a/Kiwi/1.0.0/Kiwi.podspec
+++ b/Kiwi/1.0.0/Kiwi.podspec
@@ -7,6 +7,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/allending/Kiwi.git', :tag => 'v1.0.0' }
   s.source_files = 'Kiwi'
   s.framework    = 'SenTestingKit'
-  s.xcconfig     = { 'FRAMEWORK_SEARCH_PATHS' => '"$(SDKROOT)/Developer/Library/Frameworks"' }
+  s.xcconfig     = { 'FRAMEWORK_SEARCH_PATHS' => '"$(SDKROOT)/Developer/Library/Frameworks" "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
   s.clean_paths  = ["Examples", "Classes", "*.xcodeproj", "Other Sources", "Resources", "Templates", "Tests", "*.sh"]
 end


### PR DESCRIPTION
I was not able to find SenTestingKit framework in _$(SDKROOT)/Developer/Library/Frameworks_ on my machine. Since SenTestingKit is required by Kiwi and in the podspec file for Kiwi is only the other path given, I had to add a second path. These paths are often mentioned together (see http://stackoverflow.com/a/9406210/670119).
