### PR TITLE
enable blocks in EGOImageLoading using prefix definition

### DIFF
--- a/EGOImageLoading/0.0.1/EGOImageLoading.podspec
+++ b/EGOImageLoading/0.0.1/EGOImageLoading.podspec
@@ -8,8 +8,7 @@ Pod::Spec.new do |s|
   s.author   = 'Shaun Harrison'
   s.source   = { :git    => 'https://github.com/enormego/EGOImageLoading.git',
                  :commit => '9a3fa6b657c6b8217a24ff87c1fe4f670401f3bd' }
-
   s.source_files = 'EGO*/*.{h,m}'
-
   s.dependency 'EGOCache'
+  s.prefix_header_contents = "#define __EGOIL_USE_BLOCKS 1"
 end


### PR DESCRIPTION
EGOImageLoader offers use of blocks, but only if a particular constant is defined (__EGOIL_USE_BLOCKS):
https://github.com/enormego/EGOImageLoading/blob/master/EGOImageLoader/EGOImageLoader.m#L182-225

Prior to using cocoapods, this definition was easily enough set in one's project prefix file.  Integrated as a cocoapod, though, the definition must exist in Pods-prefix.pch

cc: @fphilipe, @irrationalfab
