### PR TITLE
GTMHHTPFetcher not yet compatible with head version

### DIFF
--- a/GTMHTTPFetcher/0.0.1/GTMHTTPFetcher.podspec
+++ b/GTMHTTPFetcher/0.0.1/GTMHTTPFetcher.podspec
@@ -28,5 +28,7 @@ Pod::Spec.new do |s|
   s.requires_arc = false
   s.ios.deployment_target = '3.0'
   s.osx.deployment_target = '10.5'
-  s.source_files   = 'Source/*.{h,m}'
+  s.ios.framework = 'UIKit'
+  s.ios.source_files   = 'Source/*.{h,m}'
+  s.osx.source_files   = FileList['Source/*.{h,m}'].exclude('**/GTMHTTPFetcherLogViewController.*')
 end


### PR DESCRIPTION
2 Days ago Google introduce a new class for iOS, it should be removed during the deployment in OS X environments
