### PR TITLE
Fixed eigen.podspec and updated vMAT.podspec with eigen dependency

### DIFF
--- a/eigen/3.1.2/eigen.podspec
+++ b/eigen/3.1.2/eigen.podspec
@@ -13,9 +13,7 @@ Pod::Spec.new do |s|
 
   s.compiler_flags = '-DEIGEN_MPL2_ONLY'
 
-  s.header_mappings_dir = '.'
-
-  s.preserve_paths = './Eigen/**'
+  s.preserve_paths = 'Eigen/*', 'Eigen/**/*'
 
   s.dependency 'boost/numeric-includes'
   s.dependency 'boost/preprocessor-includes'

--- a/vMAT/0.0.1/vMAT.podspec
+++ b/vMAT/0.0.1/vMAT.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.source_files = 'vMAT', 'vMAT/**/*.{h,m}'
   s.frameworks = 'Accelerate', 'Foundation'
   s.requires_arc = true
-  s.xcconfig = { 'CLANG_CXX_LANGUAGE_STANDARD' => 'gnu++11' }
+  s.xcconfig = { 'CLANG_CXX_LANGUAGE_STANDARD' => 'gnu++0x', 'CLANG_CXX_LIBRARY' => 'libc++' }
   s.dependency 'BlocksKit', '~> 1.8.1'
+  s.dependency 'eigen', '~> 3.1.2'
 end


### PR DESCRIPTION
The **eigen** podspec was broken before:

``` shell
aoide:vMAT kaelin$ pod spec lint /Users/Shared/github/Specs/eigen/3.1.2/eigen.podspec --no-clean

 -> eigen (3.1.2)
    - ERROR | The `preserve_paths` pattern did not match any file.

Pods project available at `/tmp/CocoaPods/Lint/Pods/Pods.xcodeproj` for inspection.

Analyzed 1 podspec.

[!] The spec did not pass validation.
```

Now it passes lint, and more importantly actually installs the **C++** template header files:

``` shell
aoide:~ kaelin$ pod spec lint ~/.cocoapods/kaelin/eigen/3.1.2/eigen.podspec 

 -> eigen (3.1.2)

Analyzed 1 podspec.

eigen.podspec passed validation.
```
