### PR TITLE
CocoaPods Issue #1020: Omit CorePlotProbes.d

### DIFF
--- a/CorePlot/1.2/CorePlot.podspec
+++ b/CorePlot/1.2/CorePlot.podspec
@@ -14,11 +14,14 @@ Pod::Spec.new do |s|
                   'of data, and is tightly integrated with Apple technologies like Core Animation, ' \
                   'Core Data, and Cocoa Bindings.'
 
-  files = FileList['framework/TestResources/CorePlotProbes.d', 'framework/Source/*.{h,m}']
+  files = FileList['framework/Source/*.{h,m}']
   files.exclude(/(TestCase|Tests)\.[hm]/)
   s.ios.source_files = files.dup.include('framework/CorePlot-CocoaTouch.h', 'framework/iPhoneOnly/*.{h,m}')
   s.osx.source_files = files.dup.include('framework/CorePlot.h', 'framework/MacOnly/*.{h,m}')
 
-
   s.framework   = 'QuartzCore'
+  
+  s.pre_install do |pod, target_definition|
+    Dir.chdir(pod.root) {`/usr/sbin/dtrace -h -s framework/TestResources/CorePlotProbes.d -o framework/Source/CorePlotProbes.h`}
+  end
 end


### PR DESCRIPTION
CocoaPods Issue #1020: Omit CorePlotProbes.d, and generate CorePlotProbes.h in a preinstall hook.
