### PR TITLE
Update OCHamcrest repo URL. Added version 1.8 of OCHamcrest.

### DIFF
--- a/OCHamcrest/1.6/OCHamcrest.podspec
+++ b/OCHamcrest/1.6/OCHamcrest.podspec
@@ -4,10 +4,10 @@ Pod::Spec.new do |s|
   s.version  = '1.6'
   s.license  = 'BSD'
   s.summary  = 'Unit test assertions on steroids: Hamcrest matchers for Objective-C'
-  s.homepage = 'https://github.com/jonreid/OCHamcrest'
+  s.homepage = 'https://github.com/hamcrest/OCHamcrest'
   s.author   = { 'Jon Reid' => 'jon.reid@mac.com' }
 
-  s.source   = { :git => 'https://github.com/jonreid/OCHamcrest.git', :tag => 'V1.6' }
+  s.source   = { :git => 'https://github.com/hamcrest/OCHamcrest.git', :tag => 'V1.6' }
 
   s.description = %{
       OCHamcrest is a framework for writing matcher objects, allowing you to

--- a/OCHamcrest/1.8/OCHamcrest.podspec
+++ b/OCHamcrest/1.8/OCHamcrest.podspec
@@ -1,13 +1,13 @@
 
 Pod::Spec.new do |s|
   s.name     = 'OCHamcrest'
-  s.version  = '1.7'
+  s.version  = '1.8'
   s.license  = 'BSD'
   s.summary  = 'Unit test assertions on steroids: Hamcrest matchers for Objective-C'
   s.homepage = 'https://github.com/hamcrest/OCHamcrest'
   s.author   = { 'Jon Reid' => 'jon.reid@mac.com' }
 
-  s.source   = { :git => 'https://github.com/hamcrest/OCHamcrest.git', :tag => 'V1.7' }
+  s.source   = { :git => 'https://github.com/hamcrest/OCHamcrest.git', :tag => 'V1.8' }
 
   s.description = %{
       OCHamcrest is a framework for writing matcher objects, allowing you to
@@ -19,5 +19,4 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Source/OCHamcrest.h', 'Source/Core/**/*.{h,m,mm}', 'Source/Library/**/*.{h,m,mm}'
   s.clean_paths = "Examples", "Documentation", "Source/Tests", "Source/TestSupport"
-  s.library = 'stdc++'
 end


### PR DESCRIPTION
Apparently, the OCHamcrest repo moved earlier today. This PR should fix that. Also, v1.8 was released, so I included the podspec for that as well.
