### PR TITLE
add JTTargetActionBlock podspec

### DIFF
--- a/JTTargetActionBlock/1.0.0/JTTargetActionBlock.podspec
+++ b/JTTargetActionBlock/1.0.0/JTTargetActionBlock.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name         = "JTTargetActionBlock"
+  s.version      = "1.0.0"
+  s.summary      = "imported from https://gist.github.com/mystcolor/2205564"
+  s.homepage     = "https://github.com/ZeR0-Wu/JTTargetActionBlock"
+  s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }
+  s.author       = { "ZeR0-Wu" => "thelongestmailaccounteverexist@gmail.com" }
+  s.source       = { :git => "https://github.com/ZeR0-Wu/JTTargetActionBlock.git", :commit => "528c3fe36e4af8f9231b8ec19598745e7d3c0430" }
+  s.platform     = :ios
+  s.source_files = 'Classes', '*.{h,m}'        
+end


### PR DESCRIPTION
JTTargetActionBlock is an extension to enable any UIControl instance to use blocks as event handler.
