### PR TITLE
As it stands, this podspec won't work with Rubymotion

### DIFF
--- a/CorePlot/1.0/CorePlot.podspec
+++ b/CorePlot/1.0/CorePlot.podspec
@@ -16,8 +16,9 @@ Pod::Spec.new do |s|
 
   files = FileList['framework/TestResources/CorePlotProbes.d', 'framework/Source/*.{h,m}']
   files.exclude(/(TestCase|Tests)\.[hm]/)
-  s.ios.source_files = files.dup.include('framework/CorePlot-CocoaTouch.h', 'framework/iPhoneOnly/*.{h,m}')
-  s.osx.source_files = files.dup.include('framework/CorePlot.h', 'framework/MacOnly/*.{h,m}')
+  s.source_files = files.dup.include('framework/CorePlot-CocoaTouch.h', 'framework/iPhoneOnly/*.{h,m}')
+  s.platform=:ios
+  #s.osx.source_files = files.dup.include('framework/CorePlot.h', 'framework/MacOnly/*.{h,m}')
 
   s.clean_paths = 'documentation', 'examples', 'scripts', 'QCPlugin', 'framework/*.{xcodeproj,lproj}'
   s.framework   = 'QuartzCore'


### PR DESCRIPTION
I got the following error:

undefined method `ios' for #<Pod::Specification for CorePlot (1.0)>
/Users/mark/.cocoapods/master/CorePlot/1.0/CorePlot.podspec:19:in`_eval_podspec'

My change sucks in terms of maintaining OSX compat, perhaps this is a motion-cocoapods issue.
