### PR TITLE
Add Facebook-iOS-SDK v3.0.8

### DIFF
--- a/Facebook-iOS-SDK/3.0.8/Facebook-iOS-SDK.podspec
+++ b/Facebook-iOS-SDK/3.0.8/Facebook-iOS-SDK.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         =  'Facebook-iOS-SDK'
+  s.version      =  '3.0.8'
+  s.platform     =  :ios
+  s.license      =  'Apache License, Version 2.0'
+  s.summary      =  'The iOS SDK provides Facebook Platform support for iOS apps.'
+  s.description  =  'The Facebook SDK for iOS enables you to access the Facebook Platform APIs including the Graph API, FQL, and Dialogs.'
+  s.homepage     =  'http://developers.facebook.com/docs/reference/iossdk'
+  s.author       =  'Facebook'
+  s.source       =  { :git => 'https://github.com/facebook/facebook-ios-sdk.git', :tag => 'sdk-version-3.0.8' }
+  s.source_files =  'src/*.{h,m}'
+  s.resource     =  'src/FacebookSDKResources.bundle'
+  s.library      =  'sqlite3.0'
+  s.header_dir   =  'FacebookSDK'
+  s.dependency 'SBJson', '2.2.3'
+end


### PR DESCRIPTION
Released Aug 21st. I removed the creation of "FBSDKVersion-generated.h" as they added it and pointed it to 3.0.8 in the commits below.

https://github.com/facebook/facebook-ios-sdk/commit/ed90724e9065206a9ec23aa2e67126c001200fba
https://github.com/facebook/facebook-ios-sdk/commit/682535050207c771706823cbf0fc31a206b12956

I also slightly modified the copy as the Facebook people are now calling it the "Facebook SDK for iOS" instead of the "Facebook iOS SDK."

If you're having trouble installing, delete the caches in the ~/Library/CocoaPods directory. Seems I'm not the only one with this issue at the moment.

https://github.com/CocoaPods/Specs/issues/325
https://github.com/CocoaPods/CocoaPods/issues/407

Cheers.
