### PR TITLE
Add SDWebImage 2.7.4 spec

### DIFF
--- a/SDWebImage/2.7.4/SDWebImage.podspec
+++ b/SDWebImage/2.7.4/SDWebImage.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name     = 'SDWebImage'
+  s.version  = '2.7.4'
+  s.platform = :ios
+  s.license  = 'MIT'
+  s.summary  = 'Asynchronous image downloader with cache support with an UIImageView category.'
+  s.homepage = 'https://github.com/rs/SDWebImage'
+  s.author   = { 'Olivier Poitrey' => 'rs@dailymotion.com' }
+  s.source   = { :git => 'https://github.com/rs/SDWebImage.git', :tag => '2.7.4' }
+
+  s.description  = 'This library provides a category for UIImageVIew with support for remote '      \
+                   'images coming from the web. It provides an UIImageView category adding web '    \
+                   'image and cache management to the Cocoa Touch framework, an asynchronous '      \
+                   'image downloader, an asynchronous memory + disk image caching with automatic '  \
+                   'cache expiration handling, a guarantee that the same URL won\'t be downloaded ' \
+                   'several times, a guarantee that bogus URLs won\'t be retried again and again, ' \
+                   'and performances!'
+
+  s.preferred_dependency = 'Main'	
+
+  s.subspec 'Main' do |sp|
+    sp.source_files = 'SDWebImage/{SD,UI}*.{h,m}'
+    sp.framework = 'ImageIO'
+  end
+
+  s.subspec 'MapKit' do |sp|
+    sp.dependency 'SDWebImage/Main'
+    sp.source_files = 'SDWebImage/MKAnnotationView+WebCache.*'
+    sp.framework    = 'MapKit'
+  end
+end


### PR DESCRIPTION
because SDWebImage 3.x and 2.x has lots of differences and the version 2.7 in cocoapod has some bugs which already fixed in 2.7.4.So I create 2.7.4 spec and pull it. 
