### PR TITLE
Add DCIntrospect 0.0.2 podspec. Updates to 9555122e94e0f61375e5b375b906b...

### DIFF
--- a/DCIntrospect/0.0.2/DCIntrospect.podspec
+++ b/DCIntrospect/0.0.2/DCIntrospect.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name     = 'DCIntrospect'
+  s.version  = '0.0.2'
+  s.license  = 'MIT'
+  s.summary  = 'Introspect is small set of tools for iOS that aid in debugging user interfaces built with UIKit.'
+  s.homepage = 'https://github.com/domesticcatsoftware/DCIntrospect'
+  s.author   = { 'Patrick Richards' => 'contact@domesticcat.com.au' }
+  s.source   = { :git => 'git://github.com/domesticcatsoftware/DCIntrospect.git', :commit => "9555122e94e0f61375e5b375b906b81d6d5b1e6e" }
+  s.source_files = 'DCIntrospect'
+  s.frameworks   = 'QuartzCore'
+  s.clean_paths  = 'DCIntrospectDemo'
+  s.compiler_flags = '-DDEBUG=1'
+end


### PR DESCRIPTION
This pull request introduces a new 0.0.2 version of the Podfile. The DCIntrospect version has been arbitrarily bumped to 9555122e94e0f61375e5b375b906b -- the latest revision of the library as of July 2, 2012. I have also fixed a build issue with the previous Podfile:

DCIntrospect requires the DEBUG flag to be set during compilation, else the sharedInspector singleton reference will return nil. The Podfile has been updated with -DDEBUG=1 to ensure DEBUG is set during build time. This enables DCIntrospect to work out of the box.
