### PR TITLE
SEFilterControl spec (0.0.1)

### DIFF
--- a/SEFilterControl/0.0.1/SEFilterControl.podspec
+++ b/SEFilterControl/0.0.1/SEFilterControl.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+    s.name         = 'SEFilterControl'
+    s.version      = '0.0.1'
+    s.license      = 'MIT'
+    s.authors      = { 'Shady Elyaski' => 'shady@elyaski.com' }
+    s.homepage     = 'https://github.com/ShadyElyaski/ios-filter-control'
+    s.summary      = 'An iOS Filter UIControl Subclass. Zero Graphics. Highly Customizable.'
+    s.source       = { :git => 'https://github.com/ShadyElyaski/ios-filter-control.git', :commit => '0eb53f60f060c60b0eb99a8ffad30923ddeaab74' }
+    s.source_files = '*.{h,m}' 
+
+    s.platform = :ios
+end


### PR DESCRIPTION
Converting a few projects over to use cocoapods. I've created a spec for the [SEFilterControl](https://github.com/ShadyElyaski/ios-filter-control) we use and would love to see it merged.

I've submitted a pull request to the original author with the podspec included.

Thanks!
