### PR TITLE
Update ZBarSDK.podspec

### DIFF
--- a/ZBarSDK/1.3.1/ZBarSDK.podspec
+++ b/ZBarSDK/1.3.1/ZBarSDK.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
   s.public_header_files = 'iphone/**/**/*.h', 'include/*.h'
 
-  s.source_files = 'include/zbar.h', 'zbar/**/*.h', 'iphone/*.h', 'iphone/include/**/*.h',
+  s.source_files = 'include/zbar.h', 'include/zbar/*.h', 'zbar/**/*.h', 'iphone/*.h', 'iphone/include/**/*.h',
                    'zbar/{config,decoder,error,image,img_scanner,refcnt,scanner,symbol}.c',
                    'zbar/decoder/{codabar,code39,code93,code128,databar,ean,i25,qr_finder}.c',
                    'zbar/qrcode/*.c',


### PR DESCRIPTION
I get a compilation error: 'zbar/Exception.h' file not found.
From what I see header file were not included.
