### PR TITLE
Fix MagicalRecord 1.8.3 installation issues

### DIFF
--- a/MagicalRecord/1.8.3/MagicalRecord.podspec
+++ b/MagicalRecord/1.8.3/MagicalRecord.podspec
@@ -2,13 +2,18 @@ Pod::Spec.new do |s|
   s.name     = 'MagicalRecord'
   s.version  = '1.8.3'
   s.license  = 'MIT'
-  s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1!.'
+  s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1!'
   s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
-  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => '1.8.3' }
+  s.source   = { :git => 'http://github.com/magicalpanda/MagicalRecord.git', :tag => '1.8.3' }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'Source/**/*.{h,m}'
   s.framework    = 'CoreData'
 
-  s.prefix_header_contents = "#define MR_SHORTHAND 1\n#import \"CoreData+MagicalRecord.h\""
+  def s.post_install(target)
+    prefix_header = config.project_pods_root + target.prefix_header_filename
+    prefix_header.open('a') do |file|
+      file.puts(%{#ifdef __OBJC__\n#define MR_SHORTHAND 1\n#import "CoreData+MagicalRecord.h"\n#endif})
+    end
+  end
 end

--- a/MagicalRecord/1.8.3/MagicalRecord.podspec
+++ b/MagicalRecord/1.8.3/MagicalRecord.podspec
@@ -3,9 +3,9 @@ Pod::Spec.new do |s|
   s.version  = '1.8.3'
   s.license  = 'MIT'
   s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1!.'
-  s.homepage = 'https://github.com/magicalpanda/MagicalRecord'
+  s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
-  s.source   = { :git => 'http://github.com/magicalpanda/MagicalRecord.git', :tag => '1.8.3' }
+  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => '1.8.3' }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'Source/**/*.{h,m}'
   s.framework    = 'CoreData'

--- a/MagicalRecord/1.8.3/MagicalRecord.podspec
+++ b/MagicalRecord/1.8.3/MagicalRecord.podspec
@@ -2,8 +2,8 @@ Pod::Spec.new do |s|
   s.name     = 'MagicalRecord'
   s.version  = '1.8.3'
   s.license  = 'MIT'
-  s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1!'
-  s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
+  s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1!.'
+  s.homepage = 'https://github.com/magicalpanda/MagicalRecord'
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
   s.source   = { :git => 'http://github.com/magicalpanda/MagicalRecord.git', :tag => '1.8.3' }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
@@ -17,3 +17,4 @@ Pod::Spec.new do |s|
     end
   end
 end
+


### PR DESCRIPTION
As of right now, the 1.8.3 tag of MagicalRecord doesn't install correctly. The podspec in [CocoaPods/Specs](https://github.com/CocoaPods/Specs/blob/master/MagicalRecord/1.8.3/MagicalRecord.podspec) differs from the one in the [MagicalRecord repo](https://github.com/magicalpanda/MagicalRecord/blob/1.8.3/MagicalRecord.podspec) in that it doesn't wrap the include call in Pods-prefix.pch with an `#ifdef __OBJC__ ... #endif`. This causes a number of compilation errors, currently being experienced (https://github.com/magicalpanda/MagicalRecord/issues/146) by MagicalRecord users such as myself. 1.8.3 is an older version, but it is the last version to support iOS 4 out-of-the-box.

On a side note, I made a [pull request](https://github.com/CocoaPods/Specs/pull/420#issuecomment-7998698) a few months ago and never got push access to the CocoaPods repo. Could I get access to that?

Edit: Whoops. Sorry for the extra commits. It wound up not passing validation due to some small semantic issues in the podspec I copied over (use https and end the description with a period). Is there a way to run those validations client-side so Travis won't yell at me next time?
