### PR TITLE
Omit CorePlotProbes.d from CorePlot 1.2 source.

### DIFF
--- a/CorePlot/1.2/CorePlot.podspec
+++ b/CorePlot/1.2/CorePlot.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
                   'of data, and is tightly integrated with Apple technologies like Core Animation, ' \
                   'Core Data, and Cocoa Bindings.'
 
-  s.source_files = 'framework/TestResources/CorePlotProbes.d', 'framework/Source/*.{h,m}'
+  s.source_files = 'framework/Source/*.{h,m}'
   s.exclude_files = '**/*{TestCase,Tests}.{h,m}'
   s.ios.source_files = 'framework/CorePlot-CocoaTouch.h', 'framework/iPhoneOnly/*.{h,m}'
   s.osx.source_files = 'framework/CorePlot.h', 'framework/MacOnly/*.{h,m}'


### PR DESCRIPTION
1.1 and 1.0 could probably use this too, but they require the preinstall hook and I haven't had a chance to test them.
