### PR TITLE
Updated iTVDb v0.0.1 .podspec

### DIFF
--- a/iTVDb/0.0.1/iTVDb.podspec
+++ b/iTVDb/0.0.1/iTVDb.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.summary      = "iTVDb provides a wrapper around the TVDB (http://thetvdb.com) XML API and can be used in iOS apps."
 
   s.source       = { :git => "https://github.com/kevintuhumury/itvdb.git", :tag => "0.0.1" }
-  s.source_files = '*.{h,m}', '**/*.{h,m}'
+  s.source_files = '**/*.{h,m}'
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.platform     = :ios
   s.requires_arc = true


### PR DESCRIPTION
A small update to the iTVDb v0.0.1 .podspec. The current version is including the `*.h` and `*.h` multiple times, because of the incorrect value I filled in for the `source_files` property.

As mentioned in the comments of my [previous pull request](https://github.com/CocoaPods/Specs/pull/320#issuecomment-7124717), I would like to have push access to this repository. Otherwise I'll have to keep creating pull requests for small changes like these. Thanks in advance :)!
