### PR TITLE
Fix MKNetworkKit 0.83 import statements

### DIFF
--- a/MKNetworkKit/0.83/MKNetworkKit.podspec
+++ b/MKNetworkKit/0.83/MKNetworkKit.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
     # Fix an import statement which is used inconsistently in MKNetworkKit
     # TODO create a ticket for this upstream
     header = (pod_destroot + 'MKNetworkKit/MKNetworkKit.h')
-    header_contents = header.read.sub('Reachability/Reachability.h', 'Reachability.h')
+    header_contents = header.read.sub('Reachability/Reachability.h', 'Reachability.h').gsub('Categories/', '')
     header.open('w') do |file|
      file.puts(header_contents)
     end


### PR DESCRIPTION
I'm having trouble using MKNetworkKit 0.83 with CocoaPods.
When I `import "MKNetworkKit.h"` into my project, I get a compile-time error:

```
Lexical or Preprocessor Issue
'Categories/NSString+MKNetworkKitAdditions.h' file not found
```

I found that `MKNetworkKit.h` looks for some headers in a subfolder called `Categories/`.
However, the header files in `Pods/Headers/MKNetworkKit/` have a flat hierarchy (no `Categories/` subfolder). When I adjust the import statements in MKNetworkKit.h post-install (just remove `Categories/` from them), it works fine.

I'm using XCode 4.3.2 and iOS 5.1.
