### PR TITLE
TwUI: Add pod for released versions 0.1-0.4

### DIFF
--- a/TwUI/0.1/TwUI.podspec
+++ b/TwUI/0.1/TwUI.podspec
@@ -11,7 +11,6 @@ Pod::Spec.new do |s|
   s.source         = { :git => "https://github.com/twitter/twui.git", :commit => "2a704ca1fb225a36dac5103797167a21f682a873" }
 
   s.platform       = :osx, '10.6'
-#  s.compiler_flags = '-Wno-objc-missing-super-calls'
   s.frameworks     = 'ApplicationServices', 'QuartzCore', 'Cocoa'
 
   s.subspec 'Support' do |ss|

--- a/TwUI/0.1/TwUI.podspec
+++ b/TwUI/0.1/TwUI.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |s|
+  s.name           = "TwUI"
+  s.version        = "0.1"
+  s.summary        = "A UI framework for Mac based on Core Animation."
+  s.description    = "TwUI is a hardware accelerated UI framework for Mac, inspired by UIKit. It enables:\n"\
+                     "- GPU accelerated rendering backed by CoreAnimation.\n"\
+                     "- Simple model/view/controller development familiar to iOS developers."
+  s.homepage       = "https://github.com/github/twui"
+  s.author         = { "Twitter, Inc." => "opensource@twitter.com" }
+  s.license        = { :type => 'Apache License, Version 2.0' }
+  s.source         = { :git => "https://github.com/twitter/twui.git", :commit => "2a704ca1fb225a36dac5103797167a21f682a873" }
+
+  s.platform       = :osx, '10.6'
+#  s.compiler_flags = '-Wno-objc-missing-super-calls'
+  s.frameworks     = 'ApplicationServices', 'QuartzCore', 'Cocoa'
+
+  s.subspec 'Support' do |ss|
+    ss.source_files = 'lib/Support'
+  end
+
+  s.subspec 'UIKit' do |ss|
+    ss.source_files = FileList['lib/UIKit/*.{h,m}'].exclude(/TUIAccessibilityElement/)
+    ss.dependency 'TwUI/Support'
+  end
+end

--- a/TwUI/0.2/TwUI.podspec
+++ b/TwUI/0.2/TwUI.podspec
@@ -11,7 +11,6 @@ Pod::Spec.new do |s|
   s.source         = { :git => "https://github.com/twitter/twui.git", :commit => "ef55cfcd65f5ce364abde22452bed1fa84c7e03f" }
 
   s.platform       = :osx, '10.6'
-#  s.compiler_flags = '-Wno-objc-missing-super-calls'
   s.frameworks     = 'ApplicationServices', 'QuartzCore', 'Cocoa'
 
   s.subspec 'Support' do |ss|

--- a/TwUI/0.2/TwUI.podspec
+++ b/TwUI/0.2/TwUI.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |s|
+  s.name           = "TwUI"
+  s.version        = "0.2"
+  s.summary        = "A UI framework for Mac based on Core Animation."
+  s.description    = "TwUI is a hardware accelerated UI framework for Mac, inspired by UIKit. It enables:\n"\
+                     "- GPU accelerated rendering backed by CoreAnimation.\n"\
+                     "- Simple model/view/controller development familiar to iOS developers."
+  s.homepage       = "https://github.com/github/twui"
+  s.author         = { "Twitter, Inc." => "opensource@twitter.com" }
+  s.license        = { :type => 'Apache License, Version 2.0' }
+  s.source         = { :git => "https://github.com/twitter/twui.git", :commit => "ef55cfcd65f5ce364abde22452bed1fa84c7e03f" }
+
+  s.platform       = :osx, '10.6'
+#  s.compiler_flags = '-Wno-objc-missing-super-calls'
+  s.frameworks     = 'ApplicationServices', 'QuartzCore', 'Cocoa'
+
+  s.subspec 'Support' do |ss|
+    ss.source_files = 'lib/Support'
+  end
+
+  s.subspec 'UIKit' do |ss|
+    ss.source_files = FileList['lib/UIKit/*.{h,m}'].exclude(/TUIAccessibilityElement/)
+    ss.dependency 'TwUI/Support'
+  end
+end

--- a/TwUI/0.3/TwUI.podspec
+++ b/TwUI/0.3/TwUI.podspec
@@ -11,7 +11,6 @@ Pod::Spec.new do |s|
   s.source         = { :git => "https://github.com/github/twui.git", :commit => "0.3.0" }
 
   s.platform       = :osx, '10.6'
-#  s.compiler_flags = '-Wno-objc-missing-super-calls'
   s.requires_arc   = true
   s.frameworks     = 'ApplicationServices', 'QuartzCore', 'Cocoa'
 

--- a/TwUI/0.3/TwUI.podspec
+++ b/TwUI/0.3/TwUI.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage       = "https://github.com/github/twui"
   s.author         = { "Twitter, Inc." => "opensource@twitter.com" }
   s.license        = { :type => 'Apache License, Version 2.0' }
-  s.source         = { :git => "https://github.com/github/twui.git", :commit => "0.3.0" }
+  s.source         = { :git => "https://github.com/github/twui.git", :tag => "0.3.0" }
 
   s.platform       = :osx, '10.6'
   s.requires_arc   = true

--- a/TwUI/0.3/TwUI.podspec
+++ b/TwUI/0.3/TwUI.podspec
@@ -1,17 +1,18 @@
 Pod::Spec.new do |s|
   s.name           = "TwUI"
-  s.version        = "0.0.1"
+  s.version        = "0.3"
   s.summary        = "A UI framework for Mac based on Core Animation."
   s.description    = "TwUI is a hardware accelerated UI framework for Mac, inspired by UIKit. It enables:\n"\
                      "- GPU accelerated rendering backed by CoreAnimation.\n"\
                      "- Simple model/view/controller development familiar to iOS developers."
-  s.homepage       = "https://github.com/twitter/twui"
+  s.homepage       = "https://github.com/github/twui"
   s.author         = { "Twitter, Inc." => "opensource@twitter.com" }
   s.license        = { :type => 'Apache License, Version 2.0' }
-  s.source         = { :git => "https://github.com/twitter/twui.git", :commit => "0d03e1aa88bb2ed73e02b5eaac3e993254ca0545" }
+  s.source         = { :git => "https://github.com/github/twui.git", :commit => "0.3.0" }
 
   s.platform       = :osx, '10.6'
-  s.compiler_flags = '-Wno-objc-missing-super-calls'
+#  s.compiler_flags = '-Wno-objc-missing-super-calls'
+  s.requires_arc   = true
   s.frameworks     = 'ApplicationServices', 'QuartzCore', 'Cocoa'
 
   s.subspec 'Support' do |ss|

--- a/TwUI/0.4/TwUI.podspec
+++ b/TwUI/0.4/TwUI.podspec
@@ -11,7 +11,6 @@ Pod::Spec.new do |s|
   s.source         = { :git => "https://github.com/github/twui.git", :tag => "0.4.0" }
 
   s.platform       = :osx, '10.6'
-#  s.compiler_flags = '-Wno-objc-missing-super-calls'
   s.requires_arc   = true
   s.frameworks     = 'ApplicationServices', 'QuartzCore', 'Cocoa'
 

--- a/TwUI/0.4/TwUI.podspec
+++ b/TwUI/0.4/TwUI.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |s|
+  s.name           = "TwUI"
+  s.version        = "0.4"
+  s.summary        = "A UI framework for Mac based on Core Animation."
+  s.description    = "TwUI is a hardware accelerated UI framework for Mac, inspired by UIKit. It enables:\n"\
+                     "- GPU accelerated rendering backed by CoreAnimation.\n"\
+                     "- Simple model/view/controller development familiar to iOS developers."
+  s.homepage       = "https://github.com/github/twui"
+  s.author         = { "Twitter, Inc." => "opensource@twitter.com" }
+  s.license        = { :type => 'Apache License, Version 2.0' }
+  s.source         = { :git => "https://github.com/github/twui.git", :tag => "0.4.0" }
+
+  s.platform       = :osx, '10.6'
+#  s.compiler_flags = '-Wno-objc-missing-super-calls'
+  s.requires_arc   = true
+  s.frameworks     = 'ApplicationServices', 'QuartzCore', 'Cocoa'
+
+  s.subspec 'Support' do |ss|
+    ss.source_files = 'lib/Support'
+  end
+
+  s.subspec 'UIKit' do |ss|
+    ss.source_files = FileList['lib/UIKit/*.{h,m}'].exclude(/TUIAccessibilityElement/)
+    ss.dependency 'TwUI/Support'
+  end
+end


### PR DESCRIPTION
And drop support for random commit version 0.0.1!

Current (and now removed) version 0.0.1 points to this "random" (?) commit:
- 0.0.1: https://github.com/github/twui/commit/0d03e1aa88bb2ed73e02b5eaac3e993254ca0545

I've added release versions for 0.1 - 0.4 to two matching commit refs and two tags:
- 0.1: https://github.com/github/twui/commit/2a704ca1fb225a36dac5103797167a21f682a873
- 0.2: https://github.com/github/twui/commit/ef55cfcd65f5ce364abde22452bed1fa84c7e03f
- 0.3: https://github.com/github/twui/tree/0.3.0
- 0.4: https://github.com/github/twui/tree/0.4.0
