### PR TITLE
GData: add quotes around libxml header search path declaration.

### DIFF
--- a/GData/1.9.1/GData.podspec
+++ b/GData/1.9.1/GData.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
                          'Source/XMLSupport/*.{h,m}', 'Source/*.{h,m}'
     gdc.compiler_flags = '-Wno-format-extra-args', '-Wno-format-invalid-specifier', '-Wno-incompatible-pointer-types'
     gdc.libraries      = 'xml2'
-    gdc.xcconfig       = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
+    gdc.xcconfig       = { 'HEADER_SEARCH_PATHS' => '"$(SDKROOT)/usr/include/libxml2"' }
   end
 
   s.subspec 'YouTube' do |gdyt|
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.subspec 'XMLNode' do |gdxml|
     gdxml.source_files = 'Source/XMLSupport/*.{h,m}'
     gdxml.libraries    = 'xml2'
-    gdxml.xcconfig     = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
+    gdxml.xcconfig     = { 'HEADER_SEARCH_PATHS' => '"$(SDKROOT)/usr/include/libxml2"' }
   end
 
 end


### PR DESCRIPTION
Fixes a problem you’ll encounter (see https://github.com/CocoaPods/CocoaPods/issues/682) if you have a space in `SDKROOT`.
