### PR TITLE
Calabash: Do not flatten framework folder

### DIFF
--- a/Calabash/0.9.126/Calabash.podspec
+++ b/Calabash/0.9.126/Calabash.podspec
@@ -16,9 +16,9 @@ this software.'
   s.summary  = 'Calabash is an automated testing technology for Android and iOS native and hybrid applications.'
   s.homepage = 'https://github.com/calabash/calabash-ios'
   s.author   = { 'Karl Krukow' => 'karl.krukow@gmail.com' }
-  s.source   = { :http => 'https://github.com/downloads/calabash/calabash-ios/calabash.framework-0.9.126.zip', :flatten => true }
-  s.preserve_paths = 'Headers', 'Versions', 'calabash'
-  s.source_files = 'Headers/*'
+  s.source   = { :http => 'https://github.com/downloads/calabash/calabash-ios/calabash.framework-0.9.126.zip'}
+  s.preserve_paths = 'calabash.framework'
+  s.source_files = 'calabash.framework/Versions/A/Headers/*'
   s.xcconfig = { 'OTHER_LDFLAGS' => '-force_load "$(PODS_ROOT)/Calabash/calabash.framework/calabash" -lstdc++' } 
   s.framework = 'CFNetwork'
 end


### PR DESCRIPTION
In the previous spec version zip archive was flattened, so 'cucumber.framework' folder appeared to be empty.
