### PR TITLE
TextExpander SDK requires AudioToolbox framework

### DIFF
--- a/TextExpander/1.2.2/TextExpander.podspec
+++ b/TextExpander/1.2.2/TextExpander.podspec
@@ -9,5 +9,6 @@ Pod::Spec.new do |s|
   s.platform = :ios
   s.source_files = 'teTouchSDK/TextExpander.framework/Versions/A/Headers/*.h'
   s.preserve_paths = 'teTouchSDK/TextExpander.framework'
+  s.frameworks = 'AudioToolbox'
   s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '$(PODS_ROOT)/TextExpander/teTouchSDK', 'OTHER_LDFLAGS' => '-framework TextExpander' }
 end


### PR DESCRIPTION
As per [Smile Software's documentation](https://smile.clarify-it.com/d/lkwwdw) (see 2nd paragraph in the section "Next, add the TextExpander.framework folder to your Xcode project") the AudioToolbox framework is used by TextExpander framework and is therefore required.
