### PR TITLE
FlurrySDK depends on the UIKit framework

### DIFF
--- a/FlurrySDK/4.2.1/FlurrySDK.podspec
+++ b/FlurrySDK/4.2.1/FlurrySDK.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.preserve_paths = '**/*.a'
   s.library = 'Flurry'
   s.xcconfig  =  { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/FlurrySDK/Flurry"' }
-  s.framework = 'SystemConfiguration'
+  s.framework = 'SystemConfiguration', 'UIKit'
 end


### PR DESCRIPTION
I was getting:

```
Undefined symbols for architecture i386:
  "_CGRectContainsPoint", referenced from:
      +[FlurryUtil viewIsVisible:] in libFlurry.a(libFlurry.a-i386-master.o)
  "_CGRectGetMidX", referenced from:
      +[FlurryUtil viewIsVisible:] in libFlurry.a(libFlurry.a-i386-master.o)
  "_CGRectGetMidY", referenced from:
      +[FlurryUtil viewIsVisible:] in libFlurry.a(libFlurry.a-i386-master.o)
ld: symbol(s) not found for architecture i386
```
