### PR TITLE
ParseKit: Import prefix header files

### DIFF
--- a/ParseKit/0.5/ParseKit.podspec
+++ b/ParseKit/0.5/ParseKit.podspec
@@ -23,9 +23,11 @@ Pod::Spec.new do |s|
     for ParseKit.
   }
 
-  s.source_files   =  'include/**/*.{h,m}', 'src/**/*.{h,m}'
-  s.ios.frameworks =  'Foundation', 'CoreGraphics'
-  s.osx.framework  =  'Foundation'
-  s.library        =  'icucore'
-  s.requires_arc   =  false
+  s.source_files           =  'include/**/*.{h,m}', 'src/**/*.{h,m}'
+  s.ios.prefix_header_file =  'ParseKitMobile_Prefix.pch'
+  s.osx.prefix_header_file =  'ParseKit_Prefix.pch'
+  s.ios.frameworks         =  'Foundation', 'CoreGraphics'
+  s.osx.framework          =  'Foundation'
+  s.library                =  'icucore'
+  s.requires_arc           =  false
 end


### PR DESCRIPTION
Import prefix header files to prevent PKAssertMainThread() not defined during compile.
