### PR TITLE
Add versioned fork of WEPopover.

### DIFF
--- a/WEPopover@krzd/0.1.0/WEPopover@krzd.podspec
+++ b/WEPopover@krzd/0.1.0/WEPopover@krzd.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         =  'WEPopover@krzd'
+  s.version      =  '0.1.0'
+  s.platform     =  :ios
+  s.summary      =  'Versioned fork of WEPopover.'
+  s.description  =  'Versioned fork of WEPopover. Generic popover implementation for iOS with same API as the UIPopoverController for the iPad, but configurable with custom background and available for iPhone as well.'
+  s.homepage     =  'https://github.com/werner77/WEPopover'
+  s.author       =  { 'Werner Altewischer' => 'http://www.werner-it.com/' }
+  s.license      =  'MIT'
+  s.source       =  { :git => 'https://github.com/krzd/WEPopover.git', :tag => '0.1.0' }
+  s.resources    =  '*.png'
+  s.source_files =  'Classes/**/*.*'
+end


### PR DESCRIPTION
The maintainer is not adding versioned tags, although an issue has been created some time ago.
I want to add this versioned fork, to be able to access the latest revision of WEPopover through CocoaPods, which makes WEPopover compatible with the latest SDK.
