### PR TITLE
Update libffi.podspec

### DIFF
--- a/libffi/3.0.13/libffi.podspec
+++ b/libffi/3.0.13/libffi.podspec
@@ -15,5 +15,4 @@ Pod::Spec.new do |s|
   s.ios.source_files = 'ios/include/*.h', 'ios/src/arm/*.{c,S}', 'ios/src/x86/*.{c,S}', 'ios/src/{closures,debug,prep_cif,raw_api,types}.c'
   s.osx.preserve_paths = 'osx/src/dlmalloc.c'
   s.osx.source_files = 'osx/include/*.h', 'osx/src/x86/*.{c,S}', 'osx/src/{closures,debug,prep_cif,raw_api,types}.c'
-  s.xcconfig    = { 'OTHER_LDFLAGS' => "-Wl,-no_compact_unwind" }
 end


### PR DESCRIPTION
no_compact_unwind is no longer supported since ld64-134.9:
http://opensource.apple.com/source/ld64/ld64-134.9/src/ld/Options.cpp

It should be removed from the Podspec as it causes builds to fail.
