### PR TITLE
[Rakefile] fix uninitialized constant Pathname error.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+require 'pathname'
+
 def rvm_ruby_dir
   @rvm_ruby_dir ||= File.expand_path('../..', `which ruby`.strip)
 end


### PR DESCRIPTION
When I was commiting a bug fix for podspec, I encountered following error (after adding --trace):

```
** Invoke lint (first_time)
** Execute lint
rake aborted!
uninitialized constant Pathname
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/rake/ext/module.rb:36:in `const_missing'
/Users/dlackty/.cocoapods/master/Rakefile:35:in `block in <top (required)>'
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/rake/task.rb:205:in `call'
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/rake/task.rb:205:in `block in execute'
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/rake/task.rb:200:in `each'
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/rake/task.rb:200:in `execute'
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/rake/task.rb:158:in `block in invoke_with_call_chain'
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/rake/task.rb:151:in `invoke_with_call_chain'
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/rake/task.rb:144:in `invoke'
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/rake/application.rb:116:in `invoke_task'
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/rake/application.rb:94:in `block (2 levels) in top_level'
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/rake/application.rb:94:in `each'
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/rake/application.rb:94:in `block in top_level'
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/rake/application.rb:133:in `standard_exception_handling'
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/rake/application.rb:88:in `top_level'
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/rake/application.rb:66:in `block in run'
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/rake/application.rb:133:in `standard_exception_handling'
/Users/dlackty/.rbenv/versions/1.9.3-p0/lib/ruby/1.9.1/rake/application.rb:63:in `run'
/Users/dlackty/.rbenv/versions/1.9.3-p0/bin/rake:32:in `<main>'
Tasks: TOP => lint
```

After tracing the codes, I found the changes in 39b1a6ba caused this issue, and can be fixed by explicitly requiring the class at the first line of Rakefile.
