### PR TITLE
Update cocos2d.podspec

### DIFF
--- a/cocos2d/2.0/cocos2d.podspec
+++ b/cocos2d/2.0/cocos2d.podspec
@@ -8,10 +8,9 @@ Pod::Spec.new do |s|
   s.author      =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
   s.source      =  {:git => 'https://github.com/cocos2d/cocos2d-iphone.git', :tag => 'release-2.0'}
 
-  s.source_files = ['cocos2d/**/*.{h,m,c}',
-                    'external/kazmath/src/**/*.{c,h}',
-                    'external/kazmath/include/**/*.{c,h}'] +
-                    FileList['external/libpng/*.{h,c}'].exclude(/pngtest/)
+  s.source_files = 'cocos2d/**/*.{h,m,c}', 'external/kazmath/src/**/*.{c,h}', 'external/kazmath/include/**/*.{c,h}', 'external/libpng/*.{h,c}'
+  s.exclude_files = 'external/libpng/pngtest.c', 'external/libpng/example.c'                    
+                    
   s.xcconfig   =  { 'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/cocos2d/external/kazmath/include"' }
   s.frameworks =  ["OpenGLES", "QuartzCore", "GameKit"]
   s.library    =  'z'


### PR DESCRIPTION
Update podspec because the (Rake) FileList class is no longer supported. 
Changed to the `exclude_files` attribute of the spec to exclude files instead.
