### PR TITLE
fixed broken podspec for GPUImage

### DIFF
--- a/GPUImage/0.1.0/GPUImage.podspec
+++ b/GPUImage/0.1.0/GPUImage.podspec
@@ -8,6 +8,8 @@ Pod::Spec.new do |s|
   s.author   = { 'Brad Larson' => 'contact@sunsetlakesoftware.com' }
   s.source   = { :git => 'https://github.com/BradLarson/GPUImage.git', :tag => '0.1.0' }
   s.source_files = 'framework/Source/**/*.{h,m}'
+  s.osx.exclude_files = 'framework/Source/iOS/**/*.{h,m}'
+  s.ios.exclude_files = 'framework/Source/Mac/**/*.{h,m}'
   s.frameworks   = ['OpenGLES', 'CoreVideo', 'CoreMedia', 'QuartzCore', 'AVFoundation']
 
   s.requires_arc = true


### PR DESCRIPTION
The GPUImage podspec currently doesn't omit platform-specific framework directories. This commit fixes it by adding `exclude` arguments.
