### PR TITLE
Update CocoaLibSpotify.podspec of version 2.1.0

### DIFF
--- a/CocoaLibSpotify/2.1.0/CocoaLibSpotify.podspec
+++ b/CocoaLibSpotify/2.1.0/CocoaLibSpotify.podspec
@@ -29,10 +29,10 @@ import os
 import sys
 import commands
 
-libspotifyFileName = \\"libspotify-12.1.45-iOS-universal.zip\\"
+libspotifyFileName = \\"libspotify-12.1.51-iOS-universal.zip\\"
 libspotifyRemoteLocation = \\"http://developer.spotify.com/download/libspotify/\\"
 projectDir = os.path.join(\\"#{config.project_pods_root}\\", \\"cocoalibspotify\\")
-libspotifyDirectoryDir = os.path.join(projectDir, \\"libspotify-12.1.45-iOS-universal\\")
+libspotifyDirectoryDir = os.path.join(projectDir, \\"libspotify-12.1.51-iOS-universal\\")
 libspotifyZipDir = os.path.join(projectDir, libspotifyFileName)
 
 if (os.path.exists(libspotifyDirectoryDir)):

--- a/CocoaLibSpotify/2.1.0/CocoaLibSpotify.podspec
+++ b/CocoaLibSpotify/2.1.0/CocoaLibSpotify.podspec
@@ -9,11 +9,11 @@ Pod::Spec.new do |s|
   s.source       =  { :git => 'https://github.com/spotify/cocoalibspotify.git', :tag => "2.1.0" }
   s.requires_arc =  true
 
-  s.source_files =  'common', 'iOS Library/View Controllers', 'libspotify-12.1.45-iOS-universal/libspotify.framework/Headers'
+  s.source_files =  'common', 'iOS Library/View Controllers', 'libspotify-12.1.51-iOS-universal/libspotify.framework/Headers'
   s.resource     =  'iOS Library/SPLoginResources.bundle'
   s.frameworks   =  'SystemConfiguration', 'CFNetwork', 'CoreAudio', 'AudioToolbox', 'AVFoundation', 'libspotify'
   s.library      =  'stdc++'
-  s.xcconfig     =  { 'OTHER_LDFLAGS' => '-all_load', 'FRAMEWORK_SEARCH_PATHS' => '$(PODS_ROOT)/CocoaLibSpotify/libspotify-12.1.45-iOS-universal' }
+  s.xcconfig     =  { 'OTHER_LDFLAGS' => '-all_load', 'FRAMEWORK_SEARCH_PATHS' => '$(PODS_ROOT)/CocoaLibSpotify/libspotify-12.1.51-iOS-universal' }
   s.platform     =  :ios
 
   def s.post_install(target)


### PR DESCRIPTION
The download link of the post-install script doesn't work anymore. I'm not a member of the Spotify Team but since I wanted to check out the pod, I found out that the download link was broken. After looking the correct download link up at their homepage it works again.
