### PR TITLE
Add podspec for iTVDb v0.0.1

### DIFF
--- a/iTVDb/0.0.1/iTVDb.podspec
+++ b/iTVDb/0.0.1/iTVDb.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "iTVDb"
+  s.version      = "0.0.1"
+  s.author       = { "Kevin Tuhumury" => "kevin.tuhumury@gmail.com" }
+  s.homepage     = "https://github.com/kevintuhumury/itvdb"
+  s.summary      = "iTVDb provides a wrapper around the TVDB (http://thetvdb.com) XML API and can be used in iOS apps."
+
+  s.source       = { :git => "https://github.com/kevintuhumury/itvdb.git", :tag => "0.0.1" }
+  s.source_files = '*.{h,m}', '**/*.{h,m}'
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.platform     = :ios
+  s.requires_arc = true
+end


### PR DESCRIPTION
iTVDb is an Objective-C wrapper around the TVDB (http://thetvdb.com) XML API for use in iOS apps. 
