### PR TITLE
[Add] GTM (1.6.0)

### DIFF
--- a/GTM/1.6.0/GTM.podspec
+++ b/GTM/1.6.0/GTM.podspec
@@ -1,0 +1,67 @@
+Pod::Spec.new do |s|
+  s.name                    = "GTM"
+  s.version                 = "1.6.0"
+  s.summary                 = "Google Toolbox for Mac."
+  s.homepage                = "http://code.google.com/p/google-toolbox-for-mac/"
+  s.author                  = "Google"
+  s.source                  = { :svn => 'http://google-toolbox-for-mac.googlecode.com/svn/tags/google-toolbox-for-mac-1.6.0' }
+  s.license                 = { :type => 'Apache License 2.0', :file => 'COPYING' }
+  s.description             = 'A collection of source from different Google projects that may be of use to developers working other Mac projects. Also includes the Google Developer Spotlight Importers.'
+  s.source_files            = 'GTMDefines.h',
+  s.prefix_header_file      = 'GTM_Prefix.pch'
+  s.framework               = 'Cocoa', 'Carbon'
+  # TODO: s.xcconfig        = {}
+
+  ### Core subspecs
+
+  s.subspec 'Foundation' do |ss|
+    ss.osx.source_files = FileList['Foundation/*.{h,m}'].exclude(/Test/)
+    ss.osx.framework    = 'QuartzCore'
+    ss.ios.source_files = %w[
+      GTMStringEncoding         GTMNSDictionary+CaseInsensitive   GTMCalculatedRange
+      GTMExceptionalInlines     GTMGarbageCollection              GTMGeometryUtils
+      GTMLightweightProxy       GTMLogger                         GTMLoggerRingBufferWriter
+      GTMNSArray+Merge          GTMNSData+zlib                    GTMNSDictionary+URLArguments
+      GTMNSEnumerator+Filter    GTMNSFileManager+Path             GTMNSFileHandle+UniqueName
+      GTMNSNumber+64Bit         GTMNSObject+KeyValueObserving     GTMNSScanner+JSON
+      GTMNSScanner+Unsigned     GTMNSString+HTML                  GTMNSString+URLArguments
+      GTMNSString+XML           GTMNSThread+Blocks                GTMObjC2Runtime
+      GTMObjectSingleton        GTMPath                           GTMRegex
+      GTMStackTrace             GTMSystemVersion                  GTMURLBuilder
+      GTMValidatingContainers
+    ].map { |n| "Foundation/#{n}.{h,m}" }
+    ss.ios.framework    = 'QuartzCore', 'CoreGraphics'
+    ss.library          = 'sqlite3', 'z'
+  end
+
+  s.subspec 'DebugUtils' do |ss|
+    ss.source_files = FileList['DebugUtils/*.{h,m}'].exclude(/Test/)
+    ss.dependency     'GTM/Foundation'
+  end
+
+  ### Subspecs
+
+  s.subspec 'AddressBook' do |ss|
+    ss.source_files = FileList['AddressBook/*.{h,m}'].exclude(/Test/)
+    ss.framework    = 'AddressBook'
+    ss.dependency     'GTM/Foundation'
+    ss.dependency     'GTM/DebugUtils'
+  end
+
+  s.subspec 'AppKit' do |ss|
+    ss.osx.source_files = FileList['AppKit/*.{h,m}'].exclude(/Test/)
+    ss.osx.framework    = 'AppKit'
+    ss.ios.source_files = FileList['AppKit/GTMGoogleSearch.{h,m}']
+    ss.ios.framework    = 'UIKit'
+    ss.dependency         'GTM/Foundation'
+    ss.dependency         'GTM/DebugUtils'
+  end
+
+  s.subspec 'iPhone' do |ss|
+    ss.platform     = :ios
+    ss.source_files = FileList['iPhone/*.{h,m}'].exclude(/Test|GTMABAddressBook/)
+    ss.framework    = 'UIKit'
+    ss.dependency     'GTM/Foundation'
+    ss.dependency     'GTM/DebugUtils'
+  end
+end


### PR DESCRIPTION
I'm not sure if the name should be `Google-Toolbox-for-Mac` instead of `GTM`.

GTM is needed for the AWSiOSSDK (0c28b46fae657ba7822e6e4c99c18535bcc85a79). But it is crazy to download such a large library only for the logger. Moreover, I'm not sure which version of GTM Amazon is using, as this one is pretty old.

Also the xcconfigs of this library are very complex and I wasn't able to resolve them:

``` console
$ pod spec lint --verbose

 -> GTM (1.6.0)
    - NOTE  | XCODEBUILD >  GTM/AppKit/GTMGoogleSearch.m:131:1: warning: conflicting distributed object modifiers on return type in implementation of 'release' [-Wdistributed-object-modifiers]
    - NOTE  | XCODEBUILD >  GTM/Foundation/GTMObjectSingleton.h:62:52: note: expanded from macro 'GTMOBJECT_SINGLETON_BOILERPLATE'
    - NOTE  | XCODEBUILD >  GTM/Foundation/GTMStackTrace.m:106:17: warning: ordered comparison of function pointers ('IMP' (aka 'id (*)(id, SEL, ...)') and 'IMP')
    - NOTE  | XCODEBUILD >  GTM/Foundation/GTMStackTrace.m:119:17: warning: ordered comparison of function pointers ('IMP' (aka 'id (*)(id, SEL, ...)') and 'IMP')
    - NOTE  | XCODEBUILD >  GTM/Foundation/GTMValidatingContainers.m:213:10: warning: incompatible pointer types returning 'NSMutableArray *' from a function with result type 'GTMValidatingArray *' [-Wincompatible-pointer-types]
    - NOTE  | XCODEBUILD >  GTM/Foundation/GTMValidatingContainers.m:290:10: warning: incompatible pointer types returning 'NSMutableDictionary *' from a function with result type 'GTMValidatingDictionary *' [-Wincompatible-pointer-types]
    - NOTE  | XCODEBUILD >  GTM/Foundation/GTMValidatingContainers.m:369:10: warning: incompatible pointer types returning 'NSMutableSet *' from a function with result type 'GTMValidatingSet *' [-Wincompatible-pointer-types]
    - NOTE  | [OS X] XCODEBUILD >  warning: no rule to process file '$(PROJECT_DIR)/GTM/GTM_Prefix.pch' of type sourcecode.c.h for architecture x86_64
    - NOTE  | [OS X] XCODEBUILD >  warning: no rule to process file '$(PROJECT_DIR)/GTM/GTM_Prefix.pch' of type sourcecode.c.h for architecture x86_64
    - NOTE  | [OS X] XCODEBUILD >  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSObject.h:36:1: note: previous declaration is here
    - NOTE  | [OS X] XCODEBUILD >  GTM/AppKit/GTMCarbonEvent.m:496:1: warning: conflicting distributed object modifiers on return type in implementation of 'release' [-Wdistributed-object-modifiers]
    - NOTE  | [OS X] XCODEBUILD >  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSObject.h:36:1: note: previous declaration is here
    - NOTE  | [OS X] XCODEBUILD >  GTM/AppKit/GTMCarbonEvent.m:513:1: warning: conflicting distributed object modifiers on return type in implementation of 'release' [-Wdistributed-object-modifiers]
    - NOTE  | [OS X] XCODEBUILD >  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSObject.h:36:1: note: previous declaration is here
    - NOTE  | [OS X] XCODEBUILD >  GTM/AppKit/GTMCarbonEvent.m:524:1: warning: conflicting distributed object modifiers on return type in implementation of 'release' [-Wdistributed-object-modifiers]
    - NOTE  | [OS X] XCODEBUILD >  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSObject.h:36:1: note: previous declaration is here
    - NOTE  | [OS X] XCODEBUILD >  GTM/AppKit/GTMHotKeyTextField.m:746:1: warning: conflicting distributed object modifiers on return type in implementation of 'release' [-Wdistributed-object-modifiers]
    - NOTE  | [OS X] XCODEBUILD >  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSObject.h:36:1: note: previous declaration is here
    - NOTE  | [OS X] XCODEBUILD >  GTM/AppKit/GTMNSWorkspace+Running.m:193:1: warning: conflicting distributed object modifiers on return type in implementation of 'release' [-Wdistributed-object-modifiers]
    - NOTE  | [OS X] XCODEBUILD >  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSObject.h:36:1: note: previous declaration is here
    - NOTE  | [OS X] XCODEBUILD >  GTM/Foundation/GTMLogger+ASL.m:28:20: warning: incompatible pointer types sending 'GTMLogBasicFormatter *' to parameter of type 'NSFormatter *' [-Wincompatible-pointer-types]
    - NOTE  | [OS X] XCODEBUILD >  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSObject.h:37:1: note: instance method 'autorelease' is assumed to return an instance of its receiver type ('GTMLogBasicFormatter *')
    - NOTE  | [OS X] XCODEBUILD >  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSCell.h:219:37: note: passing argument to parameter 'newFormatter' here
    - NOTE  | [OS X] XCODEBUILD >  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSArray.h:154:1: note: instance method 'initWithCapacity:' is assumed to return an instance of its receiver type ('NSMutableArray *')
    - NOTE  | [OS X] XCODEBUILD >  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSDictionary.h:94:1: note: instance method 'initWithCapacity:' is assumed to return an instance of its receiver type ('NSMutableDictionary *')
    - NOTE  | [OS X] XCODEBUILD >  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSSet.h:89:1: note: instance method 'initWithCapacity:' is assumed to return an instance of its receiver type ('NSMutableSet *')
    - NOTE  | [iOS] XCODEBUILD >  warning: no rule to process file '$(PROJECT_DIR)/GTM/GTM_Prefix.pch' of type sourcecode.c.h for architecture armv7
    - NOTE  | [iOS] XCODEBUILD >  warning: no rule to process file '$(PROJECT_DIR)/GTM/GTM_Prefix.pch' of type sourcecode.c.h for architecture armv7
    - NOTE  | [iOS] XCODEBUILD >  /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.1.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSObject.h:36:1: note: previous declaration is here
    - NOTE  | [iOS] XCODEBUILD >  /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.1.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSArray.h:154:1: note: instance method 'initWithCapacity:' is assumed to return an instance of its receiver type ('NSMutableArray *')
    - NOTE  | [iOS] XCODEBUILD >  /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.1.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSDictionary.h:94:1: note: instance method 'initWithCapacity:' is assumed to return an instance of its receiver type ('NSMutableDictionary *')
    - NOTE  | [iOS] XCODEBUILD >  /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.1.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSSet.h:89:1: note: instance method 'initWithCapacity:' is assumed to return an instance of its receiver type ('NSMutableSet *')

GTM.podspec passed validation
```
