### PR TITLE
Added support for osx deployment target for pod DCKeyValueObjectMapping

### DIFF
--- a/DCKeyValueObjectMapping/1.3/DCKeyValueObjectMapping.podspec
+++ b/DCKeyValueObjectMapping/1.3/DCKeyValueObjectMapping.podspec
@@ -2,6 +2,7 @@ Pod::Spec.new do |s|
   s.name             		=  'DCKeyValueObjectMapping'
   s.version          		=  '1.3'
   s.ios.deployment_target	=  '5.0'
+  s.osx.deployment_target   =  '10.7'
   s.license          		=  'MIT'
   s.summary          		=  'Automatic KeyValue Object Mapping for Objective-C, parse JSON/Plist/XML automatically, support Core Data, convetion over configuration.'
   s.homepage         		=  'https://github.com/dchohfi/KeyValueObjectMapping'


### PR DESCRIPTION
No compat issue, since it only adds a new deployment target.
