### PR TITLE
Adds MTRecursiveKVC .podspec

### DIFF
--- a/MTRecursiveKVC/1.0.0/MTRecursiveKVC.podspec
+++ b/MTRecursiveKVC/1.0.0/MTRecursiveKVC.podspec
@@ -1,11 +1,3 @@
-#
-# Be sure to run `pod spec lint MTRecursiveKVC.podspec' to ensure this is a
-# valid spec.
-#
-# Remove all comments before submitting the spec. Optional attributes are commented.
-#
-# For details see: https://github.com/CocoaPods/CocoaPods/wiki/The-podspec-format
-#
 Pod::Spec.new do |s|
   s.name         = "MTRecursiveKVC"
   s.version      = "1.0.0"
@@ -16,18 +8,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/MaxGabriel/MTRecursiveKVC.git", :tag => "1.0.0" }
   s.ios.deployment_target = '4.3'
   s.osx.deployment_target = '10.7'
-
-  # A list of file patterns which select the source files that should be
-  # added to the Pods project. If the pattern is a directory then the
-  # path will automatically have '*.{h,m,mm,c,cpp}' appended.
-  #
-  # Alternatively, you can use the FileList class for even more control
-  # over the selected files.
-  # (See http://rake.rubyforge.org/classes/Rake/FileList.html.)
-  #
-  # s.source_files = 'Classes', 'Classes/**/*.{h,m}'
-
   s.source_files = 'MTRecursiveKVC/*+*.{h,m}'
-
   s.requires_arc = true
 end

--- a/MTRecursiveKVC/1.0.0/MTRecursiveKVC.podspec
+++ b/MTRecursiveKVC/1.0.0/MTRecursiveKVC.podspec
@@ -1,0 +1,33 @@
+#
+# Be sure to run `pod spec lint MTRecursiveKVC.podspec' to ensure this is a
+# valid spec.
+#
+# Remove all comments before submitting the spec. Optional attributes are commented.
+#
+# For details see: https://github.com/CocoaPods/CocoaPods/wiki/The-podspec-format
+#
+Pod::Spec.new do |s|
+  s.name         = "MTRecursiveKVC"
+  s.version      = "1.0.0"
+  s.summary      = "A small category on `NSObject` that adds support for recursive lookup using `valueForKey:`."
+  s.homepage     = "https://github.com/MaxGabriel/MTRecursiveKVC"
+  s.license      = 'MIT'
+  s.author       = { "Maximilian Tagher" => "feedback.tagher@gmail.com" }
+  s.source       = { :git => "https://github.com/MaxGabriel/MTRecursiveKVC.git", :tag => "1.0.0" }
+  s.ios.deployment_target = '4.3'
+  s.osx.deployment_target = '10.7'
+
+  # A list of file patterns which select the source files that should be
+  # added to the Pods project. If the pattern is a directory then the
+  # path will automatically have '*.{h,m,mm,c,cpp}' appended.
+  #
+  # Alternatively, you can use the FileList class for even more control
+  # over the selected files.
+  # (See http://rake.rubyforge.org/classes/Rake/FileList.html.)
+  #
+  # s.source_files = 'Classes', 'Classes/**/*.{h,m}'
+
+  s.source_files = 'MTRecursiveKVC/*+*.{h,m}'
+
+  s.requires_arc = true
+end


### PR DESCRIPTION
MTRecursiveKVC -- https://github.com/MaxGabriel/MTRecursiveKVC

A small category on `NSObject` that adds support for recursive lookup using `valueForKey:`:

```
NSArray *superviewChain = [view recursiveValueForKey:@"superview"]; 
// Recursively gets the superview property until it is nil 
```

Like the traditional `valueForKey:` method, when used on collection classes (`NSArray`, `NSSet`, and `NSOrderedSet`) it applies the method to each of the objects inside the collection.

```
NSArray *allSubviews = [view recursiveValueForKey:@"subviews"]; 
// Returns all the subviews of a view, and all their subviews, and all their subviews, etc. 
```
