### PR TITLE
Add sqlite lib dependency to Facebook SDK v3.0.5 beta

### DIFF
--- a/Facebook-iOS-SDK/3.0.5.b/Facebook-iOS-SDK.podspec
+++ b/Facebook-iOS-SDK/3.0.5.b/Facebook-iOS-SDK.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.source       =  { :git => 'https://github.com/facebook/facebook-ios-sdk.git', :tag => 'sdk-version-3.0.5.b' }
   s.source_files =  'src/*.{h,m}'
   s.resource     =  'src/FBiOSSDKResources.bundle'
+  s.library      =  'sqlite3.0'
 
   s.dependency 'SBJson', '2.2.3'
   def s.post_install(target)


### PR DESCRIPTION
https://developers.facebook.com/docs/getting-started/getting-started-with-the-ios-sdk/#project

Scroll down a bit and you'll see that linking the sqlite3.0 library is required.
