### PR TITLE
Add spec for WKVerticalScrollBar version 0.1.0

### DIFF
--- a/WKVerticalScrollBar/0.1.0/WKVerticalScrollBar.podspec
+++ b/WKVerticalScrollBar/0.1.0/WKVerticalScrollBar.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name         = 'WKVerticalScrollBar'
+  s.version      = '0.1.0'
+  s.license      = 'MIT'
+  s.platform     = :ios
+
+  s.summary      = 'A traditional-style scrollbar for iOS that integrates with existing UIScrollView or UIScrollView subclasses.'
+  s.homepage     = 'https://github.com/litl/WKVerticalScrollBar'
+  s.author       = { 'Brad Taylor' => 'btaylor@litl.com' }
+  s.source       = { :git => 'https://github.com/litl/WKVerticalScrollBar.git', :tag => 'version/0.1.0' }
+
+  s.source_files = 'WKVerticalScrollBar/WKVerticalScrollBar.{h,m}'
+  
+  s.frameworks   = 'QuartzCore'
+end


### PR DESCRIPTION
This is a handy library for when you need a traditional scrollbar — ala Instapaper and DropBox — to easily navigate long lists of items or text.
