### PR TITLE
iPhoneMK update podspec to require AVFoundation and QuartzCore

### DIFF
--- a/iPhoneMK/0.0.1/iPhoneMK.podspec
+++ b/iPhoneMK/0.0.1/iPhoneMK.podspec
@@ -7,6 +7,6 @@ Pod::Spec.new do |s|
   s.author   = { 'Michael F. Kamprath' => 'michael@claireware.com' }
   s.source   = { :git => 'https://github.com/michaelkamprath/iPhoneMK.git', :commit => '85b3b4aac8' }
   s.platform = :ios
-
+  s.frameworks   = ['QuartzCore', 'AVFoundation']
   s.source_files = '**/*.{h,m}'
 end


### PR DESCRIPTION
MKSoundCoordinatedAnimationLayer requires AVFoundation and QuartzCore
