### PR TITLE
KIF pod that supports building for iOS 6

### DIFF
--- a/KIF/0.0.2/KIF.podspec
+++ b/KIF/0.0.2/KIF.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name     = 'KIF'
+  s.version  = '0.0.2'
+  s.license  = 'Apache'
+  s.summary  = 'Keep It Functional - iOS Test Framework.'
+  s.homepage = 'https://github.com/square/KIF'
+  s.author   = { 'Square' => 'https://squareup.com/' }
+  s.source   = { :git => 'https://github.com/square/KIF.git', :commit => 'e4bc08c5f3e8a6a547ab5ce8561fda4912f2129f' }
+
+  s.description = 'KIF, which stands for Keep It Functional, is an iOS integration test framework. It allows for easy automation of iOS apps by leveraging the accessibility attributes that the OS makes available for those with visual disabilities.'
+  s.platform = :ios
+
+  s.source_files = 'Classes', 'Additions'
+  s.xcconfig     = {  'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) RUN_KIF_TESTS=1' }
+end


### PR DESCRIPTION
I needed this locally and thought I'd share to save others some time.

The commit that was needed for compiling with iOS 6 can be found [here](https://github.com/square/KIF/commit/6b2a85d4d202717988c556ca3ff0bb328976fdc3), and a relevant discussion can be found [here](https://github.com/square/KIF/issues/139).
