### PR TITLE
added "deprecated" to pod description

### DIFF
--- a/INKeychainAccess/1.0/INKeychainAccess.podspec
+++ b/INKeychainAccess/1.0/INKeychainAccess.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 	s.name			= 'INKeychainAccess'
 	s.version		= '1.0'
-	s.summary		= 'Keychain services wrapper for OS X and iOS.'
+	s.summary		= '[Deprecated] Keychain services wrapper for OS X and iOS.'
 	s.homepage		= 'https://github.com/indragiek/INKeychainAccess'
 	s.author   		= { 'Indragie Karunaratne' => 'indragiek@gmail.com' }
 	s.source_files	= '*.{h,m}'


### PR DESCRIPTION
This pod is deprecated by Author as below:
"INKeychainAccess is deprecated and will not be maintained anymore. You should not use this code going forward."
https://github.com/indragiek/INKeychainAccess/blob/master/README.md
