### PR TITLE
Fix for MKNetworkKit.podspec

### DIFF
--- a/MKNetworkKit/0.87/MKNetworkKit.podspec
+++ b/MKNetworkKit/0.87/MKNetworkKit.podspec
@@ -14,6 +14,8 @@ Pod::Spec.new do |s|
 
   s.requires_arc     =  true
 
+  s.header_mappings_dir =  'MKNetworkKit/'
+
   s.dependency 'Reachability', '~> 3.1.0'
 
   s.license  = { :type => 'MIT',


### PR DESCRIPTION
Fixed using of deprecated s.copy_header_mapping  hook for
MKNetworkKit.podspec.
