### PR TITLE
Update Localytics-iOS-Client/2.14/Localytics-iOS-Client.podspec

### DIFF
--- a/Localytics-iOS-Client/2.14/Localytics-iOS-Client.podspec
+++ b/Localytics-iOS-Client/2.14/Localytics-iOS-Client.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.source       = { :http => "http://files.localytics.com/ClientLibraries/iOS/Localytics-iOS-Client-latest.source.zip" }
   s.platform     = :ios, '4.0'
 
-  s.source_files = 'Localytics-iOS-Client-2.14.source/src/*.{h,m}'
+  s.source_files = 'Localytics-iOS-Client-latest.source/src/*.{h,m}'
 
   s.framework = 'AdSupport'
   s.library   = 'z', 'sqlite3'


### PR DESCRIPTION
Fixed wrong path. Localytics pod doesn't work completely.
