### PR TITLE
Add KISSmetrics v1.1.3

### DIFF
--- a/KISSmetrics/1.0.0/KISSmetrics.podspec
+++ b/KISSmetrics/1.0.0/KISSmetrics.podspec
@@ -5,6 +5,6 @@ Pod::Spec.new do |s|
   s.summary  = 'Library for KISSmetrics.'
   s.homepage = 'http://www.kissmetrics.com'
   s.author   = { 'kissmetrics' => 'support@kissmetrics.com' }
-  s.source   = { :git => 'https://github.com/enriquez/KISSmetrics-iOS-Mac-OS-X-Library.git', :tag => '1.0.0' }
+  s.source   = { :git => 'https://github.com/kissmetrics/KISSmetrics-iOS-Mac-OS-X-Library.git', :tag => 'v1.0.0' }
   s.source_files = '*.{h,m}'
 end

--- a/KISSmetrics/1.1.3/KISSmetrics.podspec
+++ b/KISSmetrics/1.1.3/KISSmetrics.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name     = 'KISSmetrics'
   s.version  = '1.1.3'
-  s.license  = 'MIT'
+  s.license  = { :type => 'MIT', :file => 'LICENSE' }
   s.summary  = 'Library for KISSmetrics.'
   s.homepage = 'http://www.kissmetrics.com'
   s.author   = { 'kissmetrics' => 'support@kissmetrics.com' }

--- a/KISSmetrics/1.1.3/KISSmetrics.podspec
+++ b/KISSmetrics/1.1.3/KISSmetrics.podspec
@@ -1,0 +1,10 @@
+Pod::Spec.new do |s|
+  s.name     = 'KISSmetrics'
+  s.version  = '1.1.3'
+  s.license  = 'MIT'
+  s.summary  = 'Library for KISSmetrics.'
+  s.homepage = 'http://www.kissmetrics.com'
+  s.author   = { 'kissmetrics' => 'support@kissmetrics.com' }
+  s.source   = { :git => 'https://github.com/kissmetrics/KISSmetrics-iOS-Mac-OS-X-Library.git', :tag => 'v1.1.3' }
+  s.source_files = '*.{h,m}'
+end


### PR DESCRIPTION
In addition to the new version, this updates the v1.0.0 spec to use the correct repository. See #2385 for background.
