### PR TITLE
add libxml2 build setting to CocoaHTTPServer for iOS

### DIFF
--- a/CocoaHTTPServer/2.2.1/CocoaHTTPServer.podspec
+++ b/CocoaHTTPServer/2.2.1/CocoaHTTPServer.podspec
@@ -13,7 +13,8 @@ Pod::Spec.new do |s|
   else
     s.frameworks = 'CoreServices', 'Security'
   end
-  
+  s.library      = 'xml2'
+  s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
   s.dependency "CocoaAsyncSocket", "0.0.1"
   s.dependency "CocoaLumberjack", "1.3"
 end


### PR DESCRIPTION
it will have compile error if `$(SDKROOT)/usr/include/libxml2` doesn't appear in header search paths
