### PR TITLE
AFImageDownloader

### DIFF
--- a/AFImageDownloader/1.0.0/AFImageDownloader.podspec
+++ b/AFImageDownloader/1.0.0/AFImageDownloader.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name         = 'AFImageDownloader'
+  s.version      = '1.0.0'
+  s.summary      = 'Downloads JPEG images asynchronously and decompresses them on a background thread.'
+  s.author       = { 'Ash Furrow' => 'ash@ashfurrow.com' }
+  s.source       = { :git => 'https://github.com/AshFurrow/AFImageDownloader.git', :tag => '1.0.0' }
+  s.source_files = 'Classes', '*.{h,m}'
+  s.license	     = 'MIT'
+  s.homepage     = 'https://github.com/AshFurrow/AFImageDownloader'
+  s.dependency    'Kiwi', '~> 1.1.1'
+  s.platform     = :ios, '5.0'
+  s.license      = 'MIT'
+end
+


### PR DESCRIPTION
This is a library for easily downloading JPEGs from the Internet, asynchronously, and offloading the decompression of those JPEGs into bitmap `UIImage` instances on a background GCD queue. The requests are also cancellable and it has full unit test coverage using Kiwi. 
