### PR TITLE
Update AFNetworking.podspec

### DIFF
--- a/AFNetworking/1.2.1/AFNetworking.podspec
+++ b/AFNetworking/1.2.1/AFNetworking.podspec
@@ -16,9 +16,10 @@ Pod::Spec.new do |s|
   s.osx.frameworks = 'CoreServices', 'SystemConfiguration', 'Security'
 
   s.prefix_header_contents = <<-EOS
-#import <Availability.h>
-
 #define _AFNETWORKING_PIN_SSL_CERTIFICATES_
+
+#ifdef __OBJC__
+#import <Availability.h>
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED
   #import <SystemConfiguration/SystemConfiguration.h>
@@ -26,6 +27,7 @@ Pod::Spec.new do |s|
 #else
   #import <SystemConfiguration/SystemConfiguration.h>
   #import <CoreServices/CoreServices.h>
+#endif
 #endif
 EOS
 end


### PR DESCRIPTION
This commit readds the **OBJC** guard to the PCH generated by AFNetworking.podspec
