### PR TITLE
Add NS prefix to source files

### DIFF
--- a/SDWebImage/3.2/SDWebImage.podspec
+++ b/SDWebImage/3.2/SDWebImage.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
                   'and performances!'
 
   s.requires_arc = true
-  s.source_files = 'SDWebImage/{SD,UI}*.{h,m}'
+  s.source_files = 'SDWebImage/{NS,SD,UI}*.{h,m}'
   s.framework = 'ImageIO'
 
   # TODO currently CocoaPods always tries to install the subspec even if the dependency is on just 'SDWebImage'


### PR DESCRIPTION
The latest revision of SDWebImage includes source files with the NS prefix, so preemptively add it and also if users of this spec are using :head.
