### PR TITLE
Spec did not allow for previous values for pre compiler macros

### DIFF
--- a/HockeySDK/2.5.1/HockeySDK.podspec
+++ b/HockeySDK/2.5.1/HockeySDK.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'Resources', 'Support', 'Vendor'
   s.frameworks   = 'QuartzCore', 'SystemConfiguration', 'CrashReporter', 'CoreGraphics', 'UIKit'
   s.xcconfig     = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/HockeySDK/Vendor"',
-                     'GCC_PREPROCESSOR_DEFINITIONS' => %{BITHOCKEY_VERSION="@\\"#{s.version}\\""} }
+                     'GCC_PREPROCESSOR_DEFINITIONS' => "${GCC_PREPROCESSOR_DEFINITIONS} " + %{BITHOCKEY_VERSION="@\\"#{s.version}\\""} }
 
   def s.post_install(target_installer)
     puts "\nGenerating HockeySDK resources bundle\n".yellow if config.verbose?


### PR DESCRIPTION
HockeySDK overwrites the previous setting for pre compiler macros. Changed this so the previous values are inherited.
