### PR TITLE
WebViewJavascriptBridge 2.1.0

### DIFF
--- a/WebViewJavascriptBridge/2.1.0/WebViewJavascriptBridge.podspec
+++ b/WebViewJavascriptBridge/2.1.0/WebViewJavascriptBridge.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = "WebViewJavascriptBridge"
+  s.version      = "2.1.0"
+  s.summary      = "A standalone iOS class for sending messages to and from javascript in a UIWebView."
+  s.homepage     = "http://github.com/marcuswestin/WebViewJavascriptBridge"
+  s.license      = { :type => "MIT", :file => "LICENSE" }
+  s.author       = { "marcuswestin" => "marcus.westin@gmail.com" }
+  s.source       = { :git => "https://github.com/marcuswestin/WebViewJavascriptBridge.git", :commit => "0d413190c79822256eb2b1368f59bcddd400214a" }
+  s.platform     = :ios, "4.2"
+  s.source_files = "WebViewJavascriptBridge/WebViewJavascriptBridge.{h,m}"
+  s.framework    = "UIKit"
+end


### PR DESCRIPTION
Hi,

I have created a new pod spec for version 2.1.0 of WebViewJavascriptBridge that now uses NSJSONSerialization amongst other things.

This is my very first pod spec, created based on the previous version (I purposefully removed JSONKit dependency because we don't need it anymore). 
