### PR TITLE
SCNetworkReachability version 1.2.0

### DIFF
--- a/SCNetworkReachability/1.2.0/SCNetworkReachability.podspec
+++ b/SCNetworkReachability/1.2.0/SCNetworkReachability.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = "SCNetworkReachability"
+  s.version      = "1.2.0"
+  s.summary      = "Painless network reachability with delegate and blocks support."
+  s.homepage     = "https://github.com/belkevich/reachability-ios"
+  s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }
+  s.author       = { "Alexey Belkevich" => "belkevich.alexey@gmail.com" }
+  s.source       = { :git => "https://github.com/belkevich/reachability-ios.git",
+		     :tag => "1.2.0"}
+  s.platform     = :ios
+  s.source_files = '*.{h,m}'
+  s.framework  = 'SystemConfiguration', 'Foundation'
+  s.ios.deployment_target = "5.0"
+  s.osx.deployment_target = "10.7"
+  s.requires_arc = true
+end


### PR DESCRIPTION
- added OS X support
- added ability to use block instead of delegate
- changed reachability check in asynchronous way
- improved thread safety, delegate or block will be called in thread where reachability instance was created
