### PR TITLE
Add new KIF version for latest commit

### DIFF
--- a/KIF/0.0.2/KIF.podspec
+++ b/KIF/0.0.2/KIF.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name     = 'KIF'
+  s.version  = '0.0.2'
+  s.license  = 'Apache'
+  s.summary  = 'Keep It Functional - iOS Test Framework.'
+  s.homepage = 'https://github.com/square/KIF'
+  s.author   = { 'Square' => 'https://squareup.com/' }
+  s.source   = { :git => 'https://github.com/square/KIF.git', :commit => 'e4bc08c5f3' }
+
+  s.description = 'KIF, which stands for Keep It Functional, is an iOS integration test framework. It allows for easy automation of iOS apps by leveraging the accessibility attributes that the OS makes available for those with visual disabilities.'
+  s.platform = :ios
+
+  s.source_files = 'Classes', 'Additions'
+  s.xcconfig     = {  'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) RUN_KIF_TESTS=1' }
+end


### PR DESCRIPTION
The KIF commit in the repo at the moment doesn't work with iOS 6, so I've added a new version that points to a commit that does.
