### PR TITLE
exlude utility executables from proj4 so we don't link unnecessary main methods

### DIFF
--- a/proj4/4.8.0/proj4.podspec
+++ b/proj4/4.8.0/proj4.podspec
@@ -53,5 +53,5 @@ CONFIG_H
   end
 
   s.source_files = "proj/src/*.{c,h}"
-  s.exclude_files = "proj.c", "nad2bin.c", "multistresstest.c", "geod.c", "cs2cs.c"
+  s.exclude_files = "**/proj.c", "**/nad2bin.c", "**/multistresstest.c", "**/geod.c", "**/cs2cs.c"
 end

--- a/proj4/4.8.0/proj4.podspec
+++ b/proj4/4.8.0/proj4.podspec
@@ -53,5 +53,5 @@ CONFIG_H
   end
 
   s.source_files = "proj/src/*.{c,h}"
-
+  s.exclude_files = "proj.c", "nad2bin.c", "multistresstest.c", "geod.c", "cs2cs.c"
 end


### PR DESCRIPTION
this solves my problem linking after including the ShapeKit pod which depends on proj4 with duplicate symbol main.  it doesn't fix the other unrelated ShapeKit dependency problem (Assert.h collision with geos pod on cocoapods 0.21).
