### PR TITLE
Update various Google podspecs to use https:// when downloading source files

### DIFF
--- a/AdMob/6.0.1/AdMob.podspec
+++ b/AdMob/6.0.1/AdMob.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary  = 'The Google AdMob Ads SDK.'
   s.homepage = 'https://developers.google.com/mobile-ads-sdk/download'
   s.author   = 'Google'
-  s.source   = { :http => 'http://dl.google.com/googleadmobadssdk/googleadmobadssdkios.zip' }
+  s.source   = { :http => 'https://dl.google.com/googleadmobadssdk/googleadmobadssdkios.zip' }
   s.description = %{
     The Google AdMob Ads SDK is the next generation in Google mobile advertising featuring refined ad formats and streamlined APIs for access to Google's AdMob and DoubleClick For Publishers (upgraded DFP) [Android and iOS only] mobile advertising solutions.
   }

--- a/AdMob/6.3.0/AdMob.podspec
+++ b/AdMob/6.3.0/AdMob.podspec
@@ -12,7 +12,7 @@ Copyright 2009 - 2013 Google, Inc. All rights reserved.
 LICENSE
   }
   s.author = 'Google Inc.'
-  s.source = { :http => "http://dl.google.com/googleadmobadssdk/googleadmobadssdkios.zip" }
+  s.source = { :http => "https://dl.google.com/googleadmobadssdk/googleadmobadssdkios.zip" }
   s.platform = :ios
 
   s.source_files = 'GoogleAdMobAdsSdkiOS-6.3.0/*.h'

--- a/Google-API-Client/0.0.1/Google-API-Client.podspec
+++ b/Google-API-Client/0.0.1/Google-API-Client.podspec
@@ -21,9 +21,9 @@ Pod::Spec.new do |s|
   }
 
   s.summary  = "Written by Google, this library is a flexible and efficient Objective-C framework for accessing JSON APIs."
-  s.homepage = 'http://code.google.com/p/google-api-objectivec-client/'
-  s.author   = { 'Google, Inc.' => 'http://code.google.com/p/google-api-objectivec-client/' }
-  s.source   = { :svn => 'http://google-api-objectivec-client.googlecode.com/svn/trunk/' }
+  s.homepage = 'https://code.google.com/p/google-api-objectivec-client/'
+  s.author   = { 'Google, Inc.' => 'https://code.google.com/p/google-api-objectivec-client/' }
+  s.source   = { :svn => 'https://google-api-objectivec-client.googlecode.com/svn/trunk/' }
   s.resource = 'Source/OAuth2/Touch/GTMOAuth2ViewTouch.xib' 
   s.frameworks = 'Security', 'SystemConfiguration'
   s.platform = :ios, '5.0'

--- a/Google-AdMob-Ads-SDK/6.3.0/Google-AdMob-Ads-SDK.podspec
+++ b/Google-AdMob-Ads-SDK/6.3.0/Google-AdMob-Ads-SDK.podspec
@@ -12,7 +12,7 @@ Copyright 2009 - 2012 Google, Inc. All rights reserved.
 LICENSE
   }
   s.author = 'Google Inc.'
-  s.source = { :http => "http://dl.google.com/googleadmobadssdk/googleadmobadssdkios.zip", :flatten => true }
+  s.source = { :http => "https://dl.google.com/googleadmobadssdk/googleadmobadssdkios.zip", :flatten => true }
   s.platform = :ios
 
   s.preserve_paths = 'libGoogleAdMobAds.a'

--- a/GoogleAnalytics-iOS-SDK/1.4/GoogleAnalytics-iOS-SDK.podspec
+++ b/GoogleAnalytics-iOS-SDK/1.4/GoogleAnalytics-iOS-SDK.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
       LICENSE
   }
   s.author       = 'Google Inc.'
-  s.source       = { :http => "http://dl.google.com/gaformobileapps/GoogleAnalyticsiOS_1.4.tar.gz" }
+  s.source       = { :http => "https://dl.google.com/gaformobileapps/GoogleAnalyticsiOS_1.4.tar.gz" }
   s.platform     = :ios
 
   s.source_files = 'Library/GANTracker.h'

--- a/GoogleAnalytics-iOS-SDK/1.5.1/GoogleAnalytics-iOS-SDK.podspec
+++ b/GoogleAnalytics-iOS-SDK/1.5.1/GoogleAnalytics-iOS-SDK.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
       LICENSE
   }
   s.author       = 'Google Inc.'
-  s.source       = { :http => "http://dl.google.com/gaformobileapps/GoogleAnalyticsiOS_1.5.1.tar.gz" }
+  s.source       = { :http => "https://dl.google.com/gaformobileapps/GoogleAnalyticsiOS_1.5.1.tar.gz" }
   s.platform     = :ios
 
   s.source_files = 'Library/GANTracker.h'

--- a/GoogleAnalytics-iOS-SDK/2.0beta3/GoogleAnalytics-iOS-SDK.podspec
+++ b/GoogleAnalytics-iOS-SDK/2.0beta3/GoogleAnalytics-iOS-SDK.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
       LICENSE
   }
   s.author       = 'Google Inc.'
-  s.source       = { :http => "http://dl.google.com/dl/gaformobileapps/googleanalyticsios.zip" }
+  s.source       = { :http => "https://dl.google.com/dl/gaformobileapps/googleanalyticsios.zip" }
   s.platform     = :ios
 
   s.source_files = 'Library/*.h'

--- a/GoogleAnalytics-iOS-SDK/2.0beta4/GoogleAnalytics-iOS-SDK.podspec
+++ b/GoogleAnalytics-iOS-SDK/2.0beta4/GoogleAnalytics-iOS-SDK.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
       LICENSE
   }
   s.author       = 'Google Inc.'
-  s.source       = { :http => "http://dl.google.com/dl/gaformobileapps/GoogleAnalyticsiOS.zip", :flatten => true }
+  s.source       = { :http => "https://dl.google.com/dl/gaformobileapps/GoogleAnalyticsiOS.zip", :flatten => true }
   s.platform     = :ios
 
   s.source_files = 'Library/*.h'


### PR DESCRIPTION
Instead of using http://dl.google.com/, use https://dl.google.com so that source files are downloaded over SSL to protect against MITM attacks.
