### PR TITLE
Add MessageUI.framework for SVWebViewController Spec

### DIFF
--- a/SVWebViewController/0.1/SVWebViewController.podspec
+++ b/SVWebViewController/0.1/SVWebViewController.podspec
@@ -6,6 +6,7 @@ Pod::Spec.new do |s|
   s.author   = { 'Sam Vermette' => 'http://samvermette.com' }
   s.source   = { :git => 'https://github.com/samvermette/SVWebViewController.git',
                  :tag => '0.1' }
+  s.platform = :ios
   s.source_files = 'SVWebViewController/*.{h,m}'
   s.resources = 'SVWebViewController/SVWebViewController.bundle'
   s.clean_paths = 'Demo'

--- a/SVWebViewController/0.1/SVWebViewController.podspec
+++ b/SVWebViewController/0.1/SVWebViewController.podspec
@@ -10,4 +10,5 @@ Pod::Spec.new do |s|
   s.resources = 'SVWebViewController/SVWebViewController.bundle'
   s.clean_paths = 'Demo'
   s.requires_arc = true;
+  s.frameworks = 'MessageUI'
 end


### PR DESCRIPTION
I created following Podfile.

```
platform :ios

dependency 'SVWebViewController'

target :tests, :exclusive => true do
  dependency 'Kiwi'
end
```

`pod install` installation was successful.
But, it occurred a build error when run TestTarget.

Xcode console...

```
Undefined symbols for architecture i386:
  "_OBJC_CLASS_$_MFMailComposeViewController", referenced from:
      objc-class-ref in libPods.a(SVWebViewController.o)
ld: symbol(s) not found for architecture i386
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

I've found SVWebViewController depend on MessageUI.framework. and fixed podspec.

https://github.com/samvermette/SVWebViewController/blob/master/SVWebViewController/SVWebViewController.h#L9
