### PR TITLE
Change all repo paths to ReactiveCocoa/ReactiveCocoa from github/ReactiveCocoa

### DIFF
--- a/ReactiveCocoa/0.0.1/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/0.0.1/ReactiveCocoa.podspec
@@ -2,9 +2,9 @@ Pod::Spec.new do |s|
   s.name         = "ReactiveCocoa"
   s.version      = "0.0.1"
   s.summary      = "A framework for composing and transforming sequences of values."
-  s.homepage     = "https://github.com/github/ReactiveCocoa"
+  s.homepage     = "https://github.com/ReactiveCocoa/ReactiveCocoa"
   s.author       = { "Josh Abernathy" => "josh@github.com" }
-  s.source       = { :git => "https://github.com/github/ReactiveCocoa.git", :commit => "46a1ca24ca711f0140d999a069044e0fc057975c" }
+  s.source       = { :git => "https://github.com/ReactiveCocoa/ReactiveCocoa.git", :commit => "46a1ca24ca711f0140d999a069044e0fc057975c" }
   s.license      = 'Simplified BSD License'
   s.description  = "ReactiveCocoa offers:\n"                                                               \
                    "1. The ability to compose operations on future data.\n"                                \

--- a/ReactiveCocoa/0.10.0/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/0.10.0/ReactiveCocoa.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = "A framework for composing and transforming sequences of values."
   s.homepage     = "https://github.com/blog/1107-reactivecocoa-is-now-open-source"
   s.author       = { "Josh Abernathy" => "josh@github.com" }
-  s.source       = { :git => "https://github.com/github/ReactiveCocoa.git", :tag => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/ReactiveCocoa/ReactiveCocoa.git", :tag => "v#{s.version}" }
   s.license      = 'Simplified BSD License'
   s.description  = "ReactiveCocoa offers:\n"                                                               \
                    "1. The ability to compose operations on future data.\n"                                \

--- a/ReactiveCocoa/0.12.0/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/0.12.0/ReactiveCocoa.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = "A framework for composing and transforming sequences of values."
   s.homepage     = "https://github.com/blog/1107-reactivecocoa-is-now-open-source"
   s.author       = { "Josh Abernathy" => "josh@github.com" }
-  s.source       = { :git => "https://github.com/github/ReactiveCocoa.git", :tag => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/ReactiveCocoa/ReactiveCocoa.git", :tag => "v#{s.version}" }
   s.license      = 'Simplified BSD License'
   s.description  = "ReactiveCocoa offers:\n"                                                               \
                    "1. The ability to compose operations on future data.\n"                                \

--- a/ReactiveCocoa/0.13.1/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/0.13.1/ReactiveCocoa.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = "A framework for composing and transforming sequences of values."
   s.homepage     = "https://github.com/blog/1107-reactivecocoa-is-now-open-source"
   s.author       = { "Josh Abernathy" => "josh@github.com" }
-  s.source       = { :git => "https://github.com/github/ReactiveCocoa.git", :tag => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/ReactiveCocoa/ReactiveCocoa.git", :tag => "v#{s.version}" }
   s.license      = 'Simplified BSD License'
   s.description  = "ReactiveCocoa offers:\n"                                                               \
                    "1. The ability to compose operations on future data.\n"                                \

--- a/ReactiveCocoa/0.16.1/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/0.16.1/ReactiveCocoa.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = "A framework for composing and transforming sequences of values."
   s.homepage     = "https://github.com/blog/1107-reactivecocoa-is-now-open-source"
   s.author       = { "Josh Abernathy" => "josh@github.com" }
-  s.source       = { :git => "https://github.com/github/ReactiveCocoa.git", :tag => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/ReactiveCocoa/ReactiveCocoa.git", :tag => "v#{s.version}" }
   s.license      = 'Simplified BSD License'
   s.description  = "ReactiveCocoa offers:\n"                                                               \
                    "1. The ability to compose operations on future data.\n"                                \

--- a/ReactiveCocoa/0.5.0/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/0.5.0/ReactiveCocoa.podspec
@@ -2,9 +2,9 @@ Pod::Spec.new do |s|
   s.name         = "ReactiveCocoa"
   s.version      = "0.5.0"
   s.summary      = "A framework for composing and transforming sequences of values."
-  s.homepage     = "https://github.com/github/ReactiveCocoa"
+  s.homepage     = "https://github.com/ReactiveCocoa/ReactiveCocoa"
   s.author       = { "Josh Abernathy" => "josh@github.com" }
-  s.source       = { :git => "https://github.com/github/ReactiveCocoa.git", :tag => "v0.5.0" }
+  s.source       = { :git => "https://github.com/ReactiveCocoa/ReactiveCocoa.git", :tag => "v0.5.0" }
   s.license      = 'Simplified BSD License'
   s.description  = "ReactiveCocoa offers:\n"                                                               \
                    "1. The ability to compose operations on future data.\n"                                \

--- a/ReactiveCocoa/0.6.0/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/0.6.0/ReactiveCocoa.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = "A framework for composing and transforming sequences of values."
   s.homepage     = "https://github.com/blog/1107-reactivecocoa-is-now-open-source"
   s.author       = { "Josh Abernathy" => "josh@github.com" }
-  s.source       = { :git => "https://github.com/github/ReactiveCocoa.git", :tag => "v0.6.0" }
+  s.source       = { :git => "https://github.com/ReactiveCocoa/ReactiveCocoa.git", :tag => "v0.6.0" }
   s.license      = 'Simplified BSD License'
   s.description  = "ReactiveCocoa offers:\n"                                                               \
                    "1. The ability to compose operations on future data.\n"                                \

--- a/ReactiveCocoa/0.8.0/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/0.8.0/ReactiveCocoa.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = "A framework for composing and transforming sequences of values."
   s.homepage     = "https://github.com/blog/1107-reactivecocoa-is-now-open-source"
   s.author       = { "Josh Abernathy" => "josh@github.com" }
-  s.source       = { :git => "https://github.com/github/ReactiveCocoa.git", :tag => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/ReactiveCocoa/ReactiveCocoa.git", :tag => "v#{s.version}" }
   s.license      = 'Simplified BSD License'
   s.description  = "ReactiveCocoa offers:\n"                                                               \
                    "1. The ability to compose operations on future data.\n"                                \

--- a/ReactiveCocoa/0.9.0/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/0.9.0/ReactiveCocoa.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = "A framework for composing and transforming sequences of values."
   s.homepage     = "https://github.com/blog/1107-reactivecocoa-is-now-open-source"
   s.author       = { "Josh Abernathy" => "josh@github.com" }
-  s.source       = { :git => "https://github.com/github/ReactiveCocoa.git", :tag => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/ReactiveCocoa/ReactiveCocoa.git", :tag => "v#{s.version}" }
   s.license      = 'Simplified BSD License'
   s.description  = "ReactiveCocoa offers:\n"                                                               \
                    "1. The ability to compose operations on future data.\n"                                \


### PR DESCRIPTION
The ReactiveCocoa repo has moved from github/ReactiveCocoa to ReactiveCocoa/ReactiveCocoa, this affects a number of historic versions as well as the latest. All of the tags are still in place in the new repo
