### PR TITLE
Add GoogleAnalytics-SDK-iOS 1.4 spec.

### DIFF
--- a/GoogleAnalytics-SDK-iOS/1.4/GoogleAnalytics-SDK-iOS.podspec
+++ b/GoogleAnalytics-SDK-iOS/1.4/GoogleAnalytics-SDK-iOS.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name     = 'GoogleAnalytics-SDK-iOS'
+  s.version  = '1.4'
+  s.license  = 'Commercial'
+  s.summary  = 'This SDK enables developers to add Google Analytics tracking to applications.'
+  s.homepage = 'https://developers.google.com/analytics/devguides/collection/ios/'
+  s.author   = { 'Daniel Tull' => 'dt@danieltull.co.uk' }
+  s.source   = { :git => 'https://github.com/danielctull/GoogleAnalytics-SDK-iOS.git', :tag => '1.4' }
+  s.platform = :ios
+
+  s.source_files = 'GANTracker.h'
+
+  s.frameworks = 'CFNetwork'
+  s.libraries = 'sqlite3', 'GoogleAnalytics.a'
+
+  s.xcconfig  =  { 'LIBRARY_SEARCH_PATHS' => '"$(SRCROOT)/Pods/GoogleAnalytics-SDK-iOS"' }
+end


### PR DESCRIPTION
I think this is a special case because there're no official git repository for the SDK.
However, since there is a pod spec for TestFlightSDK, I think it's also possible to create one for Google Analytics.

P.S. I just couldn't find the official support email for the SDK, so I put the email of git mirror author.
