### PR TITLE
Fix PayPalMPL 2.0.0 spec

### DIFF
--- a/PayPalMPL/2.0.0/PayPalMPL.podspec
+++ b/PayPalMPL/2.0.0/PayPalMPL.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = "#{file_name}/Library/*.a"
   # s.frameworks = 'Security'
   # s.weak_frameworks = 'PassKit'
-  s.libraries   = 'PayPalMPL', 'xml2', 'iconv', 'z'
+  s.libraries   = 'xml2', 'iconv', 'z'
   s.xcconfig  =  {'LIBRARY_SEARCH_PATHS' => "$(PODS_ROOT)/PayPalMPL/#{file_name}/Library"}
   # s.requires_arc = true
 end


### PR DESCRIPTION
Current spec includes _itself_ in the libraries dependencies list. This cause a linker duplicate symbol error. Fixed here.
