### PR TITLE
Fixing ARC declarations on two related pods.

### DIFF
--- a/FTWButton/1.0/FTWButton.podspec
+++ b/FTWButton/1.0/FTWButton.podspec
@@ -23,4 +23,5 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
   s.source_files  = 'FTWButton/FTWButton.{h,m}'
   s.frameworks    = 'QuartzCore'
   s.dependency    'SKInnerShadowLayer', '~> 1.0'
+  s.requires_arc = true
 end

--- a/SKInnerShadowLayer/1.0/SKInnerShadowLayer.podspec
+++ b/SKInnerShadowLayer/1.0/SKInnerShadowLayer.podspec
@@ -21,4 +21,5 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
   s.source    = { :git => 'https://github.com/khanlou/SKInnerShadowLayer.git', :tag => 'v1.0' }
   s.source_files  = 'SKInnerShadowLayer/SKInnerShadowLayer.{h,m}'
   s.frameworks    = 'QuartzCore'
+  s.requires_arc = true
 end


### PR DESCRIPTION
I'm curious if this is allowed on existing podspecs. I submitted these two the other day, haphazardly omitting the requires_arc option on both. Can I correct these in their existing podspecs? Or will new versions need to be submitted?
