### PR TITLE
added "deprecated" to pod description

### DIFF
--- a/KKGridView/0.0.1/KKGridView.podspec
+++ b/KKGridView/0.0.1/KKGridView.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version  = '0.0.1'
   s.license  = 'MIT'
   s.platform = :ios
-  s.summary  = 'A high-performance iOS grid view.'
+  s.summary  = '[deprecated] A high-performance iOS grid view.'
   s.homepage = 'https://github.com/kolinkrewinkel/KKGridView'
   s.authors  = { 'Kolin Krewinkel'   => 'kolin.krewinkel@me.com',
                  'Giulio Petek'      => 'gi-lo@touch-mania.com',


### PR DESCRIPTION
This pod was deprecated by the author as below:
https://github.com/kolinkrewinkel/KKGridView/blob/master/README.md
"Deprecated
In iOS 6, Apple has now created a first-party solution to what KKGridView tries to solve. See Session 219 from WWDC 2012 for more information."
