### PR TITLE
Add new pod, TwelveTwentyToolkit

### DIFF
--- a/TwelveTwentyToolkit/0.0.1/TwelveTwentyToolkit.podspec
+++ b/TwelveTwentyToolkit/0.0.1/TwelveTwentyToolkit.podspec
@@ -1,0 +1,29 @@
+Pod::Spec.new do |s|
+  s.name         = 'TwelveTwentyToolkit'
+  s.version      = '0.0.1'
+  s.summary      = 'The Twelve Twenty Toolkit of reusable Objective-C classes.'
+  s.homepage     = 'http://twelvetwenty.nl'
+  s.license      = 'MIT'
+  s.author       = { 'Eric-Paul Lecluse' => 'epologee@gmail.com', 'Jankees van Woezik' => 'jankeesvw@gmail.com' }
+  s.source       = { :git => 'https://github.com/TwelveTwenty/TwelveTwentyToolkit-ObjC.git', :commit => :head }
+  s.platform     = :ios, '5.0'
+  s.source_files = 'TwelveTwentyToolkit/TwelveTwentyToolkit.h'
+  s.requires_arc = true
+  s.preferred_dependency = 'CoreGraphics'
+
+  s.subspec 'CoreGraphics' do |cg|
+    cg.frameworks = 'UIKit','QuartzCore'
+	cg.source_files = 'TwelveTwentyToolkit/CoreGraphics/*'
+  end
+  
+  s.subspec 'CoreData' do |cd|
+    cd.frameworks = 'CoreData'
+	cd.source_files = 'TwelveTwentyToolkit/CoreData/*'
+  end
+  
+  s.subspec 'AddressBook' do |ab|
+    ab.frameworks = 'AddressBook'
+    ab.dependency 'TwelveTwentyToolkit/CoreData'
+    ab.source_files = 'TwelveTwentyToolkit/AddressBook/*.{h,m}','TwelveTwentyToolkit/AddressBook/**/*.{h.m}'
+  end
+end


### PR DESCRIPTION
Hi! Could this library be added to the awesome CocoaPods specs?

Thanks,
Eric-Paul.
## 

> pod spec lint TwelveTwentyToolkit/0.0.1/TwelveTwentyToolkit.podspec                                                                                                                                                         master [13954df]

 -> TwelveTwentyToolkit (0.0.1)

Analyzed 1 podspecs files.

TwelveTwentyToolkit.podspec passed validation.
