### PR TITLE
Added the NJKWebViewProgress Pod

### DIFF
--- a/NJKWebViewProgress/0.1.2/NJKWebViewProgress.podspec
+++ b/NJKWebViewProgress/0.1.2/NJKWebViewProgress.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "NJKWebViewProgress"
+  s.version      = "0.1.2"
+  s.license      = 'MIT'
+  s.summary      = "UIWebView progress interface."
+  s.description  = "NJKWebViewProgress is a progress interface library for UIWebView. Currently, UIWebView don't have official progress interface. You can implement progress bar for your in-app browser using this module."
+  s.homepage     = "https://github.com/ninjinkun/NJKWebViewProgress"
+  s.authors      = { "ninjinkun" => "ninjin@mac.com" }
+  s.source       = { :git => "https://github.com/ninjinkun/NJKWebViewProgress.git", :tag => "v#{s.version}" }
+  s.platform     = :ios, '5.0'
+  s.source_files = 'NJKWebViewProgress'
+  s.requires_arc = true
+end

--- a/NJKWebViewProgress/0.1.3/NJKWebViewProgress.podspec
+++ b/NJKWebViewProgress/0.1.3/NJKWebViewProgress.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "NJKWebViewProgress"
-  s.version      = "0.1.2"
-  s.license      = 'MIT'
+  s.version      = "0.1.3"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.summary      = "UIWebView progress interface."
   s.description  = "NJKWebViewProgress is a progress interface library for UIWebView. Currently, UIWebView don't have official progress interface. You can implement progress bar for your in-app browser using this module."
   s.homepage     = "https://github.com/ninjinkun/NJKWebViewProgress"


### PR DESCRIPTION
Added a pod for the latest tagged version of NJKWebViewProgress. Lint is successful except for a license file. The author lists the license as MIT but does not have it listed in a separate file. I don't know if this will be a problem or not.
