### PR TITLE
Fix FRAMEWORK_SEARCH_PATHS for Specta on OS X

### DIFF
--- a/Specta/0.1.8/Specta.podspec
+++ b/Specta/0.1.8/Specta.podspec
@@ -20,6 +20,7 @@ Pod::Spec.new do |s|
 
   s.frameworks = 'Foundation', 'SenTestingKit'
 
-  s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"$(SDKROOT)/Developer/Library/Frameworks" "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
+  s.ios.xcconfig    = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(SDKROOT)/Developer/Library/Frameworks" "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
+  s.osx.xcconfig    = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(DEVELOPER_LIBRARY_DIR)/Frameworks"' }
 end
 


### PR DESCRIPTION
As per the title of this pull request, this fixes a warning generated by an iOS-only framework search path being included on OS X builds.
