### PR TITLE
Fixed resources path in vungle sdk

### DIFF
--- a/VungleAdvertiserSDK/1.2.1/VungleAdvertiserSDK.podspec
+++ b/VungleAdvertiserSDK/1.2.1/VungleAdvertiserSDK.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.author = { 'Vungle' => 'support@vungle.com' }
   s.source = { :http => 'https://github.com/downloads/Vungle/AdvertiserSDK/vungle121.zip' }
   s.platform = :ios
-  s.resources  = 'vungle/lib/vunglepub/resources'
+  s.resources  = 'vungle/lib/vunglepub/resources/*.png'
   s.header_dir = 'headers'
   s.header_mappings_dir = 'vungle/lib/vunglepub/headers'  
   s.source_files = 'vungle/lib/vunglepub/*.h', 'vungle/lib/vunglepub/headers/*.h'


### PR DESCRIPTION
Old:
 s.resources  = 'vungle/lib/vunglepub/resources'
New:
  s.resources  = 'vungle/lib/vunglepub/resources/*.png'

Without this '/*.png' in path it completely broke build in  Step: Copy Pods Resources 
looks like script Pods-resources.sh does not work properly with folder paths
Please review it.
