### PR TITLE
Create a 1.3 tag to SDURLCache

### DIFF
--- a/SDURLCache/1.3/SDURLCache.podspec
+++ b/SDURLCache/1.3/SDURLCache.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name     = 'SDURLCache'
+  s.version  = '1.3'
+  s.platform = :ios
+  s.summary  = 'URLCache subclass with on-disk cache support on iPhone/iPad.'
+  s.homepage = 'https://github.com/rs/SDURLCache'
+  s.license  = 'MIT'
+  s.author   = { 'Olivier Poitrey' => 'rs@dailymotion.com' }
+  s.source   = { :git => 'https://github.com/vdaubry/SDURLCache.git', :tag => '1.3' }
+  s.source_files = 'SDURLCache.h', 'SDURLCache.m', 'SDCachedURLResponse.h', 'SDCachedURLResponse.m'
+end


### PR DESCRIPTION
SDURLCache repo is no longer maintained. The 1.2 tag is outdated and we need to be able to reference a new 1.3 tag with latest changes, so i forked the SDURLCache repo and created a new podspec pointing to it.

See this discussion for more info :

https://github.com/CocoaPods/CocoaPods/issues/1206#ref-issue-16854808
