### PR TITLE
podspec for cocos2d-iphone-2.1-beta2

### DIFF
--- a/cocos2d/2.1.beta2/cocos2d.podspec
+++ b/cocos2d/2.1.beta2/cocos2d.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications for iPod Touch, iPhone, iPad and Mac. It is based on the cocos2d design but instead of using python it, uses objective-c.'
   s.homepage    =  'http://www.cocos2d-iphone.org'
   s.author      =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
-  s.source      =  {:git => 'https://github.com/cocos2d/cocos2d-iphone.git', :tag => 'release-2.0-rc1'}
+  s.source      =  {:git => 'https://github.com/cocos2d/cocos2d-iphone.git', :tag => '2.1.beta2'}
 
   s.source_files = 'cocos2d/**/*.{h,m,c}', 'CocosDenshion/CocosDenshionExtras/*.{h,m}', 'CocosDenshion/CocosDenshion/*.{h,m}', 
     'external/libpng/*.{h,c}', 'external/kazmath/src/**/*.{c,h}', 'external/kazmath/include/**/*.{c,h}'

--- a/cocos2d/2.1.beta2/cocos2d.podspec
+++ b/cocos2d/2.1.beta2/cocos2d.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+  s.name        =  'cocos2d'
+  s.license     =  'MIT'
+  s.version     =  '2.1.beta2'
+  s.summary     =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications.'
+  s.description =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications for iPod Touch, iPhone, iPad and Mac. It is based on the cocos2d design but instead of using python it, uses objective-c.'
+  s.homepage    =  'http://www.cocos2d-iphone.org'
+  s.author      =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
+  s.source      =  {:git => 'https://github.com/cocos2d/cocos2d-iphone.git', :tag => 'release-2.0-rc1'}
+
+  s.source_files = 'cocos2d/**/*.{h,m,c}', 'CocosDenshion/CocosDenshionExtras/*.{h,m}', 'CocosDenshion/CocosDenshion/*.{h,m}', 
+    'external/libpng/*.{h,c}', 'external/kazmath/src/**/*.{c,h}', 'external/kazmath/include/**/*.{c,h}'
+
+  s.xcconfig = {
+    'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/cocos2d/external/kazmath/include"'
+  }
+  s.frameworks =  ["OpenGLES", "OpenAL", "AVFoundation", "AudioToolbox", "QuartzCore"]
+  s.library    =  'z'
+
+
+  def s.copy_header_mapping(from)
+    from.relative_path_from(Pathname.new('cocos2d'))
+  end
+end


### PR DESCRIPTION
podspec for cocos2d-iphone-2.1-beta2 added. Updated templates for iPhone5, and Mac. LabelTTF now works on Mac Retina Display.
