### PR TITLE
ZipKit: do not compile Demo project in iOS library

### DIFF
--- a/ZipKit/0.0.1/ZipKit.podspec
+++ b/ZipKit/0.0.1/ZipKit.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
                   "invoking object (e.g., a NSOperation or NSThread)."
 
   files = FileList['**/*.{h,m}']
-  s.ios.source_files = files.dup.exclude(/GMAppleDouble/)
+  s.ios.source_files = files.dup.exclude(/GMAppleDouble/).exclude(/Demo Projects/)
   s.osx.source_files = files
 
   s.clean_paths = 'ZipKit.{xcodeproj,lineform}', 'ZipKitFW-Info.plist', 'ZipKit_Prefix.pch', 'Demo Projects'

--- a/ZipKit/0.0.1/ZipKit.podspec
+++ b/ZipKit/0.0.1/ZipKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name     = 'ZipKit'
   s.version  = '0.0.1'
-  s.license  = 'BSD'
+  s.license  = { :type => 'BSD', :file => 'COPYING.TXT' }
   s.summary  = 'An Objective-C Zip framework for Mac OS X and iOS.'
   s.homepage = 'https://bitbucket.org/kolpanic/zipkit/wiki/Home'
   s.author   = { 'Karl Moskowski' => 'kolpanic@voodooergonomics.com' }
@@ -16,10 +16,9 @@ Pod::Spec.new do |s|
                   "invoking object (e.g., a NSOperation or NSThread)."
 
   files = FileList['**/*.{h,m}']
-  s.ios.source_files = files.dup.exclude(/GMAppleDouble/).exclude(/Demo Projects/)
+  files.exclude(/Demo Projects/)
+  s.ios.source_files = files.dup.exclude(/GMAppleDouble/)
   s.osx.source_files = files
-
-  s.clean_paths = 'ZipKit.{xcodeproj,lineform}', 'ZipKitFW-Info.plist', 'ZipKit_Prefix.pch', 'Demo Projects'
 
   s.library = 'z'
   s.osx.framework = 'CoreServices'


### PR DESCRIPTION
ZipKit included the Demo project in its compiled files.

This patch fixes the issue.

Note that ZipKit may be still not compile with Xcode 4.3 due to a bug in the source code. A [patch](https://bitbucket.org/kolpanic/zipkit/pull-request/3/fix-compilation-for-ios-with-xcode-43) has been posted to the project.
