### PR TITLE
Updating socket.IO-objc to 0.2.5

### DIFF
--- a/socket.IO/0.2.5/socket.IO.podspec
+++ b/socket.IO/0.2.5/socket.IO.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
 
-  s.dependency 'SocketRocket', '~> 0.1'
+  s.dependency 'SocketRocket', '~> 0.2'
 end

--- a/socket.IO/0.2.5/socket.IO.podspec
+++ b/socket.IO/0.2.5/socket.IO.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name         = "socket.IO"
+  s.version      = "0.2.5"
+  s.summary      = "socket.io v0.7.2+ for iOS devices"
+  s.description  = <<-DESC
+    Interface to communicate between Objective C and Socket.IO with the help of websockets. It's based on fpotter's socketio-cocoa and uses other libraries/classes like SocketRocket, json-framework (optional) and jsonkit (optional).
+                   DESC
+  s.homepage     = "https://github.com/pkyeck/socket.IO-objc"
+  s.license      = 'MIT'
+
+  s.author       = { "Philipp Kyeck" => "philipp@beta-interactive.de" }
+  s.source       = { :git => "https://github.com/pkyeck/socket.IO-objc.git", :tag => '0.2.5' }
+
+  s.source_files = '*.{h,m}'
+
+  s.requires_arc = true
+
+  s.dependency 'SocketRocket', '~> 0.1'
+end


### PR DESCRIPTION
I removed the SBJSON dependency that was in previous spec versions, as the library lists that and JSONKit as optional and works with NSJSONSerialization if the OS supports it.
