### PR TITLE
MKNetworkKit 0.83: Preserve header directory structure

### DIFF
--- a/MKNetworkKit/0.83/MKNetworkKit.podspec
+++ b/MKNetworkKit/0.83/MKNetworkKit.podspec
@@ -19,6 +19,10 @@ Pod::Spec.new do |s|
   s.clean_paths  = 'MKNetworkKit-*', '*-Demo', 'SampleImage.jpg'
   s.requires_arc = true
 
+  def s.copy_header_mapping(from)
+    from.sub('MKNetworkKit/', '')
+  end
+
   s.dependency 'Reachability', '~> 3.0'
 
   def s.post_install(target)


### PR DESCRIPTION
At the moment, when I `import "MKNetworkKit.h"` into my project, I get a compile-time error:

```
Lexical or Preprocessor Issue
'Categories/NSString+MKNetworkKitAdditions.h' file not found
```

The directory structure in `Pods/Headers/MKNetworkKit.h` does not match the original structure of `MKNetworkKit`. However, some imports in `MKNetworkKit.h` rely on this structure being there (they import headers from the `Categories/` subdirectory).

This commit preserves the original directory structure of the MKNetworkKit imports.
