### PR TITLE
Update Flurry SDK to version 4.0.4 (Xcode 4.5 compatible)

### DIFF
--- a/FlurrySDK/4.0.4/FlurrySDK.podspec
+++ b/FlurrySDK/4.0.4/FlurrySDK.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name     = 'FlurrySDK'
+  s.version  = '4.0.4'
+  s.license  = 'Commercial'
+  s.summary  = 'FlurrySDK for analytics reporting.'
+  s.homepage = 'http://www.flurry.com'
+  s.author   = { 'Flurry' => 'http://www.flurry.com' }
+  s.source   = { :git => 'https://github.com/jk/FlurryAnalytics.git', :tag => '4.0.4' }
+  s.description = 'FlurrySDK for analytics tracking and reporting.'
+  s.platform = :ios
+  s.source_files = '**/*.h'
+  s.preserve_paths = '**/*.a'
+  s.library = 'Flurry'
+  s.xcconfig  =  { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/FlurrySDK/Flurry"' }
+  s.framework = 'SystemConfiguration'
+end


### PR DESCRIPTION
Due to the iPhone 5 and its armv7s arch we have to update all binary-only podfiles. This update is for Flurry SDK 4.0.4.
