### PR TITLE
Add google maps directions wrapper

### DIFF
--- a/GoogleMapsDirection/0.0.2/GoogleMapsDirection.podspec
+++ b/GoogleMapsDirection/0.0.2/GoogleMapsDirection.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "GoogleMapsDirection"
+  s.version      = "0.0.2"
+  s.summary      = "Wrapper around GoogleMaps Direction API."
+  s.homepage     = "https://github.com/Djengo/GoogleMapsDirection"
+  s.license      = "MIT License"
+  s.author       = { "Djengo" => "info@djengo.net" }
+  s.source       = { :git => "https://github.com/Djengo/GoogleMapsDirection.git", :tag => "0.0.2" }
+  s.platform     = :ios, "5.0"
+  s.requires_arc = true
+  s.source_files = "GMDirection"
+  s.dependency     "AFNetworking", "1.0.1"
+end


### PR DESCRIPTION
For one of our project we created a simple wrapper around google maps directions API. It gives the ability to send a requests to the google maps api and parses the response, letting you play with the duration, distance and other information of the possible routes between an origin and a destination. Please refer to the readme in our git for more info:

https://github.com/Djengo/GoogleMapsDirection
