### PR TITLE
Duplicative spec of "objective-git"

### DIFF
--- a/ObjectiveGit/0.2/ObjectiveGit.podspec
+++ b/ObjectiveGit/0.2/ObjectiveGit.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |s|
+  s.name          =  "ObjectiveGit"
+  s.version       =  "0.2"
+  s.summary       =  "Objective-C bindings to libgit2."
+  s.homepage      =  "https://github.com/libgit2/objective-git"
+  s.license       =  'MIT'
+  s.author        =  { "Tim Clem" => "timothy.clem@gmail.com", "Josh Abernathy" => "josh@github.com" }
+  s.source        =  { :git => "https://github.com/libgit2/objective-git.git", :tag => "0.2", :submodules => true }
+  s.source_files  =  'Classes/**/*.{h,m}', 'libgit2/src/**/*.{h,c}', 'libgit2/include/**/*.h', 'libgit2/deps/http-parser/*.{h,c}'
+  s.osx.libraries =  %w|ssl crypto z|
+  s.ios.libraries =  %w|z|
+  s.requires_arc  =  true
+
+  s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.6'
+
+  s.exclude_files = 'libgit2/include/git2/inttypes.h', 'libgit2/include/git2/stdint.h', 'libgit2/src/win32/**', 'libgit2/**/hash_win32.*'
+  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(PODS_ROOT)/ObjectiveGit/libgit2/include $(PODS_ROOT)/ObjectiveGit/libgit2/src' }
+
+  s.prefix_header_contents = '#define GTLog(fmt, ...) NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__);'
+ 
+  s.description = <<-DESC
+    Objective Git provides Objective-C bindings to the libgit2 linkable C Git library.
+    This library follows the rugged API as close as possible while trying to maintain a native objective-c feel.
+  DESC
+end

--- a/libgit2/0.19.0/libgit2.podspec
+++ b/libgit2/0.19.0/libgit2.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name         = "libgit2"
+  s.version      = "0.19.0"
+  s.summary      = "The libgit2 Library."
+  s.homepage     = "http://libgit2.github.com"
+  s.license      = { :type => 'GPL v2 (with linking exception)', :file => 'COPYING' }
+  s.author       = 'See AUTHORS file'
+  s.source       = { :git => "https://github.com/libgit2/libgit2.git", :tag => "v0.19.0" }
+  s.source_files = 'deps/http-parser/*.{h,c}', 'src/**/*.{h,c}', 'include/**/*.h'
+  s.exclude_files = '**/include/git2/inttypes.h', '**/include/git2/stdint.h', '**/src/win32/**', '**/hash_win32.*'
+  s.public_header_files = 'include/**/*.h'
+  s.preserve_paths = 'Authors'
+  s.libraries = 'z'
+  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(PODS_ROOT)/libgit2/include $(PODS_ROOT)/libgit2/src' }
+end

--- a/objective-git/0.0.1/objective-git.podspec
+++ b/objective-git/0.0.1/objective-git.podspec
@@ -25,4 +25,11 @@ Pod::Spec.new do |s|
     Objective Git provides Objective-C bindings to the libgit2 linkable C Git library.
     This library follows the rugged API as close as possible while trying to maintain a native objective-c feel.
   DESC
+
+  def s.post_install(target)
+    puts "objective-git is deprecated - Please switch to ObjectiveGit to stay up to date."
+  end
 end
+
+
+


### PR DESCRIPTION
I seem to there's a duplicative spec of "objective-git":

https://github.com/CocoaPods/Specs/blob/master/ObjectiveGit/0.1/ObjectiveGit.podspec
https://github.com/CocoaPods/Specs/blob/master/objective-git/0.0.1/objective-git.podspec
