### PR TITLE
[New Pod] ProtobufObjC

### DIFF
--- a/ProtobufObjC/0.0.1/ProtobufObjC.podspec
+++ b/ProtobufObjC/0.0.1/ProtobufObjC.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name     = 'ProtobufObjC'
+  s.header_dir = "ProtocolBuffers"
+  s.version  = '0.0.1'
+  s.license  = 'Apache 2.0'
+  s.summary  = 'An implementation of Protocol Buffers in Objective C.'
+  s.homepage = 'http://code.google.com/p/metasyntactic/wiki/ProtocolBuffers'
+  s.author   = { 'Cyrus' => 'cyrusn@stwing.upenn.edu' }
+
+  s.source   = { :git => 'https://github.com/booyah/protobuf-objc.git', :commit => '9eb586b2178163c2fdbdfce772a48731e5884905' }
+  s.source_files = 'src/runtime/Classes/*.{h,m}'
+  s.xcconfig = { 'WARNING_CFLAGS' => '-Wno-missing-prototypes -Wno-format' }
+end


### PR DESCRIPTION
Objective-C wrappers around google's protobuf binary serialization format.
From the defacto canonical git repo https://github.com/booyah/protobuf-objc .

This is basically the same pull request as https://github.com/CocoaPods/Specs/pull/51 , but with JUST ProtobufObjC.

Still no reply on tagging a version :(
