### PR TITLE
Update ShareKit's commit version and Evernote subspec.

### DIFF
--- a/ShareKit/2.0/ShareKit.podspec
+++ b/ShareKit/2.0/ShareKit.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary       = 'Drop in sharing features for all iPhone and iPad apps.'
   s.homepage      = 'http://getsharekit.com/'
   s.author        = 'ShareKit Community'
-  s.source        = { :git  => 'https://github.com/ShareKit/ShareKit.git', :commit => 'b8129c7c229a383ea5926aaa7869aadbccb71e8f' }
+  s.source        = { :git  => 'https://github.com/ShareKit/ShareKit.git', :commit => '134529c27df467884b1003a4c1eca0d44612e9a9' }
   s.license       = { :type => 'MIT',
                       :text => %Q|Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n| +
                                %Q|The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n| +
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'Evernote' do |evernote|
     evernote.source_files = 'Classes/ShareKit/Sharers/Services/Evernote/**/*.{h,m}'
+    evernote.dependency 'Evernote-SDK-iOS',"0.2.1"
   end
 
   s.subspec 'Facebook' do |facebook|


### PR DESCRIPTION
Shareit's commit needs to be updated to a newer version so the correct version of the Evernote API is included. Evernote changed over to OAuth and that commit of ShareKit uses the old iOS SDK for Evernote. Also, an Evernote dependency needs to be added. This is because the SDK is now its own pod and is not included in ShareKit. 
