### PR TITLE
Adding podspec for TapkuLibrary 0.2.4

### DIFF
--- a/TapkuLibrary/0.2.4/TapkuLibrary.podspec
+++ b/TapkuLibrary/0.2.4/TapkuLibrary.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name          = 'TapkuLibrary'
+  s.version       = '0.2.4'
+  s.platform      = :ios
+  s.author        = { 'Devin Ross' => 'devin@devinsheaven.com' }
+  s.license       = { :type => 'MIT', :file => 'License.txt' }
+  s.homepage      = 'https://github.com/devinross/tapkulibrary'
+  s.summary       = 'tap + haiku = tapku, a well crafted open source iOS framework.'
+  s.description   = 'TapkuLibrary is an iOS library built on Cocoa and UIKit intended for broad ' \
+                    'use in applications. If you\'re looking to see what the library can do, check ' \
+                    'out the demo project included. Some major components include coverflow, calendar ' \
+                    'grid, network requests and progress indicators.'
+  s.source        = { :git => 'https://github.com/devinross/tapkulibrary.git', :tag => 'v0.2.4' }
+  s.requires_arc  = true
+  s.source_files  = 'src/TapkuLibrary/*.{h,m}'
+  s.resources     = 'src/TapkuLibrary.bundle'
+  s.frameworks    = 'QuartzCore'
+end


### PR DESCRIPTION
This adds the podspec for the newest version of [TapkuLibrary](https://github.com/devinross/tapkulibrary).

It's the newest version from the root of that repo, with a minor change to pass `pod lint` validation (adding a period at the end of the summary). I've submitted a [pull request](https://github.com/devinross/tapkulibrary/pull/239) to that project to update the podspec in that repo too.
