### PR TITLE
Nimbus 1.0.0 delete ios sdk 5.0 option

### DIFF
--- a/Nimbus/1.0.0/Nimbus.podspec
+++ b/Nimbus/1.0.0/Nimbus.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
                   'that accelerates the development process of any application by being easy to use and '   \
                   'simple to understand.'
 
-  s.platform = :ios, '5.0'
+  s.platform = :ios
 
   s.requires_arc = true
 


### PR DESCRIPTION
I rebuilt nimbus source in ios sdk 4.3 and it performed correctly without compile error.So I think the ios 5.0 is unnecessary.
