### PR TITLE
Fixed the SDWebImage/MapKit subspec for version 2.7 and 3.0.

### DIFF
--- a/SDWebImage/2.7/SDWebImage.podspec
+++ b/SDWebImage/2.7/SDWebImage.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'MapKit' do |sp|
     sp.dependency 'SDWebImage/Main'
-    sp.source_files = 'MKAnnotationView+WebCache.*'
+    sp.source_files = 'SDWebImage/MKAnnotationView+WebCache.*'
     sp.framework    = 'MapKit'
   end
 end

--- a/SDWebImage/3.0/SDWebImage.podspec
+++ b/SDWebImage/3.0/SDWebImage.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'MapKit' do |sp|
     sp.dependency 'SDWebImage/Main'
-    sp.source_files = 'MKAnnotationView+WebCache.*'
+    sp.source_files = 'SDWebImage/MKAnnotationView+WebCache.*'
     sp.framework    = 'MapKit'
   end
 end


### PR DESCRIPTION
The files for the MapKit subspec weren't being copied.
