### PR TITLE
for issue #3491: Evernote-SDK-iOS 1.3.0 podspec fixing

### DIFF
--- a/Evernote-SDK-iOS/1.3.0/Evernote-SDK-iOS.podspec
+++ b/Evernote-SDK-iOS/1.3.0/Evernote-SDK-iOS.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
     'evernote-sdk-ios/3rdParty/{AFNetworking,KSHTMLWriter,NSString+URLEncoding,Thrift,cocoa-oauth}/**/*.{h,m}'
   s.frameworks = 'Foundation', 'Security', 'StoreKit','MobileCoreServices'
   s.libraries = 'xml2'
-  s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '"$(SDKROOT)/usr/include/libxml2"' }
+  s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
 
   s.dependency 'SSKeychain', '0.2.1'
 end


### PR DESCRIPTION
for issue #3491: removed double quote in HEADER_SEARCH_PATHS value as shown in Evernote-SDK-iOS/1.3.0/Evernote-SDK-iOS.podspec.
