### PR TITLE
Adding FANN 2.2.0

### DIFF
--- a/FANN/2.2.0/FANN.podspec
+++ b/FANN/2.2.0/FANN.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "FANN"
+  s.version      = "2.2.0"
+  s.summary      = "A free open source neural network library."
+  s.description  = <<-DESC
+                   Fast Artificial Neural Network Library is a free open source neural network library, which implements multilayer artificial neural networks in C with support for both fully connected and sparsely connected networks. Cross-platform execution in both fixed and floating point are supported. It includes a framework for easy handling of training data sets. It is easy to use, versatile, well documented, and fast. Bindings to more than 15 programming languages are available. An easy to read introduction article and a reference manual accompanies the library with examples and recommendations on how to use the library. Several graphical user interfaces are also available for the library.
+                  DESC
+  s.homepage     = "http://leenissen.dk/fann/"
+  s.license      = { :type => 'LGPL', :file => 'COPYING.txt' }
+  s.author       = { "Steffen Nissen" => "sn@leenissen.dk" }
+  s.source       = { :git => "http://git.code.sf.net/p/fann/code", :commit => "60a02c4bfa23605f1d453c18c92f527ebf1b5b31" }
+  s.source_files = 'src', 'src/**/*.{h,c}'
+end

--- a/FANN/2.2.0/FANN.podspec
+++ b/FANN/2.2.0/FANN.podspec
@@ -8,6 +8,6 @@ Pod::Spec.new do |s|
   s.homepage     = "http://leenissen.dk/fann/"
   s.license      = { :type => 'LGPL', :file => 'COPYING.txt' }
   s.author       = { "Steffen Nissen" => "sn@leenissen.dk" }
-  s.source       = { :git => "http://git.code.sf.net/p/fann/code", :commit => "60a02c4bfa23605f1d453c18c92f527ebf1b5b31" }
+  s.source       = { :git => "http://git.code.sf.net/p/fann/code", :tag => "2.2.0" }
   s.source_files = 'src', 'src/**/*.{h,c}'
 end


### PR DESCRIPTION
Added a podspec for the Fast Artificial Neural Network Library (http://leenissen.dk/fann). Repo does not have semantic version tags so I'm using the commit that corresponds to version 2.2.0.
