### PR TITLE
Fix HHUnitConverter podspec

### DIFF
--- a/HHUnitConverter/1.0/HHUnitConverter.podspec
+++ b/HHUnitConverter/1.0/HHUnitConverter.podspec
@@ -12,4 +12,9 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Library/**/*.{h,m}'
   s.requires_arc = true
+
+  s.subspec 'PESGraph' do |ps|
+    s.requires_arc = false
+  end
+
 end

--- a/HHUnitConverter/1.0/HHUnitConverter.podspec
+++ b/HHUnitConverter/1.0/HHUnitConverter.podspec
@@ -11,10 +11,5 @@ Pod::Spec.new do |s|
   # s.platform     = :ios
 
   s.source_files = 'Library/**/*.{h,m}'
-  s.requires_arc = true
-
-  s.subspec 'PESGraph' do |ps|
-    s.requires_arc = false
-  end
-
+  s.requires_arc = false
 end


### PR DESCRIPTION
Restores sub spec for PESGraph to not require ARC
