### PR TITLE
Color Art 0.0.5

### DIFF
--- a/ColorArt/0.0.5/ColorArt.podspec
+++ b/ColorArt/0.0.5/ColorArt.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "ColorArt"
+  s.version      = "0.0.5"
+  s.summary      = "iTunes 11-style color matching code."
+  s.homepage     = "https://github.com/fleitz/ColorArt"
+  s.license      = 'CUSTOM'
+  s.authors      = { "Fred Leitz" => "fred.leitz@gmail.com", "Aaron Brethorst" => "", "Wade Cosgrove" => "" }
+  s.source       = { :git => "https://github.com/fleitz/ColorArt.git", :tag => "0.0.5" }
+  s.platform     = :ios, '5.0'
+  s.source_files = 'ColorArt/Classes', 'ColorArt/Classes/**/*.{h,m}'
+  s.frameworks = 'UIKit', 'Foundation', 'CoreGraphics', 'QuartzCore'
+  s.requires_arc = true
+end


### PR DESCRIPTION
Color Art is a color detection library to duplicate iTunes 11.

Originally written by Panic (https://github.com/panicinc/ColorArt) for OS X, this is a port to iOS.
