### PR TITLE
Changes to GHUnitOSX.podspec:

### DIFF
--- a/GHUnitOSX/0.4.33/GHUnitOSX.podspec
+++ b/GHUnitOSX/0.4.33/GHUnitOSX.podspec
@@ -7,9 +7,11 @@ Pod::Spec.new do |s|
   s.author   = { 'Gabriel Handford' => 'gabrielh@gmail.com' }
   s.source   = { :git => 'https://github.com/gabriel/gh-unit.git', :commit => '565564e3ab3b78d0b9cf9c90dd4ad66982f07ef4'}
   s.description = 'GHUnit is a test framework for Objective-C, Mac OS X 10.5 and above and iPhone 3.x and above. It can be used standalone or with other testing frameworks like SenTestingKit or GTM.'
-  s.source_files = 'Classes/**/*.{h,m}', 'Classes-MacOSX/**/*.{h,m}', 'Libraries/YelpKit/*.{h,m}', 'Libraries/GTM/**/*.{h,m}', 'Libraries/GHKit/**/*.{h,m}'
+  s.source_files = 'Classes/**/*.{h,m}', 'Classes-MacOSX/UI/*.{h,m}', 'Libraries/GTM/**/*.{h,m}', 'Libraries/GHKit/**/*.{h,m}'
   s.platform = :osx
   s.framework = 'CoreLocation'
+  s.resources = 'Classes-MacOSX/UI/*.xib'
+  s.requires_arc = true
   s.clean_paths = 'Examples', 'Documentation', 'Project-MacOSX', 'Project-iOS', 'Classes-iOS', 'Tests', 'Classes/GHViewTestCase.{h,m}', 'Libraries/YelpKit'
 end
 


### PR DESCRIPTION
- Reduced set of source files so iOS code not included in OSX build
- Added 'resources' key so nibs are included in the build
- Turned on ARC
