### PR TITLE
add a spec for seriously 2.0.0

### DIFF
--- a/Seriously/2.0.0/Seriously.podspec
+++ b/Seriously/2.0.0/Seriously.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = 'Seriously'
+  s.version      = '2.0.0'
+  s.license      = { :type => 'MIT', :file => 'COPYING' }
+  s.summary      = 'The Objective-C HTTP library that Apple should have created, seriously.'
+  s.homepage     = 'https://github.com/probablycorey/seriously'
+  s.authors      = { 'Corey Johnson' => 'cj@github.com', 'Adam Duke' => 'adam.v.duke+github.com' }
+  s.source       = { :git => 'https://github.com/probablycorey/seriously.git', :tag => "2.0.0" }
+  s.description  = 'The iPhone needs a better way to make HTTP requests, specifically calls to REST web services. Seriously mixes Blocks with NSURLConnection & NSOperationQueue to do just that. It also will automatically parse the JSON response into a dictionary if the response headers are set correctly.'
+  s.platform     = :ios
+  s.source_files = 'Classes', 'src/**/*.{h,m,c}'
+end


### PR DESCRIPTION
There are some backwards incompatible changes that recently went
into seriously. According to semantic versioning the major version
should be bumped.

`pod spec lint` shows no warnings
