### PR TITLE
[New Pod] SPSuccinct

### DIFF
--- a/SPSuccinct/1.0.0/SPSuccinct.podspec
+++ b/SPSuccinct/1.0.0/SPSuccinct.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name     = 'SPSuccinct'
+  s.version  = '1.0.0'
+  s.license  = 'MIT'
+  s.summary  = 'Tools to write succinct Objective-C.'
+  s.homepage = 'http://github.com/nevyn/SPSuccinct'
+  s.author   = { 'Joachim Bengtsson' => 'joachimb@gmail.com' }
+
+  s.source   = { :git => 'https://github.com/nevyn/SPSuccinct.git', :tag => '1.0.0' }
+
+  s.description = 'Macros for "POD" literals, KVO tools, and SPDepends.'
+
+  s.source_files = 'SPSuccinct/SP*.{h,m}'
+end

--- a/SPSuccinct/1.0.1/SPSuccinct.podspec
+++ b/SPSuccinct/1.0.1/SPSuccinct.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name     = 'SPSuccinct'
+  s.version  = '1.0.1'
+  s.license  = 'MIT'
+  s.summary  = 'Tools to write succinct Objective-C.'
+  s.homepage = 'http://github.com/nevyn/SPSuccinct'
+  s.author   = { 'Joachim Bengtsson' => 'joachimb@gmail.com' }
+
+  s.source   = { :git => 'https://github.com/nevyn/SPSuccinct.git', :tag => '1.0.1' }
+
+  s.description = 'Making ObjC succinct: KVO tools including SPDepends, and macros for "POD" literals.'
+
+  s.source_files = 'SPSuccinct/SP*.{h,m}'
+end


### PR DESCRIPTION
SPSuccinct is a library to make Objective-C and in particular KVO less verbose and easier to use.

This is the same as https://github.com/CocoaPods/Specs/pull/51 , but without all the other unrelated commits. Sorry for being a pull request noob (and for having an 11 month reaction time)
