### PR TITLE
Do not preserve 'Demo' folder for SVProgressHUD

### DIFF
--- a/SVProgressHUD/0.9/SVProgressHUD.podspec
+++ b/SVProgressHUD/0.9/SVProgressHUD.podspec
@@ -11,7 +11,6 @@ Pod::Spec.new do |s|
   s.description = 'SVProgressHUD is an easy-to-use, clean and lightweight progress HUD for iOS. It’s a simplified and prettified alternative to the popular MBProgressHUD. The success and error icons are from Glyphish.'
 
   s.source_files = 'SVProgressHUD/*.{h,m}'
-  s.preserve_paths  = 'Demo'
   s.framework    = 'QuartzCore'
   s.resources    = 'SVProgressHUD/SVProgressHUD.bundle'
   s.requires_arc = true


### PR DESCRIPTION
Doesn't seems reasonable to have Demo filed in Pods/ directory. Probably it was added by mistake?

/cc @samvermette 
