### PR TITLE
Fix license for SBJson.

### DIFF
--- a/SBJson/3.2/SBJson.podspec
+++ b/SBJson/3.2/SBJson.podspec
@@ -1,7 +1,33 @@
 Pod::Spec.new do |s|
   s.name     = 'SBJson'
   s.version  = '3.2'
-  s.license = { :type => 'BSD', :file => 'README.md' }
+  s.license = { :type => 'BSD', :text => <<-LICENSE
+    Copyright (C) 2007-2013 Stig Brautaset. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this
+      list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of the author nor the names of its contributors may be used
+      to endorse or promote products derived from this software without specific
+      prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    LICENSE
+  }
   s.summary  = 'This library implements strict JSON parsing and generation in Objective-C.'
   s.homepage = 'http://stig.github.com/json-framework/'
   s.author   = { 'Stig Brautaset' => 'stig@brautaset.org' }


### PR DESCRIPTION
The podspec was using the README as the license file. This caused the entire README to be included in the acknowledgements.

I've changed the podspec to include a copy of the license only.
