### PR TITLE
Fixed Posit license

### DIFF
--- a/Posit/0.0.1/Posit.podspec
+++ b/Posit/0.0.1/Posit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'Posit'
   s.version = '0.0.1'
-  s.license = { :type => 'MIT', :file => 'LICENSE' }
+  s.license = 'MIT'
   s.platform = :ios, '6.0'
   s.summary = "An Objective-C expectation framework based on the 'should' terminology."
   s.homepage = 'https://github.com/rdavies/Posit'

--- a/Posit/0.0.2/Posit.podspec
+++ b/Posit/0.0.2/Posit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'Posit'
   s.version = '0.0.2'
-  s.license = { :type => 'MIT', :file => 'LICENSE' }
+  s.license = 'MIT'
   s.platform = :ios, '6.0'
   s.summary = "An Objective-C expectation framework based on the 'should' terminology."
   s.homepage = 'https://github.com/rdavies/Posit'


### PR DESCRIPTION
Installations were failing due to the exact specification of the license file. Not sure why it was failing, but removing the filename is a better configuration anyway.
