### PR TITLE
Remove nonexistent header search path from Kiwi's OS X FRAMEWORK_SEARCH_PATHS

### DIFF
--- a/Kiwi/2.0.3/Kiwi.podspec
+++ b/Kiwi/2.0.3/Kiwi.podspec
@@ -8,5 +8,6 @@ Pod::Spec.new do |s|
   s.source          = { :git => 'https://github.com/allending/Kiwi.git', :tag => '2.0.3' }
   s.source_files    = 'Classes'
   s.framework       = 'SenTestingKit'
-  s.xcconfig        = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(SDKROOT)/Developer/Library/Frameworks" "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
+  s.ios.xcconfig    = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(SDKROOT)/Developer/Library/Frameworks" "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
+  s.osx.xcconfig    = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
 end


### PR DESCRIPTION
This looks like it was reverted by @allending's update to Kiwi 2.0.3 earlier today.
