### PR TITLE
Fix problem with pod spec for ECSlidingViewController

### DIFF
--- a/ECSlidingViewController/0.9.0/ECSlidingViewController.podspec
+++ b/ECSlidingViewController/0.9.0/ECSlidingViewController.podspec
@@ -8,6 +8,6 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'git://github.com/edgecase/ECSlidingViewController.git', :tag => '0.9.0' }
   s.platform = :ios
   s.source_files = 'ECSlidingViewController/Vendor/ECSlidingViewController/'
-  s.clean_paths  = 'ECSlidingViewController.xcodeproj', 'ECSlidingViewController.xcodeproj/**/*'
+  s.clean_paths  = 'ECSlidingViewController.xcodeproj'
   s.requires_arc = true
 end


### PR DESCRIPTION
Removed redundant entry from s.clean_paths

The entry in s.clean_paths already included 'ECSlidingViewController.xcodeproj' which
meant that the entry 'ECSlidingViewController.xcodeproj/*_/_' failed once the first entry completed.

This actually caused CocoaPods to silently fail which is not ideal...
