### PR TITLE
Update JCDHTTPConnection to use the 1.0.0 tag

### DIFF
--- a/JCDHTTPConnection/1.0.0/JCDHTTPConnection.podspec
+++ b/JCDHTTPConnection/1.0.0/JCDHTTPConnection.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "JCDHTTPConnection"
-  s.version      = "0.0.1"
+  s.version      = "1.0.0"
   s.summary      = "Block-based NSURLConnection wrapper."
   s.homepage     = "https://github.com/jdriscoll/JCDHTTPConnection"
   s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }

--- a/JCDHTTPConnection/1.0.0/JCDHTTPConnection.podspec
+++ b/JCDHTTPConnection/1.0.0/JCDHTTPConnection.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = "JCDHTTPConnection"
+  s.version      = "0.0.1"
+  s.summary      = "Block-based NSURLConnection wrapper."
+  s.homepage     = "https://github.com/jdriscoll/JCDHTTPConnection"
+  s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }
+  s.author       = { "Justin Driscoll" => "justin@driscolldev.com" }
+  s.source       = { :git => "https://github.com/jdriscoll/JCDHTTPConnection.git", :tag => "1.0.0" }
+  s.platform     = :ios
+  s.source_files = 'Classes/JCDHTTPConnection.{h,m}'
+  s.requires_arc = true
+end


### PR DESCRIPTION
Someone kindly added a podspec for a library I developed. I just updated it to point at a 1.0 tag instead of an older commit hash.
