### PR TITLE
[Fix] Specs with unsupported version requirements

### DIFF
--- a/BeeFramework/0.2.3/BeeFramework.podspec
+++ b/BeeFramework/0.2.3/BeeFramework.podspec
@@ -25,5 +25,5 @@ Pod::Spec.new do |s|
   s.dependency 'ASIHTTPRequest'
   s.dependency 'Reachability'
   s.dependency 'SFHFKeychainUtils'
-  s.dependency 'FMDB', :head
+  s.dependency 'FMDB'
 end

--- a/DLCImagePickerController/0.0.1/DLCImagePickerController.podspec
+++ b/DLCImagePickerController/0.0.1/DLCImagePickerController.podspec
@@ -17,8 +17,7 @@ Pod::Spec.new do |s|
   s.subspec 'Core' do |sp|
     sp.source_files = 'Classes'
     sp.resources = "Resources/**/*.*", "Images/{UI,Overlays}/*.png"
-    # Temporary, this might break the podspec in the future.
-    sp.dependency 'GPUImage', :head
+    sp.dependency 'GPUImage'
   end
 
   s.subspec 'FilterSamples' do |sp|

--- a/JMStatefulTableViewController/0.1.1/JMStatefulTableViewController.podspec
+++ b/JMStatefulTableViewController/0.1.1/JMStatefulTableViewController.podspec
@@ -18,6 +18,5 @@ Pod::Spec.new do |s|
   }
 
   s.source_files = ['JMStatefulTableViewController/*.*']
-
-  s.dependency 'SVPullToRefresh', :git => 'git://github.com/samvermette/SVPullToRefresh.git', :commit => '1362d86a52a53baa96cbd4e15ad46d50418fe4fa'
+  s.dependency 'SVPullToRefresh'
 end

--- a/LRTVDBAPIClient/0.1/LRTVDBAPIClient.podspec
+++ b/LRTVDBAPIClient/0.1/LRTVDBAPIClient.podspec
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
   s.source_files = 'LRTVDBAPIClient', 'LRTVDBAPIClient/Categories', 'LRTVDBAPIClient/Model', 'LRTVDBAPIClient/Parser', 'LRTVDBAPIClient/PersistenceManager'
   s.requires_arc = true
   s.dependency 'AFNetworking'
-  s.dependency 'TBXML', :head
+  s.dependency 'TBXML'
   s.dependency 'zipzap'
 end

--- a/MMCounterView/0.6.1/MMCounterView.podspec
+++ b/MMCounterView/0.6.1/MMCounterView.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Component'
   s.frameworks   = 'CoreGraphics', 'Foundation', 'QuartzCore', 'UIKit'
   s.requires_arc = true
-  s.dependency 'CPAnimationSequence', :git => 'https://github.com/mmccroskey/CPAnimationSequence.git', :tag => '0.2.1'
+  s.dependency 'CPAnimationSequence'
 end

--- a/NCMusicEngine/0.1.0/NCMusicEngine.podspec
+++ b/NCMusicEngine/0.1.0/NCMusicEngine.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.public_header_files = 'NCMusicEngine/*.h'
   s.requires_arc = true
   s.dependency 'AFNetworking', '>= 1.1.0'
-  s.dependency 'AFDownloadRequestOperation', :git => 'https://github.com/nickcheng/AFDownloadRequestOperation.git'
+  s.dependency 'AFDownloadRequestOperation'
 end

--- a/StackMobPush/1.0.0/StackMobPush.podspec
+++ b/StackMobPush/1.0.0/StackMobPush.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/stackmob/stackmob-ios-push-sdk.git', :tag => s.version.to_s }
   s.platform = :ios, '5.0'
   s.source_files = 'stackmob-ios-push-sdk/*.{h,m}'
-  s.dependency 'stl-oauth-client', :git => 'https://github.com/jonah-carbonfive/stl-oauth-client.git', :commit => 'd73a89b92a4ec6068b2ae36e09b32e6d8717e180'
+  s.dependency 'stl-oauth-client'
   s.requires_arc = true
   s.documentation = {
   	:appledoc => [

--- a/StackMobPush/1.0.1/StackMobPush.podspec
+++ b/StackMobPush/1.0.1/StackMobPush.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/stackmob/stackmob-ios-push-sdk.git', :tag => s.version.to_s }
   s.platform = :ios, '5.0'
   s.source_files = 'stackmob-ios-push-sdk/*.{h,m}'
-  s.dependency 'stl-oauth-client', :git => 'https://github.com/jonah-carbonfive/stl-oauth-client.git', :commit => 'd73a89b92a4ec6068b2ae36e09b32e6d8717e180'
+  s.dependency 'stl-oauth-client'
   s.requires_arc = true
   s.documentation = {
   	:appledoc => [

--- a/TestPilot/0.0.3/TestPilot.podspec
+++ b/TestPilot/0.0.3/TestPilot.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.source_files = 'TestPilot/**/*.{h,m}'
   s.public_header_files = 'TestPilot/**/*.h'
  
-  s.dependency 'Stubbilino', :git => 'git@github.com:itsthejb/Stubbilino.git', :branch => 'feature/osx-framework'
+  s.dependency 'Stubbilino'
   s.dependency 'OCHamcrest'
   s.dependency 'OCMock'
   s.dependency 'OCMockito'

--- a/TestPilot/0.0.4/TestPilot.podspec
+++ b/TestPilot/0.0.4/TestPilot.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.source_files = 'TestPilot/**/*.{h,m}'
   s.public_header_files = 'TestPilot/**/*.h'
  
-  s.dependency 'Stubbilino', :git => 'git@github.com:itsthejb/Stubbilino.git', :branch => 'feature/osx-framework'
+  s.dependency 'Stubbilino'
   s.dependency 'OCHamcrest'
   s.dependency 'OCMock'
   s.dependency 'OCMockito'

--- a/libPusher/1.2/libPusher.podspec
+++ b/libPusher/1.2/libPusher.podspec
@@ -10,5 +10,5 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.dependency "JSONKit", "1.4"
-  s.dependency 'SocketRocket', :git => "git://github.com/square/SocketRocket", :commit => "ec6c145f4a"
+  s.dependency 'SocketRocket'
 end

--- a/uploadcare-ios/0.9.0/uploadcare-ios.podspec
+++ b/uploadcare-ios/0.9.0/uploadcare-ios.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.dependency 'AFNetworking', '~> 1.0'
   s.dependency 'libPusher', '~> 1.4'
   s.dependency 'grabKit', '1.2.1'
-  s.dependency 'SVProgressHUD', :head
+  s.dependency 'SVProgressHUD'
 end


### PR DESCRIPTION
Some specification are using external sources, this setup used to work in CocoaPods 0.16 but it was never supported. In CocoaPods 0.17 it doesn't work anymore and thus it is necessary to remove them, for this reason I'm merging this pull request.

I didn't perform a full lint on them. The quick lint of Travis reveals the following issues, related to specifications depending on Pods not available on the master repo. This setup is clearly not supported.

```
StackMobPush/1.0.0/StackMobPush.podspec [Quick]
- Unable to find a specification for the `stl-oauth-client` dependency.

StackMobPush/1.0.1/StackMobPush.podspec [Quick]
- Unable to find a specification for the `stl-oauth-client` dependency.

TestPilot/0.0.3/TestPilot.podspec [Quick]
- Unable to find a specification for the `Stubbilino` dependency.

TestPilot/0.0.4/TestPilot.podspec [Quick]
- Unable to find a specification for the `Stubbilino` dependency.
```

@stcui, @ribeto, @jakemarsh, @luisrecuenco, @mmccroskey, @nickcheng, @msv, @itsthejb, @lukeredpath, @zrxq 
