### PR TITLE
[Update] Bump socket.IO up to 0.3.3

### DIFF
--- a/socket.IO/0.3.3/socket.IO.podspec
+++ b/socket.IO/0.3.3/socket.IO.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name         = "socket.IO"
+  s.version      = "0.3.3"
+  s.summary      = "socket.io v0.7.2+ for iOS devices."
+  s.description  = <<-DESC
+    Interface to communicate between Objective C and Socket.IO with the help of websockets. It's based on fpotter's socketio-cocoa and uses other libraries/classes like SocketRocket, json-framework (optional) and jsonkit (optional).
+                   DESC
+  s.homepage     = "https://github.com/pkyeck/socket.IO-objc"
+  s.license      = 'MIT'
+
+  s.author       = { "Philipp Kyeck" => "philipp@beta-interactive.de" }
+  s.source       = { :git => "https://github.com/pkyeck/socket.IO-objc.git", :tag => '0.3.3' }
+
+  s.source_files = '*.{h,m}'
+
+  s.requires_arc = true
+
+  s.dependency 'SocketRocket', '~> 0.2'
+end


### PR DESCRIPTION
I don't have push access to CocoaPods/Specs yet and noticed socket.IO was out of date. This is a bump.
