### PR TITLE
Update Appirater to 1.0.2

### DIFF
--- a/Appirater/1.0.2/Appirater.podspec
+++ b/Appirater/1.0.2/Appirater.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name              = 'Appirater'
+  s.version           = '1.0.2'
+  s.platform          = :ios
+  s.summary           = "A utility that reminds your iPhone app's users to review the app."
+  s.homepage          = 'http://arashpayan.com/blog/2009/09/07/presenting-appirater/'
+  s.author            = { 'Arash Payan' => 'arash.payan@gmail.com' }
+  s.source            = { :git => 'https://github.com/arashpayan/appirater.git', :tag => '1.0.2' }
+  s.source_files      = '*.{h,m}'
+  s.resources         = '*.lproj'
+  s.requires_arc      = true
+  s.frameworks        = 'CFNetwork', 'SystemConfiguration'
+  s.weak_framework    = 'StoreKit'
+  s.license           = { :type => 'MIT', :text => 'Copyright 2012. Arash Payan. This library is distributed under the terms of the MIT/X11.' }
+end


### PR DESCRIPTION
The podspec was updated in the main repos and it was tagged properly, but nobody submitted the updated spec to the master repos :cry: https://github.com/arashpayan/appirater/blob/master/Appirater.podspec
