### PR TITLE
Adding AMOptionMenu

### DIFF
--- a/AMOptionMenu/0.1.0/AMOptionMenu.podspec
+++ b/AMOptionMenu/0.1.0/AMOptionMenu.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name                  = "AMOptionMenu"
+  s.platform              = :osx
+  s.version               = "0.1.0"
+  s.summary               = "A popup button/menu that allows selection of multiple options."
+  s.homepage              = "https://github.com/amrox/AMOptionMenu"
+  s.license               = { :type => 'MIT', :file => 'LICENSE' }
+  s.author                = { "Andy Mroczkowski" => "andy@mrox.net" }
+  s.source                = { :git => "https://github.com/amrox/AMOptionMenu.git", :tag => '0.1.0' }
+  s.osx.deployment_target = '10.6'
+  s.source_files          = 'AMOptionMenu'
+  s.frameworks            = 'Foundation', 'Cocoa', 'AppKit'
+end


### PR DESCRIPTION
AMOptionMenu is a multi-option popup button for OS X, similar to Xcode 'Overview' control.

Highlights:
- Multiple controls can be driven by the same data source
- Setting state via key-value coding
- Populating a standard NSMenu instead of/addition to popup buttons
- Optional short titles for summaries
- Explicitly or automatically limiting the number of items in the summary.
- Instantiating controls from code or nib
- Loading data from code or external plists
