### PR TITLE
Added TestFlight SDK 1.3.0 beta 2, Fixed ZBarSDK 1.3.1

### DIFF
--- a/TestFlightSDK/1.3.0.beta2/TestFlightSDK.podspec
+++ b/TestFlightSDK/1.3.0.beta2/TestFlightSDK.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+  s.name     = 'TestFlightSDK'
+  s.version  = '1.3.0.beta2'
+  s.license      = {
+    :type => 'Commercial',
+    :text => <<-LICENSE
+              All text and design is copyright © 2010-2013 TestFlight App, Inc.
+
+              All rights reserved.
+
+              https://testflightapp.com/tos/
+    LICENSE
+  }
+  s.summary  = 'TestFlightSDK for over-the-air beta testing and crash reporting.'
+  s.homepage = 'http://www.testflightapp.com'
+  s.author   = { 'TestFlight' => 'support@testflightapp.com' }
+  s.source   = { :http => 'https://d3fqheiq7nlyrx.cloudfront.net/sdk-downloads/TestFlightSDK1.3.0-beta.2.zip' }
+  s.platform = :ios
+  s.source_files = 'TestFlight.h'
+  s.preserve_paths = 'libTestFlight.a'
+  s.library = 'TestFlight', 'z'
+  s.framework = 'UIKit'
+  s.xcconfig  =  { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/TestFlightSDK"' }
+end

--- a/ZBarSDK/1.3.1/ZBarSDK.podspec
+++ b/ZBarSDK/1.3.1/ZBarSDK.podspec
@@ -34,8 +34,8 @@ Pod::Spec.new do |s|
 
   s.compiler_flags = '-w'
 
-  def s.post_install(target_installer)
-    project = target_installer.project
+  s.post_install do |installer|
+    project = installer.project
     project.objects_by_uuid.each do |key, obj|
       if obj.isa.to_s == "PBXBuildFile"
         file_ref = obj.file_ref


### PR DESCRIPTION
- Added TestFlightSDK.podspec for TestFlight SDK 1.3.0 beta2
- Fixed ZBarSDK 1.3.1, now compatible with Cocoapods 0.17
