### PR TITLE
Fix AWSiOSSDK 1.4.5 and 1.4.6 header includes in prefix

### DIFF
--- a/AWSiOSSDK/1.4.5/AWSiOSSDK.podspec
+++ b/AWSiOSSDK/1.4.5/AWSiOSSDK.podspec
@@ -13,8 +13,10 @@ Pod::Spec.new do |s|
   s.header_mappings_dir = 'src/include'
 
   s.prefix_header_contents = <<-PCH
+#ifdef __OBJC__
 #import "AmazonLogger.h"
 #import "AmazonErrorHandler.h"
+#endif
   PCH
 
   s.subspec 'Runtime' do |ss|

--- a/AWSiOSSDK/1.4.6/AWSiOSSDK.podspec
+++ b/AWSiOSSDK/1.4.6/AWSiOSSDK.podspec
@@ -13,8 +13,10 @@ Pod::Spec.new do |s|
   s.header_mappings_dir = 'src/include'
 
   s.prefix_header_contents = <<-PCH
+#ifdef __OBJC__
 #import "AmazonLogger.h"
 #import "AmazonErrorHandler.h"
+#endif
   PCH
 
   s.subspec 'Runtime' do |ss|


### PR DESCRIPTION
Should be enclosed in a #ifdef **OBJC** #endif block.
