### PR TITLE
bugfixes in geos and spatialite

### DIFF
--- a/geos/3.3.8/geos.podspec
+++ b/geos/3.3.8/geos.podspec
@@ -100,6 +100,5 @@ CONFIG_H
 
   s.preserve_paths = 'src/**/*.h', 'include/**/*.{h,inl,in}', 'capi/*.{h,in}'
 
-  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '${PODS_ROOT}/geos/include ${PODS_ROOT}/geos/capi' }
-
+  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '${PODS_ROOT}/geos/include ${PODS_ROOT}/geos/capi', 'CLANG_CXX_LIBRARY' => 'libstdc++'}
 end

--- a/spatialite/4.1.0/spatialite.podspec
+++ b/spatialite/4.1.0/spatialite.podspec
@@ -84,6 +84,10 @@ CONFIG_H
   # spatialite has a couple #include "*.c"
   # the *.c files that are included can't be compiled
 
+  s.public_header_files = "src/headers/**/*.h"
+  s.private_header_files = "src/headers/spatialite_private.h"
+  s.header_mappings_dir = "src/headers/"
+
   s.dependency 'geos'
   s.dependency 'proj4'
   # s.dependency 'freexl'	  # I comment this because there is a header search path conflict related to config.h between spatialite and freexl.


### PR DESCRIPTION
GEOS: added a macro to tell the compile to use libstdc++ 
spatialite: expose public header files
