### PR TITLE
ShapeKit: add geos include folder in the HEADER_SEARCH_PATHS 

### DIFF
--- a/ShapeKit/0.9.0/ShapeKit.podspec
+++ b/ShapeKit/0.9.0/ShapeKit.podspec
@@ -24,6 +24,6 @@ Pod::Spec.new do |s|
 
   s.framework = 'CoreLocation'
 
-  s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC -lstdc++' }
+  s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC -lstdc++', 'HEADER_SEARCH_PATHS' => '${PODS_ROOT}/geos/include ${PODS_ROOT}/geos/capi' }
 
 end


### PR DESCRIPTION
This is a workaround for the new way cocoapods 0.22.1 manages submodules. See #2614
