### PR TITLE
Add CreateSend podspec version 1.1.1.

### DIFF
--- a/CreateSend/1.1.1/CreateSend.podspec
+++ b/CreateSend/1.1.1/CreateSend.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name                  = "CreateSend"
+  s.version               = "1.1.1"
+  s.summary               = "An Objective-C library for talking to the Campaign Monitor API from Cocoa & Cocoa Touch applications."
+  s.homepage              = "http://campaignmonitor.github.io/createsend-objectivec/"
+  s.license               = { :type => "MIT", :file => "LICENSE" }
+  s.authors               = { "Nathan de Vries" => "nathan@atnan.com", "Jonathan Younger" => "jonathan@daikini.com", "James Dennes" => "jdennes@gmail.com" }
+  s.source                = { :git => "https://github.com/campaignmonitor/createsend-objectivec.git", :tag => "v1.1.1" }
+  s.ios.deployment_target = "5.0"
+  s.osx.deployment_target = "10.7"
+  s.requires_arc          = true
+  s.source_files          = "CreateSend", "Vendor/**/*.{h,m}"
+  s.osx.exclude_files     = "CreateSend/*iOS.*", "CreateSend/CSAuthorizationViewController.*"
+  s.prefix_header_file    = "CreateSend/CreateSend-Prefix.pch"
+end


### PR DESCRIPTION
Initial version of the CreateSend Objective-C library for distribution on CocoaPods.
