### PR TITLE
Moved FESSolarCalculator to a GitHub organization

### DIFF
--- a/FESSolarCalculator/0.1.0/FESSolarCalculator.podspec
+++ b/FESSolarCalculator/0.1.0/FESSolarCalculator.podspec
@@ -3,9 +3,9 @@ Pod::Spec.new do |s|
   s.version  = '0.1.0'
   s.license  = { :type => 'MIT', :file => 'LICENSE' }
   s.summary  = 'Calculate sunrise, sunset, and twilight times for a given location and date.'
-  s.homepage = 'https://github.com/danimal/FESSolarCalculator'
+  s.homepage = 'https://github.com/FriskyElectrocat/FESSolarCalculator'
   s.author   = { 'danimal' => 'dan@danimal.org' }
-  s.source   = { :git => 'https://github.com/danimal/FESSolarCalculator.git', :tag => '0.1.0' }
+  s.source   = { :git => 'https://github.com/FriskyElectrocat/FESSolarCalculator.git', :tag => '0.1.0' }
   s.description = 'Calculate sunrise, sunset, and twilight times for a given location and date. Provides sunrise, sunset, solar noon, civil twilight, nautical twilight, and astronomical twilight times. Calculations can be limited to only those the developer is interested in.'
   s.requires_arc = true
   s.framework    = 'CoreLocation'


### PR DESCRIPTION
Updated the homepage and source urls to reflect the move. GitHub will do redirects but it's better to change them to avoid confusion later.
