### PR TITLE
ShareKit Facebook sub spec depends on facebook-ios- …

### DIFF
--- a/ShareKit/2.0/ShareKit.podspec
+++ b/ShareKit/2.0/ShareKit.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.subspec 'Facebook' do |facebook|
     facebook.source_files   = 'Classes/ShareKit/Sharers/Services/Facebook/**/*.{h,m}'
     facebook.compiler_flags = '-Wno-incomplete-implementation -Wno-protocol -Wno-missing-prototypes'
-    facebook.dependency 'Facebook-iOS-SDK'
+    facebook.dependency 'Facebook-iOS-SDK',"1.2"
   end
 
   s.subspec 'Flickr' do |flickr|


### PR DESCRIPTION
… sdk version 1.2 and doesn't work with the latest (3.0) yet.
