### PR TITLE
Update Google-Maps-iOS-SDK.podspec 1.4.0 with the right deployment target

### DIFF
--- a/Google-Maps-iOS-SDK/1.4.0/Google-Maps-iOS-SDK.podspec
+++ b/Google-Maps-iOS-SDK/1.4.0/Google-Maps-iOS-SDK.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
 
   s.source = { :http => 'https://dl.google.com/geosdk/GoogleMaps-iOS-1.4.0.zip', :flatten => true }
   s.platform = :ios
-  s.ios.deployment_target = '6.0'
+  s.ios.deployment_target = '5.1'
 
   framework_path = 'GoogleMaps.framework'
 


### PR DESCRIPTION
...t

The iOS deployment target is wrong.
Google says: "While the iOS 6.0 SDK is required for development, the Google Maps SDK will work on iOS 5.1 and above.".
https://developers.google.com/maps/documentation/ios/intro?hl=fr#supported_platforms
