### PR TITLE
Added podspec for MBPopoverBackgroundView

### DIFF
--- a/MBPopoverBackgroundView/0.1.0/MBPopoverBackgroundView.podspec
+++ b/MBPopoverBackgroundView/0.1.0/MBPopoverBackgroundView.podspec
@@ -1,0 +1,15 @@
+# podspec for MBPopoverBackgroundView
+
+Pod::Spec.new do |s|
+  s.name         =  'MBPopoverBackgroundView'
+  s.version      =  '0.1.0'
+  s.platform     =  :ios
+  s.license      =  { :type => 'MIT' }
+  s.summary      =  'Class to implement custom UIPopoverController background view.'
+  s.description  =  'MBPopoverBackgroundView is subclass of UIPopoverBackgroundView with methods for flexible customization of the iOS popover look and feel.'
+  s.homepage     =  'https://github.com/mgrebenets/mbpopoverbackgroundview.git'
+  s.author       =  'Maksym Grebenets'
+  s.source       =  { :git => 'https://github.com/mgrebenets/mbpopoverbackgroundview.git', :tag => '0.1.0' }
+  s.source_files =  'custom-popover-background/MBPopoverBackgroundView/**/*.{h,m}'
+  s.requires_arc =  true
+end


### PR DESCRIPTION
Custom `UIPopoverController` background view for iOS.
Implements custom subclass of `UIPopoverBackgroundView` as described in iOS Developer documentation
- [UIPopoverController Class Reference](https://developer.apple.com/library/ios/#documentation/UIKit/Reference/UIPopoverController_class/Reference/Reference.html#//apple_ref/occ/cl/UIPopoverController) 
- [UIPopoverBackgroundView Class Reference](https://developer.apple.com/library/ios/#documentation/UIKit/Reference/UIPopoverBackgroundView_class/Reference/Reference.html#//apple_ref/occ/cl/UIPopoverBackgroundView)
- [View Controller Catalog for iOS - Popover](https://developer.apple.com/library/ios/#documentation/WindowsViews/Conceptual/ViewControllerCatalog/Chapters/Popovers.html)
- [iPad-Specific Controllers](https://developer.apple.com/library/ios/#documentation/WindowsViews/Conceptual/ViewControllerPGforiOSLegacy/iPadControllers/iPadControllers.html)
