### PR TITLE
ObjectiveGit 0.1 and libgit2 0.17.0

### DIFF
--- a/ObjectiveGit/0.1/ObjectiveGit.podspec
+++ b/ObjectiveGit/0.1/ObjectiveGit.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |s|
+  s.name          =  "ObjectiveGit"
+  s.version       =  "0.1"
+  s.summary       =  "Objective-C bindings to libgit2."
+  s.homepage      =  "https://github.com/libgit2/objective-git"
+  s.license       =  'MIT'
+  s.author        =  { "Tim Clem" => "timothy.clem@gmail.com", "Josh Abernathy" => "josh@github.com" }
+  s.source        =  { :git => "https://github.com/libgit2/objective-git.git", :tag => "0.1", :submodules => true }
+  s.source_files  =  'Classes/**/*.{h,m}'
+  s.osx.libraries =  %w|ssl crypto z|
+  s.ios.libraries =  %w|z|
+  s.requires_arc  =  true
+
+  s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.6'
+
+  s.dependency 'libgit2', '0.18.0beta0'
+
+  s.prefix_header_contents = '#define GTLog(fmt, ...) NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__);'
+ 
+  s.description = <<-DESC
+    Objective Git provides Objective-C bindings to the libgit2 linkable C Git library.
+    This library follows the rugged API as close as possible while trying to maintain a native objective-c feel.
+  DESC
+end

--- a/libgit2/0.17.0/libgit2.podspec
+++ b/libgit2/0.17.0/libgit2.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name         = "libgit2"
+  s.version      = "0.17.0"
+  s.summary      = "The libgit2 Library."
+  s.homepage     = "http://libgit2.github.com"
+  s.license      = { :type => 'GPL v2 (with linking exception)', :file => 'COPYING' }
+  s.author       = 'See AUTHORS file'
+  s.source       = { :git => "https://github.com/libgit2/libgit2.git", :tag => "v0.17.0" }
+  s.source_files = FileList.new('deps/http-parser/*.{h,c}', 'src/**/*.{h,c}', 'include/**/*.h') do |fl|
+    fl.exclude('**/include/git2/inttypes.h')
+    fl.exclude('**/include/git2/stdint.h')
+    fl.exclude('**/src/win32/**')
+  end
+  s.public_header_files = 'include/**/*.h'
+  s.preserve_paths = 'Authors'
+  s.libraries = 'z'
+  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(PODS_ROOT)/libgit2/include' }
+end

--- a/libgit2/0.18.0beta0/libgit2.podspec
+++ b/libgit2/0.18.0beta0/libgit2.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name         = "libgit2"
+  s.version      = "0.18.0beta0"
+  s.summary      = "The libgit2 Library."
+  s.homepage     = "http://libgit2.github.com"
+  s.license      = { :type => 'GPL v2 (with linking exception)', :file => 'COPYING' }
+  s.author       = 'See AUTHORS file'
+  s.source       = { :git => "https://github.com/libgit2/libgit2.git", :commit => "2ff4469afc1e3e142d68c46e3c15e889fe32582a" }
+  s.source_files = FileList.new('deps/http-parser/*.{h,c}', 'src/**/*.{h,c}', 'include/**/*.h') do |fl|
+    fl.exclude('**/include/git2/inttypes.h')
+    fl.exclude('**/include/git2/stdint.h')
+    fl.exclude('**/src/win32/**')
+    fl.exclude('**/hash_win32.*')
+  end
+  s.public_header_files = 'include/**/*.h'
+  s.preserve_paths = 'Authors'
+  s.libraries = 'z'
+  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(PODS_ROOT)/libgit2/include $(PODS_ROOT)/libgit2/src' }
+end


### PR DESCRIPTION
Specs for libgit2 0.17.0 and ObjectiveGit 0.1. 

ObjectiveGit 0.1 needs an untagged version of libgit2, so I added that version, too.

There is an existing objetcive-git 0.0.1 already in CocoaPods, but 
I couldn't manage to build the 0.1 version with that name.

This is my first try of a spec, so please don't be too hard with me. :)
