### PR TITLE
Allow ASIHTTPRequest to build on mountain lion

### DIFF
--- a/ASIHTTPRequest/1.8.1/ASIHTTPRequest.podspec
+++ b/ASIHTTPRequest/1.8.1/ASIHTTPRequest.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'ASIWebPageRequest' do |ws|
     ws.source_files = 'Classes/ASIWebPageRequest/'
-    ws.library      = 'xml2.2.7.3'
+    ws.library      = 'xml2.2'
     ws.xcconfig     = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
   end
 


### PR DESCRIPTION
I switched to mountain lion, and found ASIHTTPRequest failed to build, due to libxml2.2.7.3 missing. Switching the requirement to libxml2.2 seems to fix the problem.

I have not tested this on earlier version of OSX. Also, I'm using ASIHTTPRequest only via Nimbus' NINetworkImageView, so I wouldn't consider this change thoroughly vetted. Someone running an earlier version of OS X should test this out.
