### PR TITLE
Nimbus/NetworkImage 0.9.3 no longer dependent on ASIHTTPRequest

### DIFF
--- a/Nimbus/0.9.3/Nimbus.podspec
+++ b/Nimbus/0.9.3/Nimbus.podspec
@@ -66,6 +66,7 @@ Pod::Spec.new do |s|
   s.subspec 'NetworkImage' do |image|
     image.source_files = 'src/networkimage/src'
     image.dependency 'Nimbus/Core'
+
   end
 
   s.subspec 'Overview' do |overview|

--- a/Nimbus/0.9.3/Nimbus.podspec
+++ b/Nimbus/0.9.3/Nimbus.podspec
@@ -24,7 +24,6 @@ Pod::Spec.new do |s|
                   'simple to understand.'
 
   s.platform = :ios
-  s.compiler_flags = '-Wno-switch'
 
 
   s.subspec 'Core' do |core|

--- a/Nimbus/0.9.3/Nimbus.podspec
+++ b/Nimbus/0.9.3/Nimbus.podspec
@@ -66,7 +66,6 @@ Pod::Spec.new do |s|
   s.subspec 'NetworkImage' do |image|
     image.source_files = 'src/networkimage/src'
     image.dependency 'Nimbus/Core'
-    image.dependency 'ASIHTTPRequest'
   end
 
   s.subspec 'Overview' do |overview|


### PR DESCRIPTION
Nimbus/NetworkImage no longer dependent on ASIHTTPRequest
