### PR TITLE
Fix DTCoreText Dependencies.

### DIFF
--- a/DTCoreText/1.2.1/DTCoreText.podspec
+++ b/DTCoreText/1.2.1/DTCoreText.podspec
@@ -5,8 +5,8 @@ Pod::Spec.new do |spec|
   spec.license      = 'BSD'
   spec.source       = { :git => 'https://github.com/Cocoanetics/DTCoreText.git', :tag => spec.version.to_s }
   spec.source_files = 'Core/Source/*.{h,m,c}'
-  spec.dependency 'DTFoundation/Core', '~>1.0'
-  spec.dependency 'DTFoundation/DTHMLParser', '~>1.0'
+  spec.dependency 'DTFoundation/Core', '~>1.0.0'
+  spec.dependency 'DTFoundation/DTHMLParser', '~>1.0.0'
   spec.frameworks   = 'MediaPlayer', 'QuartzCore', 'CoreText', 'CoreGraphics', 'ImageIO'
   spec.requires_arc = true
   spec.homepage     = 'https://github.com/Cocoanetics/DTCoreText'


### PR DESCRIPTION
DTCoreText relies on DTFoundation.  DTFoundation was just updated recently to 1.1, which broke compatibility with this spec's dependencies.  This change makes the dependency more strict to fix the pod.
