### PR TITLE
TestFlightSDK change https to http due to a unverified ssl identity

### DIFF
--- a/TestFlightSDK/1.3.0.beta2/TestFlightSDK.podspec
+++ b/TestFlightSDK/1.3.0.beta2/TestFlightSDK.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.summary  = 'TestFlightSDK for over-the-air beta testing and crash reporting.'
   s.homepage = 'http://www.testflightapp.com'
   s.author   = { 'TestFlight' => 'support@testflightapp.com' }
-  s.source   = { :http => 'https://d3fqheiq7nlyrx.cloudfront.net/sdk-downloads/TestFlightSDK1.3.0-beta.2.zip' }
+  s.source   = { :http => 'http://d3fqheiq7nlyrx.cloudfront.net/sdk-downloads/TestFlightSDK1.3.0-beta.2.zip' }
   s.platform = :ios
   s.source_files = 'TestFlight.h'
   s.preserve_paths = 'libTestFlight.a'


### PR DESCRIPTION
I think that an unverified ssl identity is causing curl to get angry.

[31m[!] Pod::Executable -L -o '../Pods/TestFlightSDK/file.zip' 'https://d3fqheiq7nlyrx.cloudfront.net/sdk-downloads/TestFlightSDK1.3.0-beta.2.zip'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
 86 1226k   86 1056k    0     0  2083k      0 --:--:-- --:--:-- --:--:-- 2301k
        curl: (56) SSL read: error:00000000:lib(0):func(0):reason(0), errno 54

![testflight](https://f.cloud.github.com/assets/386473/353270/d7c3091e-a07c-11e2-85f1-f9f3b2089928.png)
