### PR TITLE
Added Facebook dependency to Parse SDK

### DIFF
--- a/Parse/1.2.5/Parse.podspec
+++ b/Parse/1.2.5/Parse.podspec
@@ -15,4 +15,5 @@ Pod::Spec.new do |s|
   s.weak_frameworks = 'AdSupport','Social', 'Accounts'
   s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/Parse"' }
   s.library = 'z', 'sqlite3'
+  s.dependency 'Facebook-iOS-SDK', '~> 3.2'
 end


### PR DESCRIPTION
Parse SDK (1.2.5) would not compile without Facebook, I added the dependency in the spec.
