### PR TITLE
[Fix] UrbanAirship-iOS-SDK mistakenly left off AudioToolbox and MessageUI frameworks

### DIFF
--- a/UrbanAirship-iOS-SDK/1.4.0/UrbanAirship-iOS-SDK.podspec
+++ b/UrbanAirship-iOS-SDK/1.4.0/UrbanAirship-iOS-SDK.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   s.libraries    = 'z', 'sqlite3.0'
   s.frameworks   = 'CFNetwork', 'CoreGraphics', 'Foundation', 'MobileCoreServices',
                    'Security', 'SystemConfiguration', 'UIKit', 'CoreTelephony',
-                   'StoreKit', 'CoreLocation', 'MapKit'
+                   'StoreKit', 'CoreLocation', 'MapKit', 'AudioToolbox', 'MessageUI'
 end


### PR DESCRIPTION
@dkuhnke To double check here: is there a reason AudioToolbox and MessageUI were not included your update to the 1.4.0 spec? If not then this should fix the undefined symbols I ran into.
