### PR TITLE
Fix for the static library linking for AdMob SDK

### DIFF
--- a/AdMob/6.4.1/AdMob.podspec
+++ b/AdMob/6.4.1/AdMob.podspec
@@ -19,5 +19,5 @@ LICENSE
   s.frameworks = 'AudioToolbox', 'MessageUI', 'SystemConfiguration', 'CoreGraphics', 'StoreKit'
   s.weak_frameworks = 'AdSupport'
   s.library = 'GoogleAdMobAds'
-  s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' , 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/AdMob/"'}
+  s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' , 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/AdMob"'}
 end


### PR DESCRIPTION
This fixes the library search path for AdMob's static library so that it will get compiled correctly.
