### PR TITLE
Added AAImageUtils

### DIFF
--- a/AAImageUtils/0.1.0/AAImageUtils.podspec
+++ b/AAImageUtils/0.1.0/AAImageUtils.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = "AAImageUtils"
+  s.version      = "0.1.0"
+  s.platform     = :ios
+  s.summary      = "Simple framework to let your application's launch image fade-out to its initial view."
+  s.homepage     = "https://github.com/ahmet/AAImageUtils"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author       = { "Ahmet AYGÜN" => "me@ahmetaygun.net" }
+  s.source       = { :git => "https://github.com/ahmet/AAImageUtils.git", :tag => "v0.1.0" }
+  s.source_files = 'AAImageUtils/*.{h,m}'
+  s.requires_arc = true
+end


### PR DESCRIPTION
AAImageUtils will be UIKit additions to deal with images. Currently it includes only UIImage category imageNamed586h to select -586h suffixed images with [UIImage imageNamed586h:@"SuperCool.png"] call.
