### PR TITLE
Version 1.0.0 of Mixpanel

### DIFF
--- a/Mixpanel/1.0.0/Mixpanel.podspec
+++ b/Mixpanel/1.0.0/Mixpanel.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name     = 'Mixpanel'
+  s.version  = '1.0.0'
+  s.license  = 'Apache License'
+  s.summary  = 'iPhone tracking library for Mixpanel Analytics.'
+  s.homepage = 'http://mixpanel.com'
+  s.author   = { 'Mixpanel' => 'support@mixpanel.com' }
+  s.source   = { :git => 'https://github.com/mixpanel/mixpanel-iphone.git', :tag => 'v1.0.0' }
+  s.platform = :ios
+  s.source_files = 'Mixpanel/**/*.{h,m}'
+end


### PR DESCRIPTION
Here's a pull request to add the latest version of Mixpanel to CocoaPods. The Mixpanel maintainer tagged the version as 1.0.0, which could be kind of confusing since there's already a 1.3.1 in the repo. Let me know if this is going to be a problem, and if so what the best way to resolve it is.

The previous specs were not targeting tags but rather commits. 
