### PR TITLE
Fixed ADVProgressBar

### DIFF
--- a/ADVProgressBar/0.0.1/ADVProgressBar.podspec
+++ b/ADVProgressBar/0.0.1/ADVProgressBar.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary  = 'Progress Bar Design with Percentage values.'
   s.homepage = 'https://github.com/appdesignvault'
   s.author   = { 'appdesignvault' => 'appdesignvault' }
-  s.source   = { :git => 'https://github.com/appdesignvault/ADVProgressBar.git', :commit => 'ff88e5ce20fed36b1e0e2da167f0b7f51e62ce8c' }
+  s.source   = { :git => 'https://github.com/appdesignvault/ADVProgressBar.git', :commit => 'f17b15c15574d6d101cd5fcfd58239e16e806647' }
   s.platform = :ios  
   s.source_files = 'ADVProgressBar/Classes/*.{h,m}'
   s.resources = "ADVProgressBar/Resources/*.png"


### PR DESCRIPTION
The current ADVProgressBar pod doesn't work because it refers to an old commit that requires a file that doesn't exist.

That was fixed in this upstream commit https://github.com/appdesignvault/ADVProgressBar/commit/f17b15c15574d6d101cd5fcfd58239e16e806647

This pull request updates the ADVProgressBar pod to include that commit.
