### PR TITLE
Projects using the CreateSend pod must link against the Security framework.

### DIFF
--- a/CreateSend/1.1.1/CreateSend.podspec
+++ b/CreateSend/1.1.1/CreateSend.podspec
@@ -5,11 +5,12 @@ Pod::Spec.new do |s|
   s.homepage              = "http://campaignmonitor.github.io/createsend-objectivec/"
   s.license               = { :type => "MIT", :file => "LICENSE" }
   s.authors               = { "Nathan de Vries" => "nathan@atnan.com", "Jonathan Younger" => "jonathan@daikini.com", "James Dennes" => "jdennes@gmail.com" }
-  s.source                = { :git => "https://github.com/campaignmonitor/createsend-objectivec.git", :tag => "v1.1.1" }
+  s.source                = { :git => "https://github.com/campaignmonitor/createsend-objectivec.git", :tag => "v#{s.version}" }
   s.ios.deployment_target = "5.0"
   s.osx.deployment_target = "10.7"
   s.requires_arc          = true
   s.source_files          = "CreateSend", "Vendor/**/*.{h,m}"
   s.osx.exclude_files     = "CreateSend/*iOS.*", "CreateSend/CSAuthorizationViewController.*"
+  s.frameworks            = "Security"
   s.prefix_header_file    = "CreateSend/CreateSend-Prefix.pch"
 end


### PR DESCRIPTION
This fixes the current pod for CreateSend version 1.1.1.

The pod now correctly specifies that projects should link against the Security framework.

No changes to the CreateSend library have been made.
