### PR TITLE
Pull TestFlight SDK from TestFlight Directly

### DIFF
--- a/TestFlightSDK/1.0/TestFlightSDK.podspec
+++ b/TestFlightSDK/1.0/TestFlightSDK.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary  = 'TestFlightSDK for over-the-air beta testing and crash reporting.'
   s.homepage = 'http://www.testflightapp.com'
   s.author   = { 'TestFlight' => 'support@testflightapp.com' }
-  s.source   = { :git => 'https://github.com/danielctull/TestFlight-SDK.git', :tag => '1.0' }
+  s.source   = { :http => 'https://d3fqheiq7nlyrx.cloudfront.net/sdk-downloads/TestFlightSDK1.0.zip' }
   s.description = 'TestFlightSDK for over-the-air beta testing and crash reporting.'
   s.platform = :ios
   s.source_files = 'TestFlight.h'


### PR DESCRIPTION
Now that CocoaPods 0.6 is released and has support for HTTP downloads, we can pull the TestFlight SDK from TestFlight's server. I updated the podspec to download a zip file from the their server over HTTP.
