### PR TITLE
Add SSKeychain as dependency to Evernote-SDK-iOS

### DIFF
--- a/Evernote-SDK-iOS/1.1.1/Evernote-SDK-iOS.podspec
+++ b/Evernote-SDK-iOS/1.1.1/Evernote-SDK-iOS.podspec
@@ -8,6 +8,10 @@ Pod::Spec.new do |s|
   s.author   = 'Evernote'
   s.requires_arc = true
   s.source   = { :git => 'https://github.com/evernote/evernote-sdk-ios.git', :tag => '1.1.1' }
-  s.source_files = 'evernote-sdk-ios/**/*.{h,m}'
+  s.source_files = 'evernote-sdk-ios/*.{h,m}',
+    'evernote-sdk-ios/{EDAM,Utilities,internal}/**/*.{h,m}',
+    'evernote-sdk-ios/3rdParty/{AFNetworking,KSHTMLWriter,NSString+URLEncoding,Thrift,cocoa-oauth}/**/*.{h,m}'
   s.frameworks = 'Foundation', 'Security', 'StoreKit'
+
+  s.dependency 'SSKeychain', '0.2.1'
 end


### PR DESCRIPTION
SSKeychain files should not be included as part of the pod because this
will cause duplicate symbol errors if you are using the SSKeychain pod.
Instead incude SSKeychain as a dependency.
