### PR TITLE
KeychainItemWrapper 1.2

### DIFF
--- a/KeychainItemWrapper/1.2/KeychainItemWrapper.podspec
+++ b/KeychainItemWrapper/1.2/KeychainItemWrapper.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name         = "KeychainItemWrapper"
+  s.version      = "1.2"
+  s.summary      = "Objective-C wrapper for accessing a single keychain item."
+  s.description  = "This keychain wrapper was originally created by Apple and modified to be ARC compatible."
+  s.homepage     = "https://gist.github.com/3376201"
+  s.license	 = { :type => 'Custom', :text => 'Copyright (C) 2010 Apple Inc. All Rights Reserved.' }
+  s.author       = "David Hoerl"
+  s.source       = { :git => 'git://gist.github.com/3376201.git' }
+  s.source_files = "KeychainItemWrapper.*"
+  s.frameworks   = "Security"
+  s.platform	 = :ios, '3.0'
+  s.requires_arc = true
+end

--- a/KeychainItemWrapper/1.2/KeychainItemWrapper.podspec
+++ b/KeychainItemWrapper/1.2/KeychainItemWrapper.podspec
@@ -4,11 +4,54 @@ Pod::Spec.new do |s|
   s.summary      = "Objective-C wrapper for accessing a single keychain item."
   s.description  = "This keychain wrapper was originally created by Apple and modified to be ARC compatible."
   s.homepage     = "https://gist.github.com/3376201"
-  s.license	 = { :type => 'Custom', :text => 'Copyright (C) 2010 Apple Inc. All Rights Reserved.' }
   s.author       = "David Hoerl"
-  s.source       = { :git => 'git://gist.github.com/3376201.git' }
+  s.source       = { :git => "git://gist.github.com/3376201.git", :commit => "446bd2a7b36f041ae775e6af4e7aed78398df902" }
   s.source_files = "KeychainItemWrapper.*"
   s.frameworks   = "Security"
-  s.platform	 = :ios, '3.0'
+  s.platform	 = :ios, "3.0"
   s.requires_arc = true
+  s.license	 = {
+	:type => "Custom",
+	:text => <<-LICENSEINFO
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple
+ Inc. ("Apple") in consideration of your agreement to the following
+ terms, and your use, installation, modification or redistribution of
+ this Apple software constitutes acceptance of these terms.  If you do
+ not agree with these terms, please do not use, install, modify or
+ redistribute this Apple software.
+ 
+ In consideration of your agreement to abide by the following terms, and
+ subject to these terms, Apple grants you a personal, non-exclusive
+ license, under Apple's copyrights in this original Apple software (the
+ "Apple Software"), to use, reproduce, modify and redistribute the Apple
+ Software, with or without modifications, in source and/or binary forms;
+ provided that if you redistribute the Apple Software in its entirety and
+ without modifications, you must retain this notice and the following
+ text and disclaimers in all such redistributions of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may
+ be used to endorse or promote products derived from the Apple Software
+ without specific prior written permission from Apple.  Except as
+ expressly stated in this notice, no other rights or licenses, express or
+ implied, are granted by Apple herein, including but not limited to any
+ patent rights that may be infringed by your derivative works or by other
+ works in which the Apple Software may be incorporated.
+ 
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE
+ MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND
+ OPERATION ALONE OR IN COMBINATION WITH YOUR PRODUCTS.
+ 
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL
+ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION,
+ MODIFICATION AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED
+ AND WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE),
+ STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ 
+ Copyright (C) 2010 Apple Inc. All Rights Reserved.
+LICENSEINFO
+}
 end


### PR DESCRIPTION
Objective-C wrapper for accessing a single keychain item.
Code created by Apple and modified by David Hoerl to be ARC compatible.

See https://github.com/CocoaPods/CocoaPods/issues/463 for more information.
