### PR TITLE
initial import of OCMockito version 0.22

### DIFF
--- a/OCMockito/0.22/OCMockito.podspec
+++ b/OCMockito/0.22/OCMockito.podspec
@@ -1,0 +1,27 @@
+Pod::Spec.new do |s|
+  s.name     = 'OCMockito'
+  s.version  = '0.22'
+  s.summary  = 'OCMockito is an Objective-C implementation of Mockito, supporting creation, verification and stubbing of mock objects.'
+  s.description = %{
+      OCMockito is an Objective-C implementation of Mockito, supporting creation, 
+      verification and stubbing of mock objects.
+
+      Key differences from other mocking frameworks:
+
+      * Mock objects are always "nice," recording their calls instead of 
+        throwing exceptions about unspecified invocations. This makes tests less fragile.
+      * No expect-run-verify, making tests more readable. Mock objects 
+        record their calls, then you verify the methods you want.
+      * Verification failures are reported as unit test failures, 
+        identifying specific lines instead of throwing exceptions. This makes 
+        it easier to identify failures. (It also keeps the pre-iOS 5 Simulator from crashing.)
+  }
+  s.homepage = 'https://github.com/jonreid/OCMockito'
+  s.license  = 'BSD'
+  s.author   = { 'Jon Reid' => 'jon@qualitycoding.org' }
+  s.source   = { :git => 'https://github.com/jonreid/OCMockito.git', :tag => 'V0.22' }
+  s.source_files = 'Source/OCMockito/OCMockito.h', 'Source/OCMockito/**/*.{h,m,mm}'
+  s.preserve_paths = "Examples", "Documentation", "Source/Tests", "Source/TestSupport"
+  s.ios.library = 'stdc++'
+  s.dependency 'OCHamcrest', '~> 1.7'
+end


### PR DESCRIPTION
Please add the OCMockito to the specs repository but I need you to verify the correctness of the spec because I encounter the following error when running `pod spec lint OCMockito.podspec`:
### Stack

```
   CocoaPods : 0.6.1
        Ruby : ruby 1.8.7 (2011-12-28 patchlevel 357) [universal-darwin11.0]
    RubyGems : 1.8.13
        Host : Mac OS X 10.7.4 (11E53)
       Xcode : 4.5 (4G108j)
Ruby lib dir : /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib
Repositories : master - https://github.com/CocoaPods/Specs.git @ 0955c96330098e5aef06ea1146a524e4f6dddc8f
```
### Error

```
undefined method `preserve_paths' for #<Pod::LocalPod:0x10e7fc650>
/Library/Ruby/Gems/1.8/gems/cocoapods-0.6.1/lib/cocoapods/command/spec.rb:407:in `file_patterns_errors'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.6.1/lib/cocoapods/command/spec.rb:226:in `peform_extensive_analysis'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.6.1/lib/cocoapods/command/spec.rb:194:in `lint'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.6.1/lib/cocoapods/command/spec.rb:180:in `each'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.6.1/lib/cocoapods/command/spec.rb:180:in `lint'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.6.1/lib/cocoapods/command/spec.rb:98:in `lint_podspecs'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.6.1/lib/cocoapods/command/spec.rb:89:in `each'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.6.1/lib/cocoapods/command/spec.rb:89:in `lint_podspecs'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.6.1/lib/cocoapods/command/spec.rb:75:in `lint'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.6.1/lib/cocoapods/command/spec.rb:47:in `send'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.6.1/lib/cocoapods/command/spec.rb:47:in `run'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.6.1/lib/cocoapods/command.rb:71:in `run'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.6.1/bin/pod:12
/usr/bin/pod:19:in `load'
/usr/bin/pod:19
```

which I find strange because s.preserve_paths should replace the deprecated s.clean_paths. When changing the s.preserve_paths to s.clean_paths you'll see the following:

`- WARN  | clean_paths are deprecated and ignored (use preserve_paths)`
