### PR TITLE
Add podspec for UITextView+UIControl v0.1.0

### DIFF
--- a/UITextView+UIControl/0.1.0/UITextView+UIControl.podspec
+++ b/UITextView+UIControl/0.1.0/UITextView+UIControl.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name         =  'UITextView+UIControl'
+  s.summary      = 'A UIControl-like API addition to UITextView.'
+  s.homepage     = 'https://github.com/andrewsardone/UITextView-UIControl'
+  s.source       = { :git => 'https://github.com/andrewsardone/UITextView-UIControl.git', :tag => '0.1.0' }
+  s.version      =  '0.1.0'
+  s.authors      = { 'Andrew Sardone' => 'andrew@andrewsardone.com' }
+  s.license      = 'MIT'
+  s.source_files = "Classes"
+  s.platform     = :ios
+end


### PR DESCRIPTION
Adds a [UIControl-like](https://github.com/andrewsardone/UITextView-UIControl) API addition to UITextView, currently limited to the target-action methods.
