### PR TITLE
Changes Google APIs Client Library for Objective-C

### DIFF
--- a/GTMHTTPFetcher/0.0.1/GTMHTTPFetcher.podspec
+++ b/GTMHTTPFetcher/0.0.1/GTMHTTPFetcher.podspec
@@ -1,0 +1,32 @@
+Pod::Spec.new do |s|
+  s.name     = 'GTMHTTPFetcher'
+  s.version  = '0.0.1'
+  s.license      = {
+    :type => 'Apache 2.0',
+    :text => <<-LICENSE
+                Copyright (c) 2011 Google Inc.
+ 
+                Licensed under the Apache License, Version 2.0 (the "License");
+                you may not use this file except in compliance with the License.
+                You may obtain a copy of the License at
+ 
+                    http://www.apache.org/licenses/LICENSE-2.0
+ 
+                Unless required by applicable law or agreed to in writing, software
+                distributed under the License is distributed on an "AS IS" BASIS,
+                WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                See the License for the specific language governing permissions and
+                limitations under the License.
+    LICENSE
+  }
+  s.summary = "GTM HTTP Fetcher makes it easy for Cocoa applications to perform http operations."
+  s.description  = "The fetcher is implemented as a wrapper on NSURLConnection, so its behavior "\
+               "is asynchronous and uses operating-system settings on iOS and Mac OS X."
+  s.homepage = 'https://code.google.com/p/gtm-http-fetcher'
+  s.author   = { 'The Google Data APIs team' => 'https://code.google.com/p/google-api-objectivec-client' }
+  s.source   = { :svn => 'http://gtm-http-fetcher.googlecode.com/svn/trunk' }
+  s.requires_arc = false
+  s.ios.deployment_target = '3.0'
+  s.osx.deployment_target = '10.5'
+  s.source_files   = 'Source/*.{h,m}'
+end

--- a/Google-API-Client/0.0.1/Google-API-Client.podspec
+++ b/Google-API-Client/0.0.1/Google-API-Client.podspec
@@ -21,42 +21,135 @@ Pod::Spec.new do |s|
   }
 
   s.summary  = "Written by Google, this library is a flexible and efficient Objective-C framework for accessing JSON APIs."
-  s.homepage = 'https://code.google.com/p/google-api-objectivec-client/'
-  s.author   = { 'Google, Inc.' => 'https://code.google.com/p/google-api-objectivec-client/' }
-  s.source   = { :svn => 'https://google-api-objectivec-client.googlecode.com/svn/trunk/' }
-  s.resource = 'Source/OAuth2/Touch/GTMOAuth2ViewTouch.xib' 
-  s.frameworks = 'Security', 'SystemConfiguration'
-  s.platform = :ios, '5.0'
+  s.description  = "The Google APIs Client Library for Objective-C is a "\
+               "Cocoa framework that enables developers for Mac OS X "\
+               "and iOS to easily write native applications using Google's JSON-RPC APIs."
+  s.homepage = 'http://code.google.com/p/google-api-objectivec-client'
+  s.author   = { 'Google, Inc.' => 'http://code.google.com/p/google-api-objectivec-client' }
+  s.source   = { :svn => 'http://google-api-objectivec-client.googlecode.com/svn/trunk' }
+  s.requires_arc = false
+  s.ios.deployment_target = '3.0'
+  s.osx.deployment_target = '10.5'
+  s.source_files   = 'Source/*.{h,m}'
 
-  s.source_files =  'Source/*.{h,m}', 'Source/HTTPFetcher/*.{h,m}', 'Source/Networking',
-                    'Source/OAuth2/*.{h,m}', 'Source/OAuth2/Touch', 'Source/Objects', 'Source/Utilities'
+  s.dependency    'SBJson'
+  s.dependency    'GTMHTTPFetcher'
+  s.dependency    'gtm-oauth2'
 
-  s.subspec 'Drive' do |drive|
-    drive.source_files = FileList['Source/Services/Drive/**/*.{h,m}'].exclude(/\_Sources.m$/)
+  s.subspec 'Networking' do |net|
+    net.source_files   = 'Source/Networking/*.{h,m}'
   end
-
-  s.subspec 'AdSense' do |ads|
-    ads.source_files = FileList['Source/Services/AdSense/**/*.{h,m}'].exclude(/\_Sources.m$/)
+  
+  s.subspec 'Objects' do |obj|
+    obj.source_files   = 'Source/Objects/*.{h,m}'
   end
-
-  s.subspec 'Analytics' do |analytics|
-    analytics.source_files = FileList['Source/Services/Analytics/**/*.{h,m}'].exclude(/\_Sources.m$/)
+  
+  s.subspec 'Services' do |serv|
+    
+    serv.subspec 'AdSense' do |ads|
+      files = FileList['Source/Services/AdSense/**/*.{h,m}'].exclude('**/*_Sources.m')
+      ads.source_files   = files
+    end
+    
+    serv.subspec 'Analytics' do |anl|
+      files = FileList['Source/Services/Analytics/**/*.{h,m}'].exclude('**/*_Sources.m')
+      anl.source_files   = files
+    end
+    
+    serv.subspec 'Blogger' do |blg|
+      files = FileList['Source/Services/Blogger/**/*.{h,m}'].exclude('**/*_Sources.m')
+      blg.source_files   = files
+    end
+    
+    serv.subspec 'Books' do |books|
+      files = FileList['Source/Services/Books/**/*.{h,m}'].exclude('**/*_Sources.m')
+      books.source_files   = files
+    end
+    
+    serv.subspec 'Calendar' do |cal|
+      files = FileList['Source/Services/Calendar/**/*.{h,m}'].exclude('**/*_Sources.m')
+      cal.source_files   = files
+    end
+    
+    serv.subspec 'CivicInfo' do |cinfo|
+      files = FileList['Source/Services/CivicInfo/**/*.{h,m}'].exclude('**/*_Sources.m')
+      cinfo.source_files   = files
+    end
+    
+    serv.subspec 'Compute' do |compute|
+      files = FileList['Source/Services/Compute/**/*.{h,m}'].exclude('**/*_Sources.m')
+      compute.source_files   = files
+    end
+    
+    serv.subspec 'Discovery' do |disc|
+      files = FileList['Source/Services/Discovery/**/*.{h,m}'].exclude('**/*_Sources.m')
+      disc.source_files   = files
+    end
+    
+    serv.subspec 'Drive' do |drive|
+      files = FileList['Source/Services/Drive/**/*.{h,m}'].exclude('**/*_Sources.m')
+      drive.source_files   = files
+    end
+    
+    serv.subspec 'Groupssettings' do |grpss|
+      files = FileList['Source/Services/Groupssettings/**/*.{h,m}'].exclude('**/*_Sources.m')
+      grpss.source_files   = files
+    end
+    
+    serv.subspec 'Latitude' do |lat|
+      files = FileList['Source/Services/Latitude/**/*.{h,m}'].exclude('**/*_Sources.m')
+      lat.source_files   = files
+    end
+    
+    serv.subspec 'Licensing' do |lic|
+      files = FileList['Source/Services/Licensing/**/*.{h,m}'].exclude('**/*_Sources.m')
+      lic.source_files   = files
+    end
+    
+    serv.subspec 'Orkut' do |ork|
+      files = FileList['Source/Services/Orkut/**/*.{h,m}'].exclude('**/*_Sources.m')
+      ork.source_files   = files
+    end
+    
+    serv.subspec 'Plus' do |plus|
+      files = FileList['Source/Services/Plus/**/*.{h,m}'].exclude('**/*_Sources.m')
+      plus.source_files   = files
+    end
+    
+    serv.subspec 'Shopping' do |shop|
+      files = FileList['Source/Services/Shopping/**/*.{h,m}'].exclude('**/*_Sources.m')
+      shop.source_files   = files
+    end
+    
+    serv.subspec 'Storage' do |storg|
+      files = FileList['Source/Services/Storage/**/*.{h,m}'].exclude('**/*_Sources.m')
+      storg.source_files   = files
+    end
+    
+    serv.subspec 'Tasks' do |tasks|
+      files = FileList['Source/Services/Tasks/**/*.{h,m}'].exclude('**/*_Sources.m')
+      tasks.source_files   = files
+    end
+    
+    serv.subspec 'Urlshortener' do |urlshort|
+      files = FileList['Source/Services/Urlshortener/**/*.{h,m}'].exclude('**/*_Sources.m')
+      urlshort.source_files   = files
+    end
+    
+    serv.subspec 'YouTube' do |ytb|
+      files = FileList['Source/Services/YouTube/**/*.{h,m}'].exclude('**/*_Sources.m')
+      ytb.source_files   = files
+    end
+    
+    serv.subspec 'YouTubeAnalytics' do |ytbanal|
+      files = FileList['Source/Services/YouTubeAnalytics/**/*.{h,m}'].exclude('**/*_Sources.m')
+      ytbanal.source_files   = files
+    end
+    
   end
-
-  s.subspec 'Calendar' do |calendar|
-    calendar.source_files = FileList['Source/Services/Calendar/**/*.{h,m}'].exclude(/\_Sources.m$/)
-  end
-
-  s.subspec 'Plus' do |plus|
-    plus.source_files = FileList['Source/Services/Plus/**/*.{h,m}'].exclude(/\_Sources.m$/)
-  end
-
-  s.subspec 'YouTube' do |youtube|
-    youtube.source_files = FileList['Source/Services/YouTube/**/*.{h,m}'].exclude(/\_Sources.m$/)
-  end
-
-  s.subspec 'All' do |all|
-    all.source_files = FileList['Source/Services/**/*.{h,m}'].exclude(/\_Sources.m$/)
+  
+  s.subspec 'Utilities' do |utl|
+    utl.source_files   = 'Source/Utilities/*.{h,m}'
   end
   
 end

--- a/gtm-oauth2/0.0.1/gtm-oauth2.podspec
+++ b/gtm-oauth2/0.0.1/gtm-oauth2.podspec
@@ -3,30 +3,29 @@ Pod::Spec.new do |s|
   s.name         = "gtm-oauth2"
   s.version      = "0.0.1"
   s.summary      = "Google Toolbox for Mac - OAuth 2 Controllers."
+  s.description = "The Google Toolbox for Mac OAuth 2 Controllers make it easy for Cocoa applications "\
+                  "to sign in to services using OAuth 2 for authentication and authorization."
   s.homepage     = "http://code.google.com/p/gtm-oauth2"
-  s.author       = "Google Inc."
+  s.author   = { 'The Google Data APIs team' => 'https://code.google.com/p/google-api-objectivec-client' }
   s.source       = { :svn => 'http://gtm-oauth2.googlecode.com/svn/trunk/' }
-
+  s.requires_arc = false
+  s.dependency   'GTMHTTPFetcher'
   s.frameworks = 'Security', 'SystemConfiguration'
-
-  s.osx.deployment_target = '10.5'
-  s.osx.source_files =
-    'HTTPFetcher/GTMHTTPFetcher.{h,m}',
-    'HTTPFetcher/GTMHTTPFetchHistory.{h,m}',
-    'Source/GTMOAuth2Authentication.{h,m}',
-    'Source/GTMOAuth2SignIn.{h,m}',
-    'Source/Mac/GTMOAuth2WindowController.{h,m}'
-
   s.ios.deployment_target = '3.0'
-  s.ios.source_files =
-    'HTTPFetcher/GTMHTTPFetcher.{h,m}',
-    'Source/GTMOAuth2Authentication.{h,m}',
-    'Source/GTMOAuth2SignIn.{h,m}',
-    'Source/Touch/GTMOAuth2ViewControllerTouch.{h,m}'
+  s.osx.deployment_target = '10.5'
 
-  s.subspec 'nibs' do |nibs|
-    nibs.osx.resources = 'Source/Mac/GTMOAuth2Window.xib'
-    nibs.ios.resources = 'Source/Touch/GTMOAuth2ViewTouch.xib'
+  s.subspec 'Core' do |oa2|
+    oa2.source_files   = 'Source/*.{h,m}'
+    
+    oa2.subspec 'Mac' do |mac|
+      mac.osx.source_files = 'Source/Mac/**.{h,m}'
+      mac.osx.resources = 'Source/Mac/**.xib'
+    end
+    
+    oa2.subspec 'Touch' do |touch|
+      touch.ios.source_files = 'Source/Touch/**.{h,m}'
+      touch.ios.resources = 'Source/Touch/**.xib'
+    end
   end
 
   s.license = {


### PR DESCRIPTION
- _Google-API-Client_ => We have added multiplatform support (iOS and Mac OS X) because this library is compatible with applications built for iOS 3+, and Mac OS X 10.5+. Added real dependencies to _GTMHTTPFetcher_, _gtm-oauth2_ and _SBJson_. ARC isn´t required. Added all _Google APIs Client Library_ services.
- _gtm-oauth2_ => Added _GTMHTTPFetcher_ as real depedency. ARC isn´t required. Adopting safer copy phase for source files because the spec is point to HEAD.
- _GTMHTTPFetcher_ => Currently, the Google´s library _gtm-http-fetcher_ isn´t included as independent Pod.

We also emailed Google to explicitly ask them to support tag in their repository to better manage cocopods.
