### PR TITLE
Reachability does not requiere ARC

### DIFF
--- a/Reachability/3.1.0/Reachability.podspec
+++ b/Reachability/3.1.0/Reachability.podspec
@@ -21,5 +21,4 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/tonymillion/Reachability.git', :tag => 'v3.1.0' }
   s.source_files = 'Reachability.{h,m}'
   s.framework    = 'SystemConfiguration'
-  s.requires_arc = true
 end


### PR DESCRIPTION
Reachability should not require ARC. The project supports ARC but works also in non-arc projects. 
