### PR TITLE
Update KIF and MAKVONotificationCenter

### DIFF
--- a/KIF/0.0.2/KIF.podspec
+++ b/KIF/0.0.2/KIF.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name     = 'KIF'
+  s.version  = '0.0.2'
+  s.license  = 'Apache'
+  s.summary  = 'Keep It Functional - iOS Test Framework.'
+  s.homepage = 'https://github.com/square/KIF'
+  s.author   = { 'Square' => 'https://squareup.com/' }
+  s.source   = { :git => 'https://github.com/square/KIF.git', :commit => 'e4bc08c5f3' }
+
+  s.description = 'KIF, which stands for Keep It Functional, is an iOS integration test framework. It allows for easy automation of iOS apps by leveraging the accessibility attributes that the OS makes available for those with visual disabilities.'
+  s.platform = :ios
+
+  s.source_files = 'Classes', 'Additions'
+  s.xcconfig     = {  'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) RUN_KIF_TESTS=1' }
+end

--- a/MAKVONotificationCenter/0.0.2/MAKVONotificationCenter.podspec
+++ b/MAKVONotificationCenter/0.0.2/MAKVONotificationCenter.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = 'MAKVONotificationCenter'
+  s.version      = '0.0.2'
+  s.source       = { :git => 'https://github.com/mikeash/MAKVONotificationCenter.git', :commit => '1f414de5dd2fd54fad6928a09794431ffa13f30f' }
+  s.homepage     = 'http://www.mikeash.com/pyblog/key-value-observing-done-right.html'
+  s.author       = { 'Mike Ash' => 'mike@mikeash.com' }
+  s.summary      = 'Key-Value Observing Done Right.'
+  s.source_files = 'MAKVONotificationCenter.{h,m}'
+  s.header_dir   = s.name
+  s.requires_arc = true
+
+end


### PR DESCRIPTION
Both frameworks needed some fixes to work with Xcode 4.5 and iOS 6. This is reflected in the master of both projects, but the 0.0.1 podspecs are pointing to older commits. Fixed this by introducing 0.0.2 versions of both projects.
