### PR TITLE
New KIF framework version

### DIFF
--- a/KIF/0.0.2/KIF.podspec
+++ b/KIF/0.0.2/KIF.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name     = 'KIF'
+  s.version  = '0.0.2'
+  s.license  = 'Apache'
+  s.summary  = 'Keep It Functional - iOS Test Framework.'
+  s.homepage = 'https://github.com/square/KIF'
+  s.author   = { 'Square' => 'https://squareup.com/' }
+  s.source   = { :git => 'https://github.com/square/KIF.git', :commit => 'e4bc08c5f3e8a6a547ab5ce8561fda4912f2129f' }
+
+  s.description = 'KIF, which stands for Keep It Functional, is an iOS integration test framework. It allows for easy automation of iOS apps by leveraging the accessibility attributes that the OS makes available for those with visual disabilities.'
+  s.platform = :ios
+
+  s.source_files = 'Classes', 'Additions'
+  s.xcconfig     = {  'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) RUN_KIF_TESTS=1' }
+end


### PR DESCRIPTION
KIF framework defined in pod specs was quite outdated (at least compared to what they have right now). I've added a new pod spec version pointing to the latest KIF version. 
