### PR TITLE
GData works on OS X as well as iOS

### DIFF
--- a/GData/1.9.1/GData.podspec
+++ b/GData/1.9.1/GData.podspec
@@ -1,7 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'GData'
   s.version  = '1.9.1'
-  s.platform = :ios
   s.license  = { :type => 'Apache License, Version 2.0', :file => 'COPYING.txt' }
   s.summary  = "The Google data APIs provide a simple protocol for reading and "\
                "writing data on the web. Many Google services provide a Google data API."


### PR DESCRIPTION
GData works on OSX as well as iOS, removing the platform specification allows us to install the Pod on OS X targets as well.

Am I missing something? I tried this locally and ran the test with no issues.
