### PR TITLE
Added LLBinaryOperators 0.1

### DIFF
--- a/LLBinaryOperators/0.1/LLBinaryOperators.podspec
+++ b/LLBinaryOperators/0.1/LLBinaryOperators.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name         = "LLBinaryOperators"
+  s.version      = "0.1"
+  s.summary      = "Binary Enumeration Operators, since NSArray only supports object equality."
+  s.homepage     = "https://github.com/lawrencelomax/LLBinaryOperators"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author       = { "Lawrence Lomax" => "lomax.lawrence@gmail.com" }
+  s.source       = { :git => "https://github.com/lawrencelomax/LLBinaryOperators.git", :tag => "0.1" }
+  s.source_files = 'LLBinaryOperators/Classes/'
+  s.requires_arc = true
+end


### PR DESCRIPTION
Hi!

New podspec. A small helper function for NSArray to assist with binary enumeration. I've been trying to get this building on travis for unit tests, however xctool doesn't seem to find the [main project scheme](https://travis-ci.org/lawrencelomax/LLBinaryOperators#L484). If anyone knows a quick solution to this that would be great.
- lawrence
