### PR TITLE
Update CocoaLumberjack to version 1.6

### DIFF
--- a/CocoaLumberjack/1.6/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.6/CocoaLumberjack.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name     = 'CocoaLumberjack'
+  s.version  = '1.6'
+  s.license  = 'BSD'
+  s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
+  s.homepage = 'https://github.com/robbiehanson/CocoaLumberjack'
+  s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
+  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+                 :tag => '1.6' }
+
+  s.description = 'It is similar in concept to other popular logging frameworks such as log4j, '   \
+                  'yet is designed specifically for objective-c, and takes advantage of features ' \
+                  'such as multi-threading, grand central dispatch (if available), lockless '      \
+                  'atomic operations, and the dynamic nature of the objective-c runtime.'
+
+  s.requires_arc = true
+  s.source_files = 'Lumberjack', 'Lumberjack/Extensions'
+end


### PR DESCRIPTION
This updates spec's version number and git tag to 1.6.
