### PR TITLE
fix AFDownloadRequestOperation PodSpec issue in CocoaPods 0.17

### DIFF
--- a/AFDownloadRequestOperation/0.0.1/AFDownloadRequestOperation.podspec
+++ b/AFDownloadRequestOperation/0.0.1/AFDownloadRequestOperation.podspec
@@ -11,3 +11,4 @@ Pod::Spec.new do |s|
   s.license        = 'MIT'
   s.dependency 'AFNetworking', '>=1.1'
 end
+

--- a/AFDownloadRequestOperation/0.0.1/AFDownloadRequestOperation.podspec
+++ b/AFDownloadRequestOperation/0.0.1/AFDownloadRequestOperation.podspec
@@ -9,5 +9,5 @@ Pod::Spec.new do |s|
   s.requires_arc   = true
   s.source_files   = '*.{h,m}'
   s.license        = 'MIT'
-  s.dependency 'AFNetworking', :head
+  s.dependency 'AFNetworking', '>=1.1'
 end


### PR DESCRIPTION
Installed against CocoaPods 0.17 would generate 'Specifications don't support external sources' error. Now the dependency issue has been fixed
