### PR TITLE
JMImageCache v0.2.0

### DIFF
--- a/JMImageCache/0.2.0/JMImageCache.podspec
+++ b/JMImageCache/0.2.0/JMImageCache.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |s|
+  s.name      = 'JMImageCache'
+  s.version   = '0.2.0'
+
+  s.summary   = 'NSCache based remote-image caching and downloading mechanism for iOS.'
+  s.description = 'NSCache based remote-image caching and downloading mechanism for iOS. Is block based and uses a simple UIImageView category to handle loading images with placeholders.'
+
+  s.homepage  = 'https://github.com/jakemarsh/JMImageCache'
+  s.authors   = { 'Jake Marsh' => 'jake@deallocatedobjects.com' }
+  s.source   = { :git => 'https://github.com/jakemarsh/JMImageCache.git', :tag => '0.2.0' }
+
+  s.platform  = :ios
+  s.requires_arc = true
+
+  s.license   = {
+    :type => 'MIT',
+    :file => 'MIT-LICENSE'
+  }
+
+  s.source_files = ['JMImageCache/*.h', 'JMImageCache/*.m']
+end


### PR DESCRIPTION
`JMImageCache` making a comeback as a CocoaPod!
### What is it?

An NSCache based remote-image caching and downloading mechanism for iOS.

[Read more about it here](https://github.com/jakemarsh/JMImageCache#readme)
### Sample

Here's a small taste of what the library has to offer:

``` objective-c
[cell.imageView setImageWithURL:[NSURL URLWithString:@"http://dundermifflin.com/i/MichaelScott.png"]
                        placeholder:[UIImage imageNamed:@"placeholder.png"]];
```

Request an image like so:

``` objective-c
[[JMImageCache sharedCache] imageForURL:[NSURL URLWithString:@"http://dundermifflin.com/i/MichaelScott.png"] completionBlock:^(UIImage *downloadedImage) {
    someImageView.image = downloadedImage;
}];
```
