### PR TITLE
Change SRCROOT to PODS_ROOT for FlurrySDK 

### DIFF
--- a/FlurrySDK/3.0.9/FlurrySDK.podspec
+++ b/FlurrySDK/3.0.9/FlurrySDK.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.source_files = '**/*.h'
   s.preserve_paths = '**/*.a'
   s.library = 'FlurryAnalytics'
-  s.xcconfig  =  { 'LIBRARY_SEARCH_PATHS' => '"$(SRCROOT)/Pods/FlurrySDK/FlurryAnalytics"' }
+  s.xcconfig  =  { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/FlurrySDK/FlurryAnalytics"' }
 end


### PR DESCRIPTION
Change to PODS_ROOT so it will behave nicely with projects that don't have the default setup
