### PR TITLE
Add Collection+JSON parser for ObjC 1.0.1

### DIFF
--- a/Collection-JSON-ObjC/1.0.1/Collection-JSON-ObjC.podspec
+++ b/Collection-JSON-ObjC/1.0.1/Collection-JSON-ObjC.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = "Collection-JSON-ObjC"
+  s.version      = "1.0.1"
+  s.summary      = "Collection+JSON parser for Objective-C."
+  s.description  = "A simple set of classes to parse the JSON response to a Collection+JSON call into simple objects."
+  s.homepage     = "https://github.com/chrissearle/Collection-JSON-ObjC"
+  s.license      = 'Apache'
+  s.author       = { "Chris Searle" => "chris@chrissearle.org" }
+  s.source       = { :git => "https://github.com/chrissearle/Collection-JSON-ObjC.git", :tag => "1.0.1" }
+
+  s.platform     = :ios, '6.0'
+
+  s.source_files = '*.{h,m}'
+
+  s.requires_arc = true
+end


### PR DESCRIPTION
Very simple set of classes just used to parse Collection+JSON into standard ObjC objects (dictionaries, arrays etc).

Currently used as a git submodule - want to migrate to pod :)
