### PR TITLE
Adding a podspec for AdMob v6.2.1

### DIFF
--- a/Google-AdMob-Ads-SDK/6.2.0/Google-AdMob-Ads-SDK.podspec
+++ b/Google-AdMob-Ads-SDK/6.2.0/Google-AdMob-Ads-SDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = "Google-AdMob-Ads-SDK"
   s.version = "6.2.0"
-  s.summary = "Google AdMob Ads SDK"
+  s.summary = "Google AdMob Ads SDK v6.2.0 for iOS."
   s.description = "The Google AdMob Ads SDK allows developers to easily incorporate mobile-friendly text and image banners as well as rich, full-screen web apps known as interstitials."
   s.homepage = "https://developers.google.com/mobile-ads-sdk/docs/"
 

--- a/Google-AdMob-Ads-SDK/6.2.0/Google-AdMob-Ads-SDK.podspec
+++ b/Google-AdMob-Ads-SDK/6.2.0/Google-AdMob-Ads-SDK.podspec
@@ -1,8 +1,8 @@
 Pod::Spec.new do |s|
   s.name = "Google-AdMob-Ads-SDK"
   s.version = "6.2.0"
-  s.summary = "Google AdMob Ads SDK v6.2.0 for iOS."
-  s.description = "The Google AdMob Ads SDK allows developers to easily incorporate mobile-friendly text and image banners as well as rich, full-screen web apps known as interstitials."
+  s.summary = "Google AdMob Ads SDK v6.2.1 for iOS."
+  s.description = "The Google AdMob Ads SDK allows developers to easily incorporate mobile-friendly text and image banners as well as rich, full-screen web apps known as interstitials. This podspec is using v6.2.1 becaue the download link has been updated to use this."
   s.homepage = "https://developers.google.com/mobile-ads-sdk/docs/"
 
   s.license = {
@@ -15,10 +15,12 @@ LICENSE
   s.source = { :http => "http://dl.google.com/googleadmobadssdk/googleadmobadssdkios.zip" }
   s.platform = :ios
 
-  s.source_files = 'GoogleAdMobAdsSdkiOS-6.2.0/*.h'
-  s.preserve_paths = 'GoogleAdMobAdsSdkiOS-6.2.0'
+  s.preserve_paths = 'GoogleAdMobAdsSdkiOS-6.2.1'
+  s.source_files = 'GoogleAdMobAdsSdkiOS-6.2.1/*.h'
 
-  s.framework = %w{AudioToolbox MessageUI SystemConfiguration CoreGraphics AdSupport}
+  s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
+
+  s.framework = %w{AudioToolbox MessageUI SystemConfiguration CoreGraphics AdSupport StoreKit}
   s.library = 'GoogleAdMobAds'
-  s.xcconfig = { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Google-AdMob-Ads-SDK/GoogleAdMobAdsSdkiOS-6.2.0"' }
+  s.xcconfig = { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Google-AdMob-Ads-SDK/GoogleAdMobAdsSdkiOS-6.2.1"' }
 end

--- a/Google-AdMob-Ads-SDK/6.2.0/Google-AdMob-Ads-SDK.podspec
+++ b/Google-AdMob-Ads-SDK/6.2.0/Google-AdMob-Ads-SDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = "Google-AdMob-Ads-SDK"
   s.version = "6.2.0"
-  s.summary = "Google AdMob Ads SDK v6.2.0 for iOS."
+  s.summary = "Google AdMob Ads SDK"
   s.description = "The Google AdMob Ads SDK allows developers to easily incorporate mobile-friendly text and image banners as well as rich, full-screen web apps known as interstitials."
   s.homepage = "https://developers.google.com/mobile-ads-sdk/docs/"
 

--- a/Google-AdMob-Ads-SDK/6.2.0/Google-AdMob-Ads-SDK.podspec
+++ b/Google-AdMob-Ads-SDK/6.2.0/Google-AdMob-Ads-SDK.podspec
@@ -1,8 +1,8 @@
 Pod::Spec.new do |s|
   s.name = "Google-AdMob-Ads-SDK"
   s.version = "6.2.0"
-  s.summary = "Google AdMob Ads SDK v6.2.1 for iOS."
-  s.description = "The Google AdMob Ads SDK allows developers to easily incorporate mobile-friendly text and image banners as well as rich, full-screen web apps known as interstitials. This podspec is using v6.2.1 becaue the download link has been updated to use this."
+  s.summary = "Google AdMob Ads SDK v6.2.0 for iOS."
+  s.description = "The Google AdMob Ads SDK allows developers to easily incorporate mobile-friendly text and image banners as well as rich, full-screen web apps known as interstitials."
   s.homepage = "https://developers.google.com/mobile-ads-sdk/docs/"
 
   s.license = {
@@ -15,12 +15,10 @@ LICENSE
   s.source = { :http => "http://dl.google.com/googleadmobadssdk/googleadmobadssdkios.zip" }
   s.platform = :ios
 
-  s.preserve_paths = 'GoogleAdMobAdsSdkiOS-6.2.1'
-  s.source_files = 'GoogleAdMobAdsSdkiOS-6.2.1/*.h'
+  s.source_files = 'GoogleAdMobAdsSdkiOS-6.2.0/*.h'
+  s.preserve_paths = 'GoogleAdMobAdsSdkiOS-6.2.0'
 
-  s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
-
-  s.framework = %w{AudioToolbox MessageUI SystemConfiguration CoreGraphics AdSupport StoreKit}
+  s.framework = %w{AudioToolbox MessageUI SystemConfiguration CoreGraphics AdSupport}
   s.library = 'GoogleAdMobAds'
-  s.xcconfig = { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Google-AdMob-Ads-SDK/GoogleAdMobAdsSdkiOS-6.2.1"' }
+  s.xcconfig = { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Google-AdMob-Ads-SDK/GoogleAdMobAdsSdkiOS-6.2.0"' }
 end

--- a/Google-AdMob-Ads-SDK/6.2.1/Google-AdMob-Ads-SDK.podspec
+++ b/Google-AdMob-Ads-SDK/6.2.1/Google-AdMob-Ads-SDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = "Google-AdMob-Ads-SDK"
   s.version = "6.2.1"
-  s.summary = "Google AdMob Ads SDK v6.2.1 for iOS."
+  s.summary = "Google AdMob Ads SDK 6.2.1 for iOS."
   s.description = "The Google AdMob Ads SDK allows developers to easily incorporate mobile-friendly text and image banners as well as rich, full-screen web apps known as interstitials."
   s.homepage = "https://developers.google.com/mobile-ads-sdk/docs/"
 

--- a/Google-AdMob-Ads-SDK/6.2.1/Google-AdMob-Ads-SDK.podspec
+++ b/Google-AdMob-Ads-SDK/6.2.1/Google-AdMob-Ads-SDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = "Google-AdMob-Ads-SDK"
   s.version = "6.2.1"
-  s.summary = "Google AdMob Ads SDK"
+  s.summary = "Google AdMob Ads SDK v6.2.1 for iOS."
   s.description = "The Google AdMob Ads SDK allows developers to easily incorporate mobile-friendly text and image banners as well as rich, full-screen web apps known as interstitials."
   s.homepage = "https://developers.google.com/mobile-ads-sdk/docs/"
 
@@ -15,8 +15,10 @@ LICENSE
   s.source = { :http => "http://dl.google.com/googleadmobadssdk/googleadmobadssdkios.zip" }
   s.platform = :ios
 
-  s.source_files = 'GoogleAdMobAdsSdkiOS-6.2.1/*.h'
   s.preserve_paths = 'GoogleAdMobAdsSdkiOS-6.2.1'
+  s.source_files = 'GoogleAdMobAdsSdkiOS-6.2.1/*.h'
+
+  s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
 
   s.framework = %w{AudioToolbox MessageUI SystemConfiguration CoreGraphics AdSupport StoreKit}
   s.library = 'GoogleAdMobAds'

--- a/Google-AdMob-Ads-SDK/6.2.1/Google-AdMob-Ads-SDK.podspec
+++ b/Google-AdMob-Ads-SDK/6.2.1/Google-AdMob-Ads-SDK.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+  s.name = "Google-AdMob-Ads-SDK"
+  s.version = "6.2.1"
+  s.summary = "Google AdMob Ads SDK"
+  s.description = "The Google AdMob Ads SDK allows developers to easily incorporate mobile-friendly text and image banners as well as rich, full-screen web apps known as interstitials."
+  s.homepage = "https://developers.google.com/mobile-ads-sdk/docs/"
+
+  s.license = {
+    :type => 'Copyright',
+    :text => <<-LICENSE
+Copyright 2009 - 2012 Google, Inc. All rights reserved.
+LICENSE
+  }
+  s.author = 'Google Inc.'
+  s.source = { :http => "http://dl.google.com/googleadmobadssdk/googleadmobadssdkios.zip" }
+  s.platform = :ios
+
+  s.source_files = 'GoogleAdMobAdsSdkiOS-6.2.1/*.h'
+  s.preserve_paths = 'GoogleAdMobAdsSdkiOS-6.2.1'
+
+  s.framework = %w{AudioToolbox MessageUI SystemConfiguration CoreGraphics AdSupport StoreKit}
+  s.library = 'GoogleAdMobAds'
+  s.xcconfig = { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Google-AdMob-Ads-SDK/GoogleAdMobAdsSdkiOS-6.2.1"' }
+end


### PR DESCRIPTION
Adding a podspec for AdMob v6.2.1. All it involves is changing the folder name and adding an extra framework.
