### PR TITLE
TTTAttributedLabel spec tweak

### DIFF
--- a/TTTAttributedLabel/1.3.0/TTTAttributedLabel.podspec
+++ b/TTTAttributedLabel/1.3.0/TTTAttributedLabel.podspec
@@ -4,10 +4,12 @@ Pod::Spec.new do |s|
   s.authors = {'Mattt Thompson' => 'm@mattt.me'}
   s.homepage = 'https://github.com/mattt/TTTAttributedLabel/'
   s.summary = 'A drop-in replacement for UILabel that supports NSAttributedStrings.'
-  s.source = {:git => 'https://github.com/mattt/TTTAttributedLabel.git', :tag => '1.3.0'}
+  s.source = {:git => 'git://github.com/mattt/TTTAttributedLabel.git', :tag => '1.3.0'}
   s.license = { :type => 'MIT', :file => 'LICENSE' }
+  
   s.platform = :ios
+  s.requires_arc = true
+  s.compiler_flags = '-Wno-arc-bridge-casts-disallowed-in-nonarc'
   s.frameworks = 'CoreText'
   s.source_files = 'TTTAttributedLabel.{h,m}'
-  s.compiler_flags = '-Wno-arc-bridge-casts-disallowed-in-nonarc'
 end

--- a/TTTAttributedLabel/1.3.0/TTTAttributedLabel.podspec
+++ b/TTTAttributedLabel/1.3.0/TTTAttributedLabel.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.authors = {'Mattt Thompson' => 'm@mattt.me'}
   s.homepage = 'https://github.com/mattt/TTTAttributedLabel/'
   s.summary = 'A drop-in replacement for UILabel that supports NSAttributedStrings.'
-  s.source = {:git => 'git://github.com/mattt/TTTAttributedLabel.git', :tag => '1.3.0'}
+  s.source = {:git => 'https://github.com/mattt/TTTAttributedLabel.git', :tag => '1.3.0'}
   s.license = { :type => 'MIT', :file => 'LICENSE' }
   
   s.platform = :ios


### PR DESCRIPTION
Hi! Since v.1.3.0, TTTAttributedLabel actually uses ARC, which wasn't described in a spec. Updated :)
