### PR TITLE
Add podspec file for PJLinkCocoa, a library for communicating with projectors that implement the PJLink protocol.

### DIFF
--- a/PJLinkCocoa/0.9/PJLinkCocoa.podspec
+++ b/PJLinkCocoa/0.9/PJLinkCocoa.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name         = 'PJLinkCocoa'
+  s.version      = '0.9'
+  s.license      = 'MIT'
+  s.summary      = 'A Cocoa Library for communicating with projectors and other devices that implement the PJLink protocol.'
+  s.homepage     = 'https://github.com/ehyche/pjlink-cocoa'
+  s.author       = { "Eric Hyche" => "ehyche@gmail.com" }
+  s.source       = { :git => "https://github.com/ehyche/pjlink-cocoa.git", :tag => '0.9' }
+  s.source_files = 'PJLinkCocoa'
+  s.requires_arc = true
+  s.platform     = :ios, '5.0'
+  s.frameworks   = 'MobileCoreServices', 'SystemConfiguration', 'Security'
+  s.dependency 'AFNetworking', '~> 1.3.0'
+  s.dependency 'CocoaAsyncSocket', '~> 7.0'
+end


### PR DESCRIPTION
Initial version is 0.9
