### PR TITLE
SCNetworkReachability framework dependence fixed

### DIFF
--- a/SCNetworkReachability/1.0.0/SCNetworkReachability.podspec
+++ b/SCNetworkReachability/1.0.0/SCNetworkReachability.podspec
@@ -9,5 +9,5 @@ Pod::Spec.new do |s|
 		     :tag => "1.0.0"}
   s.platform     = :ios
   s.source_files = '*.{h,m}'
-  s.framework  = 'SystemConfiguration.framework'
+  s.framework  = 'SystemConfiguration'
 end


### PR DESCRIPTION
Fixed podspec file
s.framework  = 'SystemConfiguration'
was
s.framework  = 'SystemConfiguration.framework'
