### PR TITLE
MagicalRecord git url must use https not http

### DIFF
--- a/MagicalRecord/1.7.1/MagicalRecord.podspec
+++ b/MagicalRecord/1.7.1/MagicalRecord.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1! '
   s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
-  s.source   = { :git => 'http://github.com/magicalpanda/MagicalRecord.git', :tag => '1.7.1' }
+  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => '1.7.1' }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'Source/**/*.{h,m}'
   s.framework    = 'CoreData'

--- a/MagicalRecord/1.8.3/MagicalRecord.podspec
+++ b/MagicalRecord/1.8.3/MagicalRecord.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1! '
   s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
-  s.source   = { :git => 'http://github.com/magicalpanda/MagicalRecord.git', :tag => '1.8.3' }
+  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => '1.8.3' }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'Source/**/*.{h,m}'
   s.framework    = 'CoreData'


### PR DESCRIPTION
This was causing the pull request for this spec to fail silently
(the dir where the source is cloned to was empty), and so the whole
build would fail because libPods.a was never built. Would be nice
if 'pod install' failed when pulling specs from github failed.
