### PR TITLE
[Fix] Update Nimbus.spec due to backward compatibility issue of the framework build setting

### DIFF
--- a/Nimbus/0.9.2/Nimbus.podspec
+++ b/Nimbus/0.9.2/Nimbus.podspec
@@ -27,8 +27,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'AttributedLabel' do |label|
     label.source_files = 'src/attributedlabel/src'
-    label.framework    = 'CoreText'
-    label.framework    = 'CoreGraphics'
+    label.frameworks    = 'CoreText', 'CoreGraphics'
   end
 
   s.subspec 'Interapp' do |interapp|

--- a/Nimbus/0.9.3/Nimbus.podspec
+++ b/Nimbus/0.9.3/Nimbus.podspec
@@ -37,8 +37,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'AttributedLabel' do |label|
     label.source_files = 'src/attributedlabel/src'
-    label.framework    = 'CoreText'
-    label.framework    = 'CoreGraphics'
+    label.frameworks    = 'CoreText', 'CoreGraphics'
     label.dependency 'Nimbus/Core'
   end
 

--- a/Nimbus/1.0.0/Nimbus.podspec
+++ b/Nimbus/1.0.0/Nimbus.podspec
@@ -44,8 +44,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'AttributedLabel' do |label|
     label.source_files = 'src/attributedlabel/src'
-    label.framework    = 'CoreText'
-    label.framework    = 'CoreGraphics'
+    label.frameworks    = 'CoreText','CoreGraphics'
     label.dependency 'Nimbus/Core'
   end
 


### PR DESCRIPTION
multiple 'framework' settings is no longer valid way to specify multiple frameworks. Use 'frameworks' setting instead.
