### PR TITLE
Update spec of MoPubSDK with 1.12.1.0

### DIFF
--- a/MoPubSDK/1.12.1.0/MoPubSDK.podspec
+++ b/MoPubSDK/1.12.1.0/MoPubSDK.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = 'MoPubSDK'
+  s.version      = '1.12.1.0'
+  s.license      = {:type => 'New BSD'}
+  s.platform     = :ios
+
+  s.summary      = 'MoPubSDK to add banners, custom sizes and interstitials to iOS apps.'
+  s.homepage     = 'http://www.mopub.com'
+  s.author       = {'MoPub' => 'http://www.mopub.com'}
+  s.source       = {:git => "https://github.com/mopub/mopub-ios-sdk.git", :tag => '1.12.1.0'}
+
+  s.source_files = 'MoPubSDK/**/*.{h,m,c}'
+  s.resources = 'MoPubSDK/**/*.{png,xib}'
+  s.frameworks    = 'UIKit', 'Foundation', 'StoreKit', 'CoreLocation', 'CoreGraphics', 'SystemConfiguration', 'AdSupport', 'CoreTelephony', 'QuartzCore'
+  s.dependency 'TouchJSON', '~> 1.0'
+end


### PR DESCRIPTION
old pull request: https://github.com/CocoaPods/Specs/pull/2289

Hi, I added MoPubSDK 1.12.1.0 spec.
I made some improvements compared with the above old pull request.
- Old pull request had some missed files. That is fixed
- Old pull request had an old MoPubSDK version (1.12.0.1). Now is 1.12.1.0

Also I've checked by `rake lint`
and I integrated MoPubSDK successfully by using this spec.

Best regards,
