### PR TITLE
Changes the JSONKit 1.5pre url to use https so that it isn't blocked by corporate firewalls

### DIFF
--- a/JSONKit/1.5pre/JSONKit.podspec
+++ b/JSONKit/1.5pre/JSONKit.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary  = 'A Very High Performance Objective-C JSON Library.'
   s.homepage = 'https://github.com/johnezang/JSONKit'
   s.author   = 'John Engelhart'
-  s.source   = { :git => 'git://github.com/johnezang/JSONKit.git', :commit => '0aff3deb5e1bb2bbc88a83fd71c8ad5550185cce' }
+  s.source   = { :git => 'https://github.com/johnezang/JSONKit.git', :commit => '0aff3deb5e1bb2bbc88a83fd71c8ad5550185cce' }
 
   s.source_files   = 'JSONKit.*'
   s.compiler_flags = '-Wno-deprecated-objc-isa-usage', '-Wno-format'


### PR DESCRIPTION
Corporate firewalls don't like git://
