### PR TITLE
spring-objective-c and RaptureXML fix

### DIFF
--- a/RaptureXML/1.0.0/RaptureXML.podspec
+++ b/RaptureXML/1.0.0/RaptureXML.podspec
@@ -6,7 +6,6 @@ Pod::Spec.new do |s|
   s.homepage     =  'https://github.com/ZaBlanc/RaptureXML'
   s.author       =  { 'John Blanco' => 'zablanc@gmail.com' }
   s.source       =  { :git => 'https://github.com/ZaBlanc/RaptureXML.git', :tag => '1.0.0' }
-  s.platform     =  :ios
   s.source_files =  'RaptureXML/*'
 
   s.libraries    =  'z', 'xml2'

--- a/spring-objective-c/1.0.1/spring-objective-c.podspec
+++ b/spring-objective-c/1.0.1/spring-objective-c.podspec
@@ -1,6 +1,10 @@
 Pod::Spec.new do |s|
   s.name         = 'spring-objective-c'
   s.version      = '1.0.1'
+  s.license      = 'Apache2.0'
+  s.summary      = 'A spring-like dependency injection container for objective-c.'
+  s.homepage     = 'https://github.com/jasperblues/spring-objective-c'
+  s.author       = { 'Jasper Blues' => 'jasper@appsquick.ly' }
   s.source       = { :git => 'https://github.com/jasperblues/spring-objective-c', :tag => '1.0.1' }
   s.source_files = 'Source/**/*.{h,m}'
   s.libraries    =  'z', 'xml2'

--- a/spring-objective-c/1.0.1/spring-objective-c.podspec
+++ b/spring-objective-c/1.0.1/spring-objective-c.podspec
@@ -1,0 +1,8 @@
+Pod::Spec.new do |s|
+  s.name         = 'spring-objective-c'
+  s.version      = '1.0.1'
+  s.source       = { :git => 'https://github.com/jasperblues/spring-objective-c', :tag => '1.0.1' }
+  s.source_files = 'Source/**/*.{h,m}'
+  s.libraries    =  'z', 'xml2'
+  s.xcconfig     =  { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2 SpringLogTemplate.h' }
+end


### PR DESCRIPTION
- Add new spec for spring-objective-c (fixed missing attributes)
- Fixed RaptureXML spec (platform iOS is not required, works on OSX too). 
