### PR TITLE
added a forecast-ios-api 0.0.2 spec

### DIFF
--- a/forecast-ios-api/0.0.2/forecast-ios-api.podspec
+++ b/forecast-ios-api/0.0.2/forecast-ios-api.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name         = "forecast-ios-api"
+  s.version      = "0.0.2"
+  s.summary      = "A simple Objective-C wrapper for the Forecast.io API."
+  s.homepage     = "https://github.com/okitsutakatomo/forecast-ios-api"
+  s.license      = 'MIT'
+  s.author       = { "takatomo okitsu" => "okitsu.takatomo.m@gmail.com" }
+  s.source       = { :git => "https://github.com/okitsutakatomo/forecast-ios-api.git", :tag => "0.0.2" }
+  s.platform     = :ios, '5.0'
+  s.source_files = 'Forecast'
+  s.framework  = 'CoreLocation'
+  s.requires_arc = true
+  s.dependency 'AFNetworking'
+end


### PR DESCRIPTION
added a forecast-ios-api 0.0.2 spec.

Could you allow git commit and push?
