### PR TITLE
[Fix] ObjectiveMetrics, correct header files.

### DIFF
--- a/ObjectiveMetrics/2.1.1/ObjectiveMetrics.podspec
+++ b/ObjectiveMetrics/2.1.1/ObjectiveMetrics.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.osx.source_files = common_source_files
   s.ios.source_files = common_source_files + ['TouchMetrics/UIDevice-Extension']
 
-  s.public_header_files = 'ObjectiveMetrics/DMTracker.h'
+  s.public_header_files = ['ObjectiveMetrics/DMTracker.h', 'ObjectiveMetrics/ObjectiveMetrics.h']
   s.prefix_header_file = 'ObjectiveMetrics/ObjectiveMetrics-Prefix.pch'
 
   s.dependency 'SBJson', '~> 3.1.1'


### PR DESCRIPTION
This adds the missing ObjectiveMetrics.h header file to the spec.
