### PR TITLE
Change CorePlot source from Mercurial to zip file

### DIFF
--- a/CorePlot/1.3/CorePlot.podspec
+++ b/CorePlot/1.3/CorePlot.podspec
@@ -8,7 +8,8 @@ Pod::Spec.new do |s|
                  'Brad Larson'    => 'larson@sunsetlakesoftware.com',
                  'Eric Skroch'    => 'eskroch@mac.com',
                  'Barry Wark'     => 'barrywark@gmail.com' }
-  s.source   = { :hg  => 'http://code.google.com/p/core-plot', :revision => 'release_1.3' }
+
+  s.source   = { :http => 'https://core-plot.googlecode.com/files/CorePlot_1.3.zip' }
 
   s.description = 'Core Plot is a plotting framework for OS X and iOS. It provides 2D visualization ' \
                   'of data, and is tightly integrated with Apple technologies like Core Animation, ' \
@@ -18,10 +19,16 @@ Pod::Spec.new do |s|
   s.exclude_files = '**/*{TestCase,Tests}.{h,m}'
   s.ios.source_files = 'framework/CorePlot-CocoaTouch.h', 'framework/iPhoneOnly/*.{h,m}'
   s.osx.source_files = 'framework/CorePlot.h', 'framework/MacOnly/*.{h,m}'
-
   s.framework   = 'QuartzCore'
 
   s.pre_install do |pod, target_definition|
-    Dir.chdir(pod.root) {`/usr/sbin/dtrace -h -s framework/TestResources/CorePlotProbes.d -o framework/Source/CorePlotProbes.h`}
+	Dir.chdir(pod.root)
+	unless File.exists?('framework')
+		# Break out of the deep nested structure of the zip file
+		FileUtils.mv Dir.glob('**/framework'), '.'
+
+		# Generate a header file for CorePlotProbes
+    	`dtrace -h -s framework/TestResources/CorePlotProbes.d -o framework/Source/CorePlotProbes.h`
+	end
   end
 end

--- a/CorePlot/1.3/CorePlot.podspec
+++ b/CorePlot/1.3/CorePlot.podspec
@@ -8,7 +8,6 @@ Pod::Spec.new do |s|
                  'Brad Larson'    => 'larson@sunsetlakesoftware.com',
                  'Eric Skroch'    => 'eskroch@mac.com',
                  'Barry Wark'     => 'barrywark@gmail.com' }
-
   s.source   = { :http => 'https://core-plot.googlecode.com/files/CorePlot_1.3.zip' }
 
   s.description = 'Core Plot is a plotting framework for OS X and iOS. It provides 2D visualization ' \
@@ -22,12 +21,12 @@ Pod::Spec.new do |s|
   s.framework   = 'QuartzCore'
 
   s.pre_install do |pod, target_definition|
-	Dir.chdir(pod.root) {
-		unless File.exists?('framework')
-			FileUtils.mv Dir.glob('**/framework'), '.'
-			FileUtils.mv Dir.glob('**/License.txt'), '.'
-	    	`dtrace -h -s framework/TestResources/CorePlotProbes.d -o framework/Source/CorePlotProbes.h`
-		end
-	}
+    Dir.chdir(pod.root) {
+      unless File.exists?('framework')
+        FileUtils.mv Dir.glob('**/framework'), '.'
+        FileUtils.mv Dir.glob('**/License.txt'), '.'
+        `dtrace -h -s framework/TestResources/CorePlotProbes.d -o framework/Source/CorePlotProbes.h`
+      end
+    }
   end
 end

--- a/CorePlot/1.3/CorePlot.podspec
+++ b/CorePlot/1.3/CorePlot.podspec
@@ -22,13 +22,12 @@ Pod::Spec.new do |s|
   s.framework   = 'QuartzCore'
 
   s.pre_install do |pod, target_definition|
-	Dir.chdir(pod.root)
-	unless File.exists?('framework')
-		# Break out of the deep nested structure of the zip file
-		FileUtils.mv Dir.glob('**/framework'), '.'
-
-		# Generate a header file for CorePlotProbes
-    	`dtrace -h -s framework/TestResources/CorePlotProbes.d -o framework/Source/CorePlotProbes.h`
-	end
+	Dir.chdir(pod.root) {
+		unless File.exists?('framework')
+			FileUtils.mv Dir.glob('**/framework'), '.'
+			FileUtils.mv Dir.glob('**/License.txt'), '.'
+	    	`dtrace -h -s framework/TestResources/CorePlotProbes.d -o framework/Source/CorePlotProbes.h`
+		end
+	}
   end
 end


### PR DESCRIPTION
The Mercurial repository of CorePlot is huge and Mercurial doesn't support shallow clones. The previous podspec would clone a huge part of the CorePlot repository resulting in a download of at least 750MB. I've changed the podspec to target the zip file of only 8MB. Resolves issue: https://github.com/CocoaPods/Specs/issues/2892

Additional info on the pre_install step:
- first it changes the current directory to the CorePlot pod folder
- the zip file has a deeper structure than necessary, we can't use the flatten option because it has multiple root folders, so I look for the framework folder and bring it to the top
- after that we have to generate the header file for CorePlotProbes based on CorePlotProbes.d

The `File.exists?('framework')` makes sure that these steps occur only once. `Pre_install` is also called for pod updates which would cause an error with both the move and dtrace command.

/cc @alloy
