### PR TITLE
HockeySDK: Use standard mechanism for adding resources.

### DIFF
--- a/HockeySDK/3.0.0/HockeySDK.podspec
+++ b/HockeySDK/3.0.0/HockeySDK.podspec
@@ -22,6 +22,7 @@ Pod::Spec.new do |s|
   s.frameworks   = 'CoreText', 'QuartzCore', 'SystemConfiguration', 'CrashReporter', 'CoreGraphics', 'UIKit'
   s.xcconfig     = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/HockeySDK/Vendor"',
                      'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) BITHOCKEY_VERSION="@\\"#{s.version}\\""} }
+  s.resources    = 'HockeySDK/Resources/HockeySDKResources.bundle'
 
   def s.post_install(target_installer)
     puts "\nGenerating HockeySDK resources bundle\n".yellow if config.verbose?
@@ -31,14 +32,6 @@ Pod::Spec.new do |s|
       unless system(command)
         raise ::Pod::Informative, "Failed to generate HockeySDK resources bundle"
       end
-    end
-    if Version.new(Pod::VERSION) >= Version.new('0.16.999')
-      script_path = target_installer.copy_resources_script_path
-    else
-      script_path = File.join(config.project_pods_root, target_installer.target_definition.copy_resources_script_name)
-    end
-    File.open(script_path, 'a') do |file|
-      file.puts "install_resource 'HockeySDK/Resources/HockeySDKResources.bundle'"
     end
   end
 end


### PR DESCRIPTION
This seems to break multi-target builds (the bundle moves between
targets.)

I have a target which includes HockeySDK, and a child (nonexclusive) target which includes some other development dependencies. Every time I run 'pod install' the install_resources bits seem to bounce between each target. Moving to the standard mechanism for setting up resources seems to fix the problem.
