### PR TITLE
Add new pod, TwelveTwentyToolkit (2nd try)

### DIFF
--- a/TwelveTwentyToolkit/0.0.1/TwelveTwentyToolkit.podspec
+++ b/TwelveTwentyToolkit/0.0.1/TwelveTwentyToolkit.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://twelvetwenty.nl'
   s.license      = 'MIT'
   s.author       = { 'Eric-Paul Lecluse' => 'epologee@gmail.com', 'Jankees van Woezik' => 'jankeesvw@gmail.com' }
-  s.source       = { :git => 'https://github.com/TwelveTwenty/TwelveTwentyToolkit-ObjC.git', :commit => :head }
+  s.source       = { :git => 'https://github.com/TwelveTwenty/TwelveTwentyToolkit-ObjC.git', :tag => '0.0.1' }
   s.platform     = :ios, '5.0'
   s.source_files = 'TwelveTwentyToolkit/TwelveTwentyToolkit.h'
   s.requires_arc = true


### PR DESCRIPTION
Second pull request, this time s.source points to :tag => '0.0.1'. Lint still passes.
Sorry for the mixup.
## 

> pod spec lint TwelveTwentyToolkit/0.0.1/TwelveTwentyToolkit.podspec 

 -> TwelveTwentyToolkit (0.0.1)

Analyzed 1 podspecs files.

TwelveTwentyToolkit.podspec passed validation.
