### PR TITLE
Airbrake Notifier resources

### DIFF
--- a/Airbrake-iOS/3.1.0/Airbrake-iOS.podspec
+++ b/Airbrake-iOS/3.1.0/Airbrake-iOS.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios
   s.source       = { :git => "https://github.com/airbrake/airbrake-ios.git", :tag => "3.1.0" }
   s.source_files = 'Airbrake/{notifier,gcalertview}/*.{h,m}'
-  s.resources    = "Airbrake/notifier/*.bundle"
+  s.resources    = "Airbrake/notifier/*.lproj"
   s.frameworks   = 'SystemConfiguration'  
   s.libraries    = 'xml2'
   s.dependency   'KissXML'


### PR DESCRIPTION
The Airbrake notifier translations are located in a bundle which isn't correctly included by the pod spec.

I have edited the resources path to include all .lproj files and Xcode handle it itself as a bundle file.
