### PR TITLE
Add NoticeView v3.0.4.

### DIFF
--- a/NoticeView/3.0.4/NoticeView.podspec
+++ b/NoticeView/3.0.4/NoticeView.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name         = 'NoticeView'
+  s.version      = '3.0.4'
+  s.license      = 'MIT'
+  s.summary      = 'A TweetBot-like notice component for iOS.'
+  s.homepage     = 'https://github.com/tciuro/NoticeView/'
+  s.author       = { 'Tito Ciuro' => 'tciuro@mac.com' }
+  s.source       = { :git => 'https://github.com/tciuro/NoticeView.git', :tag => '3.0.4' }
+  s.platform     = :ios, '5.0'
+  s.source_files = 'NoticeView/WBNoticeView/*.{m,h}'
+  s.frameworks   = 'Foundation', 'UIKit', 'CoreGraphics', 'QuartzCore'
+  s.resources    = 'NoticeView/WBNoticeView/NoticeView.bundle'
+  s.requires_arc = true
+end


### PR DESCRIPTION
There's a new version (3.0.4) of NoticeView, this pull request / commit adds it to the CocoaPods specs.
