### PR TITLE
[AdMob] LIBRARY_SEARCH_PATHS need to be updated

### DIFF
--- a/AdMob/6.4.0/AdMob.podspec
+++ b/AdMob/6.4.0/AdMob.podspec
@@ -19,5 +19,5 @@ LICENSE
   s.frameworks = 'AudioToolbox', 'MessageUI', 'SystemConfiguration', 'CoreGraphics', 'StoreKit'
   s.weak_frameworks = 'AdSupport'
   s.library = 'GoogleAdMobAds'
-  s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' , 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Google-AdMob-Ads-SDK/"'}
+  s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' , 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/AdMob/"'}
 end


### PR DESCRIPTION
This fixes an issue caused by the migration from Google-AdMob-Ads-SDK -> AdMob this morning
