### PR TITLE
Airbrake-iOS Podspec Now Installs Correctly

### DIFF
--- a/Airbrake-iOS/3.1.0/Airbrake-iOS.podspec
+++ b/Airbrake-iOS/3.1.0/Airbrake-iOS.podspec
@@ -26,11 +26,13 @@ Pod::Spec.new do |s|
   s.summary      = "A Airbrake Notifier for iOS."
   s.homepage     = "http://airbrake.io/pages/ios-notifier"
   s.author       = { "Airbrake" => "support@airbrake.io" }
-  s.license      = { :type => 'MIT', :text => license }
+  s.license      = { :type => 'MIT' }
   s.platform     = :ios
   s.source       = { :git => "https://github.com/airbrake/airbrake-ios.git", :tag => "3.1.0" }
   s.source_files = 'Airbrake/{notifier,gcalertview}/*.{h,m}'
-  s.frameworks   = 'SystemConfiguration.framework'  
-  s.libraries    = 'libxml2.dylib'
+  s.resources    = "Airbrake/notifier/*.bundle"
+  s.frameworks   = 'SystemConfiguration'  
+  s.libraries    = 'xml2'
   s.dependency   'KissXML'
 end
+


### PR DESCRIPTION
Fixes two issues with the Airbrake-iOS podspec.
• bundle file(s) are now included. This includes all localized strings.
• frameworks and libraries were not referenced correctly which created
a bad xcconfig file
