### PR TITLE
Fix for issue #1324

### DIFF
--- a/Google-API-Client/0.0.1/Google-API-Client.podspec
+++ b/Google-API-Client/0.0.1/Google-API-Client.podspec
@@ -25,17 +25,38 @@ Pod::Spec.new do |s|
   s.author   = { 'Google, Inc.' => 'http://code.google.com/p/google-api-objectivec-client/' }
   s.source   = { :svn => 'http://google-api-objectivec-client.googlecode.com/svn/trunk/' }
   s.resource = 'Source/OAuth2/Touch/GTMOAuth2ViewTouch.xib' 
+  s.frameworks = 'Security', 'SystemConfiguration'
   s.platform = :ios, '5.0'
 
   s.source_files =  'Source/*.{h,m}', 'Source/HTTPFetcher/*.{h,m}', 'Source/Networking',
                     'Source/OAuth2/*.{h,m}', 'Source/OAuth2/Touch', 'Source/Objects', 'Source/Utilities'
 
   s.subspec 'Drive' do |drive|
-    drive.source_files = 'Source/Services/Drive/**/*.{h,m}'
-    drive.frameworks = 'Security', 'SystemConfiguration'
+    drive.source_files = FileList['Source/Services/Drive/**/*.{h,m}'].exclude(/\_Sources.m$/)
+  end
+
+  s.subspec 'AdSense' do |ads|
+    ads.source_files = FileList['Source/Services/AdSense/**/*.{h,m}'].exclude(/\_Sources.m$/)
+  end
+
+  s.subspec 'Analytics' do |analytics|
+    analytics.source_files = FileList['Source/Services/Analytics/**/*.{h,m}'].exclude(/\_Sources.m$/)
+  end
+
+  s.subspec 'Calendar' do |calendar|
+    calendar.source_files = FileList['Source/Services/Calendar/**/*.{h,m}'].exclude(/\_Sources.m$/)
+  end
+
+  s.subspec 'Plus' do |plus|
+    plus.source_files = FileList['Source/Services/Plus/**/*.{h,m}'].exclude(/\_Sources.m$/)
+  end
+
+  s.subspec 'YouTube' do |youtube|
+    youtube.source_files = FileList['Source/Services/YouTube/**/*.{h,m}'].exclude(/\_Sources.m$/)
   end
 
   s.subspec 'All' do |all|
-    all.source_files = 'Source/Services/**/*.{h,m}'
+    all.source_files = FileList['Source/Services/**/*.{h,m}'].exclude(/\_Sources.m$/)
   end
+  
 end


### PR DESCRIPTION
The generated [SERVICE]_Sources.m file is excluded when building the library; this prevents the duplicate symbol link issues that popped up with some of the Google services. Some common services can be included using the subspec definitions, and there is an 'All' subspec to include all services if more than one is needed in a project.
