### PR TITLE
vfrReader - added framework dependencies

### DIFF
--- a/vfrReader/2.5.6/vfrReader.podspec
+++ b/vfrReader/2.5.6/vfrReader.podspec
@@ -19,4 +19,6 @@ Pod::Spec.new do |s|
 
   #s.requires_arc = true
 
+  s.frameworks = 'ImageIO', 'MessageUI', 'QuartzCore'
+
 end


### PR DESCRIPTION
I didn't know of a way to test the pod spec locally.  Found that I missed listing the required frameworks when I tried it.  Added to the podspec.
