### PR TITLE
Updated correct TapkuLibrary tagging

### DIFF
--- a/TapkuLibrary/0.2.4/TapkuLibrary.podspec
+++ b/TapkuLibrary/0.2.4/TapkuLibrary.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name              = 'TapkuLibrary'
+  s.version           = '0.2.4'
+  s.platform          = :ios
+  s.author            = { 'Devin Ross' => 'devin@devinsheaven.com' }
+  s.license           = { :type => 'MIT', :file => 'License.txt' }
+  s.homepage          = 'http://tapku.com/'
+  s.summary           = 'tap + haiku = tapku, a well crafted open source iOS framework.'
+  s.description       = 'TapkuLibrary is an iOS library built on Cocoa and UIKit intended for broad ' \
+                        'use in applications. If you\'re looking to see what the library can do, check ' \
+                        'out the demo project included. Some major components include coverflow, calendar ' \
+                        'grid, network requests and progress indicators.'
+  s.source            = { :git => 'https://github.com/devinross/tapkulibrary.git', :tag => 'v0.2.4' }
+  s.requires_arc      = true
+  s.source_files      = 'src/TapkuLibrary/*.{h,m}'
+  s.resources         = 'src/TapkuLibrary.bundle'
+  s.frameworks        = 'MapKit', 'QuartzCore'
+end


### PR DESCRIPTION
The current TapkuLibrary spec is using tag "v2.1" which doesn't really exists in https://github.com/devinross/tapkulibrary/tags
I just thought we should correct this one.
