### PR TITLE
RestKit-0.10.3: Add missing implicit dependency; builds under 0.17+

### DIFF
--- a/RestKit/0.10.3/RestKit.podspec
+++ b/RestKit/0.10.3/RestKit.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
     js.dependency 'RestKit/Network'
     js.dependency 'RestKit/ObjectMapping/JSON'
     js.dependency 'RestKit/ObjectMapping/CoreData'
+    js.dependency 'RestKit/ObjectMapping'
     js.dependency 'RestKit/UI'
   end
 


### PR DESCRIPTION
Fixes https://github.com/CocoaPods/Specs/issues/1822
