### PR TITLE
GData/Youtube source path bug fix

### DIFF
--- a/GData/1.9.1/GData.podspec
+++ b/GData/1.9.1/GData.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   
   s.subspec 'YouTube' do |gdyt|
     gdyt.frameworks   = 'CFNetwork', 'SystemConfiguration'
-    gdyt.source_files = 'Clients/YouTube/*.{h,m}', 'Clients/YouTube/Touch/*.{h,m}'
+    gdyt.source_files = 'Source/Clients/YouTube/*.{h,m}', 'Source/Clients/YouTube/Touch/*.{h,m}'
   end
   
 end


### PR DESCRIPTION
There was a bug on the GData.podpsec : the source_files path was wrong, so I have fixed it.
