### PR TITLE
'libGoogleAnalytics_debug.a' isn't preserved

### DIFF
--- a/GoogleAnalytics-iOS-SDK/2.0beta4/GoogleAnalytics-iOS-SDK.podspec
+++ b/GoogleAnalytics-iOS-SDK/2.0beta4/GoogleAnalytics-iOS-SDK.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios
 
   s.source_files = 'Library/*.h'
-  s.preserve_paths = 'Library/libGoogleAnalytics.a'
+  s.preserve_paths = 'Library/*.a'
 
   s.frameworks = 'CFNetwork', 'CoreData', 'SystemConfiguration'
   s.library   = 'GoogleAnalytics'


### PR DESCRIPTION
While installing 'libGoogleAnalytics_debug.a' isn't preserved. Changed the Google analytics spec to have all .a files included.
