### PR TITLE
Removed $(inherited) from Podspec GCC_PREPROCESSOR_DEFINITIONS

### DIFF
--- a/ZBarSDK/1.3.1/ZBarSDK.podspec
+++ b/ZBarSDK/1.3.1/ZBarSDK.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
 
   s.xcconfig = { "EXCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos*][arch=*]"        => 'ZBarReaderViewImpl_Simulator.m',
                  "EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator*][arch=*]" => 'ZBarReaderViewImpl_Capture.m ZBarCaptureReader.m',
-                 "GCC_PREPROCESSOR_DEFINITIONS"                             => '$(inherited) NDEBUG=1' }
+                 "GCC_PREPROCESSOR_DEFINITIONS"                             => 'NDEBUG=1' }
 
   s.prefix_header_file = 'iphone/include/prefix.pch'
 


### PR DESCRIPTION
Cocoapods already includes $(inherited) in GCC_PREPROCESSOR_DEFINITIONS, it shouldn't be re-added here.
