### PR TITLE
Adding podspec for sqlite3 library

### DIFF
--- a/sqlite3/3.7.14.1/sqlite3.podspec
+++ b/sqlite3/3.7.14.1/sqlite3.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name         = "sqlite3"
+  s.version      = "3.7.14.1"
+  s.summary      = "SQLite is an embedded SQL database engine."
+  s.homepage     = "http://www.sqlite.org"
+  s.license      = "Public Domain"
+  s.author       = {"D. Richard Hipp" => "drh@hwaci.com"}
+
+  sqlite_version_format = "%.1d%.2d%.2d%.2d" % s.version.to_s.split('.').push(0)
+
+  s.source       = {:http => "http://www.sqlite.org/sqlite-amalgamation-#{sqlite_version_format}.zip"}
+  s.source_files = "sqlite-amalgamation-#{sqlite_version_format}/sqlite3*.{h,c}"
+
+end


### PR DESCRIPTION
This podspec retrieves the amalgamation distribution of sqlite3.
- CocoaPod libraries that specify a spec.library = 'sqlite3' will continue to link to the bundled iOS version, instead of this one. I haven't yet found a way around this, aside from using a modified podspec. Any insight into a better way to override another podspec's library requirement would appreciated.
- I wrote the this podspec so it should be trivial to add additional podspecs to other versions by simply copying the file, and changing the version number. 
