### PR TITLE
Fix xcconfig overwrite in SQLCipher podspec

### DIFF
--- a/SQLCipher/2.1.1/SQLCipher.podspec
+++ b/SQLCipher/2.1.1/SQLCipher.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/guilhermeandrade/sqlcipher.git', :tag => s.version.to_s }
   s.preserve_paths = '*.a'
   s.libraries = 'crypto', 'sqlcipher'
-  s.xcconfig     =  { 'OTHER_CFLAGS' => '-DSQLITE_HAS_CODEC', 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/SQLCipher"' }
+  s.xcconfig     =  { 'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC', 'LIBRARY_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/SQLCipher"' }
   s.platform = :ios
 end


### PR DESCRIPTION
The SQLCipher podspec overwrites existing values in xcconfig. I fixed this by adding `$(inherited)` to the relevant values.
