### PR TITLE
Removed version definition for CocoaAsyncSocket

### DIFF
--- a/CocoaHTTPServer/2.3/CocoaHTTPServer.podspec
+++ b/CocoaHTTPServer/2.3/CocoaHTTPServer.podspec
@@ -9,6 +9,9 @@ Pod::Spec.new do |s|
   s.source_files = '{Core,Extensions}/**/*.{h,m}'
   s.requires_arc = true
 
+  s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.7'
+
   s.ios.frameworks = 'CFNetwork', 'Security'
   s.osx.frameworks = 'CoreServices', 'Security'
 

--- a/CocoaHTTPServer/2.3/CocoaHTTPServer.podspec
+++ b/CocoaHTTPServer/2.3/CocoaHTTPServer.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.library = 'xml2'
   s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
 
-  s.dependency "CocoaAsyncSocket", "~> 0.0.1"
+  s.dependency "CocoaAsyncSocket"
   s.dependency "CocoaLumberjack"
 end


### PR DESCRIPTION
Robbie Hanson has updated the version number of CocoaAsyncSocket which makes it difficult to integrate this pod because of the version definition. I've removed the version requirement, it is compatible with the latest release.
