### PR TITLE
Avoid conflicts with Google-API-Client

### DIFF
--- a/GData/1.9.1/GData.podspec
+++ b/GData/1.9.1/GData.podspec
@@ -8,10 +8,13 @@ Pod::Spec.new do |s|
   s.author   = { 'The Google Data APIs team' => 'https://code.google.com/p/gdata-objectivec-client' }
   s.source   = { :svn => 'http://gdata-objectivec-client.googlecode.com/svn', :tag => 'gdata-objectivec-client-1.9.1' }
 
+  s.dependency    'GTMHTTPFetcher'
+  s.dependency    'gtm-oauth2'
+
   s.subspec 'Core' do |gdc|
     gdc.source_files   = 'Source/ACL/*.{h,m}', 'Source/BaseClasses/*.{h,m}', 'Source/Elements/*.{h,m}',
-                         'Source/Geo/*.{h,m}', 'Source/HTTPFetcher/*.{h,m}', 'Source/Introspection/*.{h,m}',
-                         'Source/Media/*.{h,m}', 'Source/Networking/*.{h,m}', 'Source/OAuth2/*.{h,m}',
+                         'Source/Geo/*.{h,m}', 'Source/Introspection/*.{h,m}',
+                         'Source/Media/*.{h,m}', 'Source/Networking/*.{h,m}',
                          'Source/XMLSupport/*.{h,m}', 'Source/*.{h,m}', 'Source/Clients/**/*.{h,m}'
     gdc.libraries      = 'xml2'
     gdc.xcconfig       = { 'HEADER_SEARCH_PATHS' => '"$(SDKROOT)/usr/include/libxml2"' }


### PR DESCRIPTION
Taking advantage work done in Google-API-Client (new API), I added real dependencies management to _GTMHTTPFetcher_ and _gtm-oauth2_.
