### PR TITLE
Update Airbrake-iOS podspec header search paths

### DIFF
--- a/Airbrake-iOS/3.1.0/Airbrake-iOS.podspec
+++ b/Airbrake-iOS/3.1.0/Airbrake-iOS.podspec
@@ -34,5 +34,6 @@ Pod::Spec.new do |s|
   s.frameworks   = 'SystemConfiguration'  
   s.libraries    = 'xml2'
   s.dependency   'KissXML'
+  s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '"$(SDKROOT)/usr/include/libxml2"' }
 end
 

--- a/Airbrake-iOS/3.1.0/Airbrake-iOS.podspec
+++ b/Airbrake-iOS/3.1.0/Airbrake-iOS.podspec
@@ -26,7 +26,30 @@ Pod::Spec.new do |s|
   s.summary      = "A Airbrake Notifier for iOS."
   s.homepage     = "http://airbrake.io/pages/ios-notifier"
   s.author       = { "Airbrake" => "support@airbrake.io" }
-  s.license      = { :type => 'MIT' }
+  s.license      = { :type => 'MIT', :text => <<-LICENSE
+
+                 Copyright (C) 2011 GUI Cocoa, LLC.
+                 
+                 Permission is hereby granted, free of charge, to any person obtaining a copy
+                 of this software and associated documentation files (the "Software"), to deal
+                 in the Software without restriction, including without limitation the rights
+                 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                 copies of the Software, and to permit persons to whom the Software is
+                 furnished to do so, subject to the following conditions:
+                 
+                 The above copyright notice and this permission notice shall be included in
+                 all copies or substantial portions of the Software.
+                 
+                 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+                 THE SOFTWARE.
+
+LICENSE
+}  
   s.platform     = :ios
   s.source       = { :git => "https://github.com/airbrake/airbrake-ios.git", :tag => "3.1.0" }
   s.source_files = 'Airbrake/{notifier,gcalertview}/*.{h,m}'


### PR DESCRIPTION
This updates the podspec for Airbrake-iOS so it can find the tree.h header from libxml2.

This issue explains the problem:
https://github.com/CocoaPods/CocoaPods/issues/1141
