### PR TITLE
CouchCocoa/TouchDB

### DIFF
--- a/CouchCocoa/0.961beta6/CouchCocoa.podspec
+++ b/CouchCocoa/0.961beta6/CouchCocoa.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name     = 'CouchCocoa'
+  s.version  = '0.961beta6'
+  s.license  = { :type => 'Apache', :text => 'Released under the Apache license, version 2.0.' }
+  s.summary  = 'Objective-C API for CouchDB on iOS and Mac OS.'
+  s.homepage = 'https://github.com/couchbaselabs/CouchCocoa'
+  s.author   = { 'Jens Alfke' => 'jens@couchbase.com' }
+
+
+  s.platform = :ios
+
+  s.source   = { :git => 'https://github.com/couchbaselabs/CouchCocoa.git', :tag => 'v0.961-beta6' }
+
+  s.source_files = 'Couch', 'Model', 'REST', 'UI/iOS'
+  s.compiler_flags = '-DCOUCHCOCOA_IMPL'
+  s.dependency 'JSONKit', '~> 1.4'
+end

--- a/MYUtilities/0.0.1/MYUtilities.podspec
+++ b/MYUtilities/0.0.1/MYUtilities.podspec
@@ -1,0 +1,41 @@
+license = <<-EOT
+ Copyright (c) 2008, Jens Alfke <jens@mooseyard.com>. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification, are permitted
+ provided that the following conditions are met:
+ 
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ and the following disclaimer in the documentation and/or other materials provided with the
+ distribution.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND 
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRI-
+ BUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF 
+ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+EOT
+
+Pod::Spec.new do |s|
+  s.name     = 'MYUtilities'
+  s.version  = '0.0.1'
+  s.license  = {type: 'BSD', text: license}
+  s.summary  = 'Objective-C utility code for Cocoa programming on Mac OS X.'
+  s.homepage = 'https://bitbucket.org/snej/myutilities/src'
+  s.authors  = { 'Jens Alfke' => 'jens@mooseyard.com' }
+  s.source   = { :hg  => 'https://bitbucket.org/snej/myutilities', :revision => '319441e240fa' }
+  s.description = 'Objective-C utility code for Cocoa programming on Mac OS X.'
+  s.platform = :ios
+  # for now, this includes just the files needed by MYNetwork.  A lot of the other files in
+  # this project are for Mac, not iOS, and cause compilation issues.  Update this podspec if you
+  # know how to get them to play nicely, thanks!  --jpepas
+  # note: GoogleToolboxSubset should probably be pulled out into its own podspec eventually.  --jpepas
+  s.source_files = 'Logging.{h,m}', 'Test.{h,m}', 'ExceptionUtils.{h,m}', 'Target.{h,m}', \
+                   'CollectionUtils.{h,m}', 'ConcurrentOperation.{h,m}', 'GoogleToolboxSubset/*.{h,m}'
+  s.preserve_paths = 'mnemonicode-0.73'
+  s.library = 'z'
+end

--- a/MYUtilities/0.0.1/MYUtilities.podspec
+++ b/MYUtilities/0.0.1/MYUtilities.podspec
@@ -25,17 +25,22 @@ Pod::Spec.new do |s|
   s.version  = '0.0.1'
   s.license  = {type: 'BSD', text: license}
   s.summary  = 'Objective-C utility code for Cocoa programming on Mac OS X.'
-  s.homepage = 'https://bitbucket.org/snej/myutilities/src'
+  s.homepage = 'https://github.com/snej/MYUtilities'
   s.authors  = { 'Jens Alfke' => 'jens@mooseyard.com' }
-  s.source   = { :hg  => 'https://bitbucket.org/snej/myutilities', :revision => '319441e240fa' }
+  s.source   = { :git  => 'https://github.com/snej/MYUtilities.git', :commit => '0cc46aaf394dfe451d83d0ae3954643662210767' }
   s.description = 'Objective-C utility code for Cocoa programming on Mac OS X.'
   s.platform = :ios
-  # for now, this includes just the files needed by MYNetwork.  A lot of the other files in
+
+  # for now, this includes just the files needed by MYNetwork and TouchDB.  A lot of the other files in
   # this project are for Mac, not iOS, and cause compilation issues.  Update this podspec if you
   # know how to get them to play nicely, thanks!  --jpepas
   # note: GoogleToolboxSubset should probably be pulled out into its own podspec eventually.  --jpepas
-  s.source_files = 'Logging.{h,m}', 'Test.{h,m}', 'ExceptionUtils.{h,m}', 'Target.{h,m}', \
-                   'CollectionUtils.{h,m}', 'ConcurrentOperation.{h,m}', 'GoogleToolboxSubset/*.{h,m}'
-  s.preserve_paths = 'mnemonicode-0.73'
+  #
+
+  sources = "Logging,Test,ExceptionUtils,Target,CollectionUtils,ConcurrentOperation," + 
+            "MYURLUtils,MYBlockUtils,MYStreamUtils,MYRegexUtils"
+
+  s.source_files = "{#{sources}}.{h,m}",
+                   'vendor/google-toolbox-for-mac/*.{h,m}'
   s.library = 'z'
 end

--- a/TouchDB/0.961/TouchDB.podspec
+++ b/TouchDB/0.961/TouchDB.podspec
@@ -1,0 +1,76 @@
+license = <<EOT
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+EOT
+
+Pod::Spec.new do |s|
+  version = '0.961'
+
+
+  s.name     = 'TouchDB'
+  s.version  = version
+  s.license  = {:type => 'Apache', :text => license}
+  s.summary  = 'CouchDB-compatible mobile database; Objective-C version.'
+  s.homepage = 'https://github.com/couchbaselabs/TouchDB-iOS'
+  s.author   = { 'Jens Alfke' => 'jens@couchbase.com' }
+
+  s.source   = { :git => 'https://github.com/couchbaselabs/TouchDB-iOS.git', 
+                 :tag => "v#{version}",
+                 :submodules => "true" }
+
+  s.platform = :ios, '5.0'
+
+
+  s.source_files = FileList['Source/**/*.{h,m}'].exclude(/GNUstep/).exclude(/_Tests/),
+                   FileList['vendor/oauthconsumer/**/*.{h,m,c}'].exclude(/OAHMAC_SHA1SignatureProvider\.m/),
+                   FileList['vendor/fmdb/src/**/*.{h,m}']
+
+  s.header_dir = 'TouchDB'
+
+  def s.post_install(target)
+    src = config.project_pods_root.to_s() + '/TouchDB/Source'
+
+    # Prepend some headers manually. The regular build does this with a prefix header, but
+    # that pollutes the global namespace. (and conflicts with CouchCocoa)
+    Dir.glob(src + '/**/*.m').each { |path|
+      File.open( path, 'r+') { |f|
+        firstLine = f.readline()
+        if firstLine =~ /patched/
+          next
+        end
+        f.rewind
+
+        content = f.readlines()
+        f.rewind
+
+        f.puts '// patched during Pod install'
+        f.puts '#import "TDJSON.h"'
+        f.puts '#import "CollectionUtils.h"'
+        f.puts '#import "Logging.h"'
+        f.puts '#import "Test.h"'
+
+        # add the version symbols to an arbitrary .m file
+        if path =~ /TDServer\.m/
+          f.puts "const unsigned char TouchDBVersionString[] __attribute__ ((used)) = \"@(#)PROGRAM:TouchDB  PROJECT:TouchDB-#{version}\";"
+          f.puts "const double TouchDBVersionNumber __attribute__ ((used)) = (double)#{version};"
+        end
+
+        f.puts
+        f.puts content
+      }
+    }
+  end
+
+  s.dependency 'CocoaHTTPServer'
+  s.dependency 'MYUtilities'
+  s.dependency 'JSONKit'
+end


### PR DESCRIPTION
I've made some podspecs for https://github.com/couchbaselabs/TouchDB-iOS and https://github.com/couchbaselabs/CouchCocoa. 

You may notice that the TouchDB spec in particular is... less elegant than it might otherwise be.  There are a number of problems upstream that show up here. Namely: 
- A conflicting definition of a common symbol is included in their prefix header
- It uses its own fork of fmdb, so the common pod can't be used
- It uses most, but not all, of the oauthconsumer library. In particular it provides its own implementation for one of the classes. This means that oauthconsumer can't be split out into its own pod, since the base implementation can't be excluded in that case and they will conflict. 
- It requires an xcode-generated version file to be present. You can see what I've done in TouchDB.podspec to work around this; it works, but there has to be a more elegant way. 

I've worked around all of these problems. I'll submit patches/issues upstream to get them resolved as possible. But in the meantime, this seems to work. 
