### PR TITLE
Fixes podspec for drupal-ios-sdk

### DIFF
--- a/drupal-ios-sdk/2.0.2/drupal-ios-sdk.podspec
+++ b/drupal-ios-sdk/2.0.2/drupal-ios-sdk.podspec
@@ -5,9 +5,8 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/workhabitinc/drupal-ios-sdk"
   s.author       = { "Kyle Browning" => "kylebrowning@me.com" }
   s.source       = { :git => "https://github.com/workhabitinc/drupal-ios-sdk.git", :tag => "2.0.2" }
-  s.requires_arc = false
-  #s.osx.deployment_target = '10.7'
-  #s.source_files = 'DIOS*.*'
+  s.requires_arc = true
+  s.ios.deployment_target = '5.0' 
   s.license  = 'MPL 1.1/GPL 2.0'
   s.dependency 'AFNetworking', '~> 1.3.0'
   s.dependency 'JSONKit', '~> 1.4'

--- a/drupal-ios-sdk/2.0.2/drupal-ios-sdk.podspec
+++ b/drupal-ios-sdk/2.0.2/drupal-ios-sdk.podspec
@@ -6,8 +6,8 @@ Pod::Spec.new do |s|
   s.author       = { "Kyle Browning" => "kylebrowning@me.com" }
   s.source       = { :git => "https://github.com/workhabitinc/drupal-ios-sdk.git", :tag => "2.0.2" }
   s.requires_arc = false
-  s.osx.deployment_target = '10.7'
-#  s.source_files = 'DIOS*.*'
+  #s.osx.deployment_target = '10.7'
+  #s.source_files = 'DIOS*.*'
   s.license  = 'MPL 1.1/GPL 2.0'
   s.dependency 'AFNetworking', '~> 1.3.0'
   s.dependency 'JSONKit', '~> 1.4'

--- a/drupal-ios-sdk/2.0.3/drupal-ios-sdk.podspec
+++ b/drupal-ios-sdk/2.0.3/drupal-ios-sdk.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/workhabitinc/drupal-ios-sdk"
   s.author       = { "Kyle Browning" => "kylebrowning@me.com" }
   s.source       = { :git => "https://github.com/workhabitinc/drupal-ios-sdk.git", :tag => "2.0.3" }
-  s.requires_arc = false
+  s.requires_arc = true
   s.ios.deployment_target = '5.0'
   s.license  = 'MPL 1.1/GPL 2.0'
   s.dependency 'AFNetworking', '~> 1.3.0'

--- a/drupal-ios-sdk/2.0.3/drupal-ios-sdk.podspec
+++ b/drupal-ios-sdk/2.0.3/drupal-ios-sdk.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name         = "drupal-ios-sdk"
+  s.version      = "2.0.3"
+  s.summary      = "A framework for communicating to Drupal via an iPhone."
+  s.homepage     = "https://github.com/workhabitinc/drupal-ios-sdk"
+  s.author       = { "Kyle Browning" => "kylebrowning@me.com" }
+  s.source       = { :git => "https://github.com/workhabitinc/drupal-ios-sdk.git", :tag => "2.0.3" }
+  s.requires_arc = false
+  s.ios.deployment_target = '5.0'
+  s.license  = 'MPL 1.1/GPL 2.0'
+  s.dependency 'AFNetworking', '~> 1.3.0'
+  s.dependency 'JSONKit', '~> 1.4'
+
+end


### PR DESCRIPTION
Updates 2.0.2 podspec to no longer look for OS X requirment.
Adds 2.0.3 podspec.
