### PR TITLE
Updated ParseKit spec to tag 0.7

### DIFF
--- a/ParseKit/0.7/ParseKit.podspec
+++ b/ParseKit/0.7/ParseKit.podspec
@@ -1,0 +1,33 @@
+Pod::Spec.new do |s|
+  s.name     = 'ParseKit'
+  s.version  = '0.7'
+  s.license  = 'Apache'
+  s.summary  = 'Objective-C/Cocoa String Tokenizer and Parser toolkit. Supports Grammars.'
+  s.homepage = 'http://parsekit.com/'
+  s.author   = { 'Todd Ditchendorf' => 'todd.ditchendorf@gmail.com' }
+
+  s.source   = { :git => 'https://github.com/itod/parsekit.git', :tag => '0.7'}
+
+  s.description = %{
+    ParseKit is a Mac OS X Framework written by Todd Ditchendorf in
+    Objective-C 2.0 and released under the Apache Open Source License
+    Version 2.0. ParseKit is suitable for use on Mac OS X Leopard,
+    Snow Leopard or iOS. ParseKit is an Objective-C implementation
+    of the tools described in Building Parsers with Java by Steven
+    John Metsker.
+
+    ParseKit includes additional features beyond the
+    designs from the book and also some changes to match common
+    Cocoa/Objective-C conventions. These changes are relatively superficial,
+    however, and Metsker’s book is the best documentation available
+    for ParseKit.
+  }
+
+  s.source_files           =  'include/**/*.{h,m}', 'src/**/*.{h,m}'
+  s.ios.prefix_header_file =  'ParseKitMobile_Prefix.pch'
+  s.osx.prefix_header_file =  'ParseKit_Prefix.pch'
+  s.ios.frameworks         =  'Foundation', 'CoreGraphics'
+  s.osx.framework          =  'Foundation'
+  s.library                =  'icucore'
+  s.requires_arc           =  false
+end

--- a/ParseKit/0.7/ParseKit.podspec
+++ b/ParseKit/0.7/ParseKit.podspec
@@ -24,9 +24,9 @@ Pod::Spec.new do |s|
   }
 
   s.source_files           =  'include/**/*.{h,m}', 'src/**/*.{h,m}'
-  s.ios.prefix_header_file =  'ParseKitMobile_Prefix.pch'
-  s.osx.prefix_header_file =  'ParseKit_Prefix.pch'
-  s.ios.frameworks         =  'Foundation', 'CoreGraphics'
+  s.ios.prefix_header_file =  'src/ParseKitMobile_Prefix.pch'
+  s.osx.prefix_header_file =  'src/ParseKit_Prefix.pch'
+  s.ios.frameworks         =  'Foundation'
   s.osx.framework          =  'Foundation'
   s.library                =  'icucore'
   s.requires_arc           =  false

--- a/ParseKit/0.7/ParseKit.podspec
+++ b/ParseKit/0.7/ParseKit.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
     for ParseKit.
   }
 
-  s.source_files           =  'include/**/*.{h,m}', 'src/**/*.{h,m}'
+  s.source_files           =  'include/**/*.{h,m}', 'src/**/*.{h,m}, lib/MGTemplateEngine/*.{h,m}'
   s.ios.prefix_header_file =  'src/ParseKitMobile_Prefix.pch'
   s.osx.prefix_header_file =  'src/ParseKit_Prefix.pch'
   s.ios.frameworks         =  'Foundation'


### PR DESCRIPTION
Hi, I'm new to git and CocoaPods, so apologies if this is not the correct way to update a spec.

But this is my attempt to update the ParseKit CocoaPods spec to point to my ParseKit tag 0.7
