### PR TITLE
Add PMCalendar v0.3

### DIFF
--- a/PMCalendar/0.3/PMCalendar.podspec
+++ b/PMCalendar/0.3/PMCalendar.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name         = "PMCalendar"
+  s.version      = "0.3"
+  s.summary      = "Yet another calendar component for iOS. Supports presenting as a popover and very flexible UI tuning."
+  s.homepage     = "https://github.com/kovpas/PMCalendar"
+  s.author       = { "Pavel Mazurin" => "kovpas@gmail.com" }
+  s.source       = { :git => "https://github.com/kovpas/PMCalendar.git", :tag => "0.3" }
+  s.platform     = :ios, '4.0'
+  s.license      = 'MIT'
+  s.source_files = './PMCalendar/**/*.{h,m}'
+  s.resources    = './PMCalendar/Theme/*.{png,plist}'
+
+  s.frameworks   = 'UIKit', 'Foundation', 'CoreGraphics', 'CoreText'
+  s.requires_arc = true
+end


### PR DESCRIPTION
Yet another calendar component for iOS. Compatible with iOS 4.0 (iPhone & iPad) and higher. Supports presenting as a popover and very flexible UI tuning.
