### PR TITLE
Updated EDSunriseSet podspec

### DIFF
--- a/EDSunriseSet/0.0.1/EDSunriseSet.podspec
+++ b/EDSunriseSet/0.0.1/EDSunriseSet.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version      = "0.0.1"
   s.summary      = "Objective-C class to calculate Sunrise/Sunset/Twilight times."
   s.description  = <<-DESC
-                    EDSunriseSet is an Objective-C wrapper for the C languages routines created by [Paul Schlyter].
+                    EDSunriseSet is an Objective-C wrapper for the C languages routines created by Paul Schlyter.
                     Calculation is done entirely by the C-code routines. EDSunrisetSet bridges those calculations to common cocoa classes (NSDate, NSTimeZone... )
 
                       - Calculates Sunrise/Sunset times
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
                     DESC
   s.homepage     = "https://github.com/erndev/EDSunriseSet"
   s.license      = { :type => 'MIT', :file => 'license.txt' }
-  s.author       = { "Ernesto García" => "", " Paul Schlyter" => "pausch@stjarnhimlen.se" }
-  s.source       = { :git => "https://github.com/erndev/EDSunriseSet.git", :commit => "bb6a9d543e7016429cdcb4011a7cfc4870041386" }
+  s.author       = { "Ernesto García" => "", "Paul Schlyter" => "pausch@stjarnhimlen.se" }
+  s.source       = { :git => "https://github.com/erndev/EDSunriseSet.git", :tag => s.version.to_s }
   s.source_files = '*.{h,m}'
 end


### PR DESCRIPTION
The owner of EDSunriseSet added a tag (version 0.0.1) at the latest commit of the repo. The spec file is now using this tag to checkout code. I also fixed a few typos.
