### PR TITLE
Adding v1.1 of TestFlightSDK.

### DIFF
--- a/TestFlightSDK/1.1/TestFlightSDK.podspec
+++ b/TestFlightSDK/1.1/TestFlightSDK.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |s|
+  s.name     = 'TestFlightSDK'
+  s.version  = '1.1'
+  s.license      = {
+    :type => 'Commercial',
+    :text => <<-LICENSE
+              All text and design is copyright © 2010-2012 TestFlight App, Inc.
+
+              All rights reserved.
+
+              https://testflightapp.com/tos/
+    LICENSE
+  }
+  s.summary  = 'TestFlightSDK for over-the-air beta testing and crash reporting.'
+  s.homepage = 'http://www.testflightapp.com'
+  s.author   = { 'TestFlight' => 'support@testflightapp.com' }
+  s.source   = { :http => 'https://d3fqheiq7nlyrx.cloudfront.net/sdk-downloads/TestFlightSDK1.1.zip'
+  s.description = 'TestFlightSDK for over-the-air beta testing and crash reporting.'
+  s.platform = :ios
+  s.source_files = 'TestFlight.h'
+  s.preserve_paths = 'libTestFlight.a'
+  s.library = 'TestFlight', 'z'
+  s.framework = 'UIKit'
+  s.xcconfig  =  { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/TestFlightSDK"' }
+end

--- a/TestFlightSDK/1.1/TestFlightSDK.podspec
+++ b/TestFlightSDK/1.1/TestFlightSDK.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.summary  = 'TestFlightSDK for over-the-air beta testing and crash reporting.'
   s.homepage = 'http://www.testflightapp.com'
   s.author   = { 'TestFlight' => 'support@testflightapp.com' }
-  s.source   = { :http => 'https://d3fqheiq7nlyrx.cloudfront.net/sdk-downloads/TestFlightSDK1.1.zip'
+  s.source   = { :http => 'https://d3fqheiq7nlyrx.cloudfront.net/sdk-downloads/TestFlightSDK1.1.zip' }
   s.description = 'TestFlightSDK for over-the-air beta testing and crash reporting.'
   s.platform = :ios
   s.source_files = 'TestFlight.h'


### PR DESCRIPTION
I've added a spec for v1.1 of the TestFlight SDK (this was released by TestFlight on 9/14/2012). Tested in my fork of the repo, which installed successfully locally. Thanks! (You also asked in my previous pull request if I'd like push; I would love it!)
