### PR TITLE
JSONKit compiler_flags should be a string instead of an array.

### DIFF
--- a/JSONKit/1.5pre/JSONKit.podspec
+++ b/JSONKit/1.5pre/JSONKit.podspec
@@ -8,5 +8,5 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/johnezang/JSONKit.git', :commit => '0aff3deb5e1bb2bbc88a83fd71c8ad5550185cce' }
 
   s.source_files   = 'JSONKit.*'
-  s.compiler_flags = '-Wno-deprecated-objc-isa-usage', '-Wno-format'
+  s.compiler_flags = '-Wno-deprecated-objc-isa-usage -Wno-format'
 end


### PR DESCRIPTION
I am using rubymotion and get compiler errors when building JSONKit. The clang shell command gets passed "[-Wno-deprecated-objc-isa-usage," "-Wno-format]" instead of "-Wno-deprecated-objc-isa-usage -Wno-format" and blows up.
