### PR TITLE
JMStatefulTableViewController v0.1.0

### DIFF
--- a/JMStatefulTableViewController/0.1.0/JMStatefulTableViewController.podspec
+++ b/JMStatefulTableViewController/0.1.0/JMStatefulTableViewController.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name      = 'JMStatefulTableViewController'
+  s.version   = '0.1.0'
+
+  s.summary   = 'A subclassable table view controller with empty, loading and error states, also supports infinte-scrolling and pull to refresh.'
+  s.description = 'A subclass-able way to cleanly and neatly implement a table view controller that has empty, loading and error states. Supports "paging" and pull to to refresh thanks to SVPullToRefresh.'
+
+  s.homepage  = 'https://github.com/jakemarsh/JMStatefulTableViewController'
+  s.authors   = { 'Jake Marsh' => 'jake@deallocatedobjects.com' }
+  s.source   = { :git => 'https://github.com/jakemarsh/JMStatefulTableViewController.git', :tag => '0.1.0' }
+
+  s.platform  = :ios
+  s.requires_arc = true
+  
+  s.license   = {
+    :type => 'MIT',
+    :file => 'MIT-LICENSE'
+  }
+
+  s.source_files = ['JMStatefulTableViewController/*.*']
+
+  s.dependency 'SVPullToRefresh'  
+end


### PR DESCRIPTION
Initial release of `JMStatefulTableViewController`!
### What is it?

A subclass-able way to cleanly and neatly implement a table view controller that has empty, loading and error states. Supports "paging" and pull to to refresh thanks to SVPullToRefresh.

[Read more about it here](https://github.com/jakemarsh/JMStatefulTableViewController#readme)
