### PR TITLE
Added OHAttributedLabel 0.0.1.pre.1

### DIFF
--- a/OHAttributedLabel/0.0.1.pre.1/OHAttributedLabel.podspec
+++ b/OHAttributedLabel/0.0.1.pre.1/OHAttributedLabel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'OHAttributedLabel'
-  s.version  = '1.0.0.prerelease.1'
+  s.version  = '0.0.1.pre.1'
   s.license  = 'MIT'
   s.summary  = 'UILabel that supports NSAttributedString.'
   s.homepage = 'https://github.com/AliSoftware/OHAttributedLabel'

--- a/OHAttributedLabel/0.0.1.prerelease.1/OHAttributedLabel.podspec
+++ b/OHAttributedLabel/0.0.1.prerelease.1/OHAttributedLabel.podspec
@@ -1,0 +1,26 @@
+#
+# Be sure to run `pod spec lint OHAttributedLabel.podspec' to ensure this is a
+# valid spec.
+#
+# Remove all comments before submitting the spec.
+#
+Pod::Spec.new do |s|
+  s.name     = 'OHAttributedLabel'
+  s.version  = '1.0.0.prerelease.1'
+  s.license  = 'MIT'
+  s.summary  = 'UILabel that supports NSAttributedString.'
+  s.homepage = 'https://github.com/AliSoftware/OHAttributedLabel'
+  s.author   = { 'AliSoftware' => 'olivier.halligon+ae@gmail.com' }
+  
+  s.source   = { :git => 'git://github.com/AliSoftware/OHAttributedLabel.git', :commit => 'a417c6a10de748eaf899ad49f23393afa8e71137' }
+  
+  s.description = 'This class allows you to use a UILabel with NSAttributedStrings, in order to display styled text with mixed style (mixed fonts, color, size, ...) in a unique label.'
+  
+  s.platform = :ios
+
+  s.source_files = '*.{h,m}'
+
+  s.clean_path = "AttributedLabel Example"
+  
+  s.framework = 'CoreText'
+end

--- a/OHAttributedLabel/0.0.1.prerelease.1/OHAttributedLabel.podspec
+++ b/OHAttributedLabel/0.0.1.prerelease.1/OHAttributedLabel.podspec
@@ -1,9 +1,3 @@
-#
-# Be sure to run `pod spec lint OHAttributedLabel.podspec' to ensure this is a
-# valid spec.
-#
-# Remove all comments before submitting the spec.
-#
 Pod::Spec.new do |s|
   s.name     = 'OHAttributedLabel'
   s.version  = '1.0.0.prerelease.1'


### PR DESCRIPTION
Adding OHAttributedLabel.

I used 0.0.1.pre.1 as the version since I don't yet see a version scheme coming up for OHAttributedLabel. Will create an issue for that.
Until then I think it's smarter to use prerelease tagged versions since they allow updating (i.e. 0.0.1.pre.2).

https://github.com/CocoaPods/Specs/pull/75 tried to deliver but unfortunately failed.
