### PR TITLE
Update Google-API-Client.podspec

### DIFF
--- a/Google-API-Client/0.0.1/Google-API-Client.podspec
+++ b/Google-API-Client/0.0.1/Google-API-Client.podspec
@@ -37,6 +37,10 @@ Pod::Spec.new do |s|
   s.dependency    'SBJson'
   s.dependency    'GTMHTTPFetcher'
   s.dependency    'gtm-oauth2'
+  
+  s.subspec 'Common' do |com|
+    com.source_files = 'Source/GTLDefines.h'
+  end
 
   s.subspec 'Networking' do |net|
     net.source_files   = 'Source/Networking/*.{h,m}'


### PR DESCRIPTION
Added Common subspec for shared files (contains only GTLDefines.h)

Currently /Services subspecs depend on GTLDefines.h, which should be included. Probably best to include a 'Common' subspec for cases like this.
