### PR TITLE
Updating MagicalRecord 2.1.0. Podspec to use the right tag

### DIFF
--- a/MagicalRecord/2.1.0/MagicalRecord.podspec
+++ b/MagicalRecord/2.1.0/MagicalRecord.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1!.'
   s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
-  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git',:branch=>'develop', :tag => '2.1.0' }
+  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git',:branch=>'develop', :tag => '2.1' }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'


### PR DESCRIPTION
Without specifying the tag correctly, you can't download the newest MagicalRecord version using CocoaPods.
