### PR TITLE
Add DCModalSegue

### DIFF
--- a/DCModalSegue/0.0.1/DCModalSegue.podspec
+++ b/DCModalSegue/0.0.1/DCModalSegue.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = "DCModalSegue"
+  s.version      = "0.0.1"
+  s.summary      = "A custom segue which makes a 'pushed back' modal presenting animation."
+  s.homepage     = "https://github.com/zetachang/DCModalSegue"
+  s.license      = 'MIT'
+  s.authors      = {"David Chang" => "zeta11235813@gmail.com"}
+  s.source       = { :git => "https://github.com/zetachang/DCModalSegue.git", :tag => "0.0.1" }
+  s.platform     = :ios, '6.0'
+  s.source_files = './DCModalSegue/*.{h,m}' 
+  s.frameworks   = "QuartzCore"
+end


### PR DESCRIPTION
As title, add DCModalSegue (https://github.com/zetachang/DCModalSegue) version 0.0.1 to CocoaPods. 
