### PR TITLE
libsodium for ios

### DIFF
--- a/libsodium-ios/0.4.2/libsodium-ios.podspec
+++ b/libsodium-ios/0.4.2/libsodium-ios.podspec
@@ -1,0 +1,32 @@
+Pod::Spec.new do |s|
+  s.name         = "libsodium-ios"
+  s.version      = "0.4.2"
+  s.summary      = "Sodium is a portable, cross-compilable, installable, packageable, API-compatible version of NaCl."
+  s.homepage     = "https://github.com/jedisct1/libsodium"
+  s.license      = { :type => "BSD",
+                     :text => <<-LICENSE
+Copyright © 2013
+Frank Denis <j at pureftpd dot org>
+
+Permission to use, copy, modify, and distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+                     LICENSE
+  }
+
+
+
+  s.author   = { "Frank Dennis" => "j@pureftpd.org" }
+  s.source   = { :git => 'https://github.com/mochtu/libsodium-ios.git', :tag => '0.4.2' }
+  
+  s.ios.deployment_target = '7.0'
+
+  s.header_mappings_dir = 'src/libsodium/include'
+  
+  s.source_files = 'src/libsodium/**/*.{c,h,data}'
+  s.exclude_files =  '**/*try.*'
+
+
+
+ end


### PR DESCRIPTION
This CocoaPod gives an easy access to the crypto library 'libsodium' for ios developers. The existing libsodium CocoaPod does not compile and is not compatible with XCode out of the box. Many headerfiles delivered by the libsodium CocoaPod need to be preprocessed in order to work with XCode. I made a new repository that includes only the necessary and preprocessed header & source files (https://github.com/mochtu/libsodium-ios) and an according Pod that works out of the box.

I hope this enables more iOS developers to use simple and secure crypto in their apps.

Best,
Mochtu
