### PR TITLE
Updated version of CocoaSoundCloudUI

### DIFF
--- a/CocoaSoundCloudUI/1.0.0/CocoaSoundCloudUI.podspec
+++ b/CocoaSoundCloudUI/1.0.0/CocoaSoundCloudUI.podspec
@@ -6,6 +6,7 @@ Pod::Spec.new do |s|
   s.author   = { 'Ullrich Schäfer' => 'ullrich@soundcloud.com',
                  'Robert Böhnke' => 'robb@soundcloud.com',
                  'Tobias Kräntzer' => 'tk@soundcloud.com' }
+  s.license  = 'Apache License, Version 2.0'
 
   s.source   = { :git => 'https://github.com/soundcloud/CocoaSoundCloudUI.git', :tag => 'v1.0' }
 

--- a/CocoaSoundCloudUI/1.0.3/CocoaSoundCloudUI.podspec
+++ b/CocoaSoundCloudUI/1.0.3/CocoaSoundCloudUI.podspec
@@ -1,0 +1,29 @@
+Pod::Spec.new do |s|
+  s.name     = 'CocoaSoundCloudUI'
+  s.version  = '1.0.3'
+  s.summary  = 'A simple way to share audio on soundcloud.com.'
+  s.homepage = 'https://github.com/soundcloud/CocoaSoundCloudUI'
+  s.author   = { 'Ullrich Schäfer' => 'ullrich@soundcloud.com',
+                 'Robert Böhnke' => 'robb@soundcloud.com',
+                 'Tobias Kräntzer' => 'tk@soundcloud.com' }
+  s.license  = 'Apache License, Version 2.0'
+
+  s.source   = { :git => 'https://github.com/soundcloud/CocoaSoundCloudUI.git', :tag => '1.0.3' }
+
+  s.platform = :ios
+
+  s.source_files = 'Sources', 'Sources/**/*.{h,m}'
+
+  s.resource = "SoundCloud.bundle"
+
+  s.framework = 'AddressBook'
+  s.framework = 'AddressBookUI'
+  s.framework = 'QuartzCore'
+  s.framework = 'CoreGraphics'
+  s.framework = 'CoreText'
+  s.framework = 'CoreLocation'
+
+  s.dependency 'CocoaSoundCloudAPI', '~> 1.0'
+  s.dependency 'OHAttributedLabel'
+  s.dependency 'JSONKit'
+end


### PR DESCRIPTION
Bumped the version to `1.0.3`. Also added the license to the Podfile (wasn't there in previous versions).

Simple as this :)
