### PR TITLE
Fix Google Analytics SDK Directory Empty

### DIFF
--- a/GoogleAnalytics-iOS-SDK/2.0beta4/GoogleAnalytics-iOS-SDK.podspec
+++ b/GoogleAnalytics-iOS-SDK/2.0beta4/GoogleAnalytics-iOS-SDK.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
       LICENSE
   }
   s.author       = 'Google Inc.'
-  s.source       = { :http => "http://dl.google.com/dl/gaformobileapps/GoogleAnalyticsiOS.zip" }
+  s.source       = { :http => "http://dl.google.com/dl/gaformobileapps/GoogleAnalyticsiOS.zip", :flatten => true }
   s.platform     = :ios
 
   s.source_files = 'Library/*.h'


### PR DESCRIPTION
In regard to: https://github.com/CocoaPods/CocoaPods/issues/779

Fixes the issue where the directory was empty after the pod install in  > 0.16.3.
