### PR TITLE
changed homepage address to appropriate page

### DIFF
--- a/MKHorizMenu/0.0.1/MKHorizMenu.podspec
+++ b/MKHorizMenu/0.0.1/MKHorizMenu.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name     = 'MKHorizMenu'
   s.version  = '0.0.1'
   s.summary  = 'Demo of MKHorizMenu a simple, drop-in replacement for the Three20 fame horizontal menus used in news apps.'
-  s.homepage = 'http://mugunthkumar.com'
+  s.homepage = 'http://blog.mugunthkumar.com/ios-components/others/'
   s.author   = { 'Mugunth Kumar' => 'contact@mk.sg' }
   s.source   = { :git => 'https://github.com/MugunthKumar/MKHorizMenuDemo.git', :commit => '32bf96e69f6d1e141e76e38b691497b3c115b531' }
   s.platform = :ios  


### PR DESCRIPTION
The old homepage was the top page of MK's blog and there is a little difficult to discover the pod page.
