### PR TITLE
Add v0.0.1 of NSEnumeratorLinq podspec

### DIFF
--- a/NSEnumeratorLinq/0.0.1/NSEnumeratorLinq.podspec
+++ b/NSEnumeratorLinq/0.0.1/NSEnumeratorLinq.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name         = "NSEnumeratorLinq"
+  s.version      = "0.0.1"
+  s.license      = 'MIT'
+  s.summary      = "An NSEnumerator LINQ category."
+  s.homepage     = "https://github.com/k06a/NSEnumeratorLinq"
+  s.author       = { "Anton Bukov" => "k06aaa@gmail.com" }
+  s.source       = { :git => "https://github.com/k06a/NSEnumeratorLinq.git", :tag => "v0.0.1" }
+  s.source_files = 'NSEnumeratorLinq'
+  s.requires_arc = true
+end


### PR DESCRIPTION
An [NSEnumerator LINQ category](https://github.com/k06a/NSEnumeratorLinq) that adds several of the [Enumerable methods](http://msdn.microsoft.com/en-us/library/system.linq.enumerable_methods.aspx) from Microsoft's [LINQ](http://en.wikipedia.org/wiki/Language_Integrated_Query) to Cocoa. 
