### PR TITLE
Fix podspec for Mailcheck

### DIFF
--- a/Mailcheck-ObjectiveC/0.1/Mailcheck-ObjectiveC.podspec
+++ b/Mailcheck-ObjectiveC/0.1/Mailcheck-ObjectiveC.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
 
   s.platform     = :ios, '6.0'
 
-  s.source_files = 'Classes'
+  s.source_files = 'Mailcheck/*.{h,m}'
 
   s.requires_arc = true
 end


### PR DESCRIPTION
Fixed directory name to get the correct files. Apparently naming the directory Classes is not a good idea?
