### PR TITLE
SHGameCenter (big) update to 0.1.0 

### DIFF
--- a/SHGameCenter/0.1.0/SHGameCenter.podspec
+++ b/SHGameCenter/0.1.0/SHGameCenter.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
 
   s.ios.framework = "GameKit"
 
-  s.source_files = 'SHGameCenter/**/*.{h,m}'
+  s.source_files = 'SHGameCenter/**/*.{h,m,implementation,privates}'
   s.requires_arc = true
   s.dependency 'BlocksKit', '~> 1.8'
 end

--- a/SHGameCenter/0.1.0/SHGameCenter.podspec
+++ b/SHGameCenter/0.1.0/SHGameCenter.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+  s.name         = "SHGameCenter"
+  s.version      = "0.1.0"
+  s.summary      = "Block based patterns and properties for GameCenter."
+  s.description  = <<-DESC
+  Making GKTurnBasedEventHandlerDelegate and authentication block based.
+  New properties (as categories) for:
+
+   * GKPlayer 
+   * GKLocalPlayer
+   * GKTurnBasedMatch
+   * GKTurnBasedParticipant
+
+   Making Game Center easier to work with.
+                   DESC
+  s.homepage     = "https://github.com/seivan/SHGameCenter"
+  s.license      = {:type => 'MIT' } 
+  s.author       = { "Seivan Heidari" => "seivan.heidari@icloud.com" }
+  
+  s.source       = { :git => "https://github.com/seivan/SHGameCenter.git", :tag => "0.1.0"}
+  
+
+  s.platform = :ios, "6.0"
+
+  s.ios.framework = "GameKit"
+
+  s.source_files = 'SHGameCenter/**/*.{h,m}'
+  s.requires_arc = true
+  s.dependency 'BlocksKit', '~> 1.8'
+end


### PR DESCRIPTION
 Getting closer to stabilizing the API. Will start adding to the CHANGELOG when we hit 1.0.

I'm OK jumping from 0.0.1 to 0.1.0 as I am getting closer to 1.0. But your opinion on this matters. So let me know. 

Breaking API changes from 0.0.1
SHGameCenter class no longer holds anything in its public interface.
Authentication is on GKLocalPlayer
MatchesAndFriends is on GKTurnBasedMatch
Match update blocks is on GKTurnBasedMatch

Added a "Get Started" - will be prone to changes soon, but will be using CocoaDocs for proper documentation in the next minor. 

Fixed imports to keep things a bit cleaner.
