### PR TITLE
Added "exclude_files" parameters for each target of GPUImage

### DIFF
--- a/GPUImage/0.1.0/GPUImage.podspec
+++ b/GPUImage/0.1.0/GPUImage.podspec
@@ -8,6 +8,8 @@ Pod::Spec.new do |s|
   s.author   = { 'Brad Larson' => 'contact@sunsetlakesoftware.com' }
   s.source   = { :git => 'https://github.com/BradLarson/GPUImage.git', :tag => '0.1.0' }
   s.source_files = 'framework/Source/**/*.{h,m}'
+  s.osx.exclude_files = 'framework/Source/iOS/**/*.{h,m}'
+  s.ios.exclude_files = 'framework/Source/Mac/**/*.{h,m}'
   s.frameworks   = ['OpenGLES', 'CoreVideo', 'CoreMedia', 'QuartzCore', 'AVFoundation']
 
   s.requires_arc = true

--- a/YapDatabase/1.2.1/YapDatabase.podspec
+++ b/YapDatabase/1.2.1/YapDatabase.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = "YapDatabase"
+  s.version      = "1.2.1"
+  s.summary      = "A key/value store built atop sqlite for iOS & Mac."
+  s.homepage     = "https://github.com/yaptv/YapDatabase"
+  s.license      = 'MIT'
+  s.platform = :ios, '6.1'
+  s.author       = { "yaptv" => "robbiehanson@deusty.com" }
+  s.source       = { :git => "https://github.com/yaptv/YapDatabase.git", :tag => "1.2.1" }
+  s.source_files = 'YapDatabase/**/*.{h,m}'
+  s.public_header_files = 'YapDatabase/Key_Value/YapDatabase.h'
+  s.dependency 'CocoaLumberjack', '~> 1.6.2'
+
+  s.requires_arc = true
+
+end


### PR DESCRIPTION
This podspec is broken. It does not compile due to the fact it tries to add both `Mac` and `iOS` frameworks. I added correct conditional `exclude_files` parameters for each target. `GPUImage` is a popular library so I'm not sure how this bug wasn't noticed before...
