### PR TITLE
Add podspec for MKMapView+AttributionView 0.0.1

### DIFF
--- a/MKMapView+AttributionView/0.0.1/MKMapView+AttributionView.podspec
+++ b/MKMapView+AttributionView/0.0.1/MKMapView+AttributionView.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name = 'MKMapView+AttributionView'
+  s.version = '0.0.1'
+  s.authors = {'Bart Vandendriessche' => 'bart.vandendriessche@gmail.com'}
+  s.homepage = 'https://github.com/bartvandendriessche/MKMapView-AttributionView'
+  s.summary = 'A MKMapView category that adds a method to obtain the AttributionView.'
+  s.source = {:git => 'https://github.com/bartvandendriessche/MKMapView-AttributionView.git', :commit => :head}
+  s.license = { :type => 'MIT', :text => <<-LICENSE
+                Copyright (c) 2012 Bart Vandendriessche
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+                associated documentation files (the "Software"), to deal in the Software without restriction,
+                including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+                and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+                subject to the following conditions:
+                The above copyright notice and this permission notice shall be included in all copies or substantial
+                portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+                LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+                IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+                WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+                SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+              LICENSE
+  }
+
+  s.platform = :ios
+  s.requires_arc = true
+  s.frameworks = 'MapKit'
+  s.source_files = 'MKMapView+AttributionView'
+end

--- a/MKMapView+AttributionView/0.1.0/MKMapView+AttributionView.podspec
+++ b/MKMapView+AttributionView/0.1.0/MKMapView+AttributionView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'MKMapView+AttributionView'
-  s.version = '0.1'
+  s.version = '0.1.0'
   s.authors = {'Bart Vandendriessche' => 'bart.vandendriessche@gmail.com'}
   s.homepage = 'https://github.com/bartvandendriessche/MKMapView-AttributionView'
   s.summary = 'A MKMapView category that adds a method to obtain the AttributionView.'

--- a/MKMapView+AttributionView/0.1.0/MKMapView+AttributionView.podspec
+++ b/MKMapView+AttributionView/0.1.0/MKMapView+AttributionView.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name = 'MKMapView+AttributionView'
-  s.version = '0.0.1'
+  s.version = '0.1'
   s.authors = {'Bart Vandendriessche' => 'bart.vandendriessche@gmail.com'}
   s.homepage = 'https://github.com/bartvandendriessche/MKMapView-AttributionView'
   s.summary = 'A MKMapView category that adds a method to obtain the AttributionView.'
-  s.source = {:git => 'https://github.com/bartvandendriessche/MKMapView-AttributionView.git', :commit => :head}
+  s.source = {:git => 'https://github.com/bartvandendriessche/MKMapView-AttributionView.git', :tag => '0.1.0'}
   s.license = { :type => 'MIT', :text => <<-LICENSE
                 Copyright (c) 2012 Bart Vandendriessche
 


### PR DESCRIPTION
A MKMapView category that adds a method to obtain the AttributionView.

In iOS < 6.0 the AttributionView is a UIImageView containing the Google logo.

As of iOS 6.0, it's a private subclass of UILabel.
