### PR TITLE
Update Cedar and PivotalCoreKit

### DIFF
--- a/Cedar/0.9.3/Cedar.podspec
+++ b/Cedar/0.9.3/Cedar.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |s|
+  s.name     = 'Cedar'
+  s.version  = '0.9.3'
+  s.license  = 'MIT'
+  s.summary  = 'BDD-style testing using Objective-C.'
+  s.homepage = 'https://github.com/pivotal/cedar'
+  s.author   = { 'Pivotal Labs' => 'http://pivotallabs.com' }
+  s.license  = { :type => 'MIT', :file => 'MIT.LICENSE' }
+  s.source   = { :git => 'https://github.com/pivotal/cedar.git', :tag => 'v0.9.3' }
+
+  s.osx.deployment_target = '10.7'
+  s.ios.deployment_target = '5.0'
+  s.source_files = 'Source/**/*.{h,m,mm}'
+  s.ios.exclude_files = '**/CDROTestRunner.m'
+  s.osx.exclude_files = '**/iPhone/**'
+  s.ios.header_dir = 'Cedar-iOS'
+
+  # Versions of this pod >= 0.9.0 require C++11.
+  #   https://github.com/pivotal/cedar/issues/47
+  s.xcconfig = {
+    'CLANG_CXX_LANGUAGE_STANDARD' => 'c++0x',
+    'CLANG_CXX_LIBRARY' => 'libc++'
+  }
+
+end

--- a/PivotalCoreKit/0.0.1/PivotalCoreKit.podspec
+++ b/PivotalCoreKit/0.0.1/PivotalCoreKit.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   s.author   = { 'Pivotal Labs' => 'http://pivotallabs.com' }
   s.source   = { :git => 'https://github.com/pivotal/PivotalCoreKit.git', :commit => '9e41f823589521b75ed205cb1a2fb1bb2747ce48' }
   s.platform = :ios
+  s.ios.deployment_target = '5.0'
 
   s.subspec 'CoreLib' do |core|
     core.source_files = 'CoreLib/**/*.{h,m}'

--- a/PivotalCoreKit/0.0.1/PivotalCoreKit.podspec
+++ b/PivotalCoreKit/0.0.1/PivotalCoreKit.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.summary  = 'Shared library and test code for iOS projects.'
   s.homepage = 'https://github.com/pivotal/PivotalCoreKit'
   s.author   = { 'Pivotal Labs' => 'http://pivotallabs.com' }
-  s.source   = { :git => 'https://github.com/pivotal/PivotalCoreKit.git', :commit => 'a87825e743bbe1b9d5062fa5ee27ee430d86f305' }
+  s.source   = { :git => 'https://github.com/pivotal/PivotalCoreKit.git', :commit => '9e41f823589521b75ed205cb1a2fb1bb2747ce48' }
   s.platform = :ios
 
   s.subspec 'CoreLib' do |core|
@@ -28,11 +28,11 @@ Pod::Spec.new do |s|
     uicore.source_files = 'UICoreLib/**/*.{h,m}'
     uicore.frameworks   = 'UIKit', 'CoreText'
   end
-  
+
   s.subspec 'SpecHelperLib' do |spec_helper|
     spec_helper.source_files = 'SpecHelperLib/**/*.{h,m}'
     spec_helper.frameworks   = 'UIKit'
     spec_helper.dependency 'Cedar'
   end
-  
+
 end


### PR DESCRIPTION
This updates PivotalCoreKit, a set of shared helpers used and maintained by Pivotal Labs.  Bumping it required updating the Cedar test framework, so I've included a Podspec for Cedar's latest tag as well.

(The PivotalCoreKit maintainers don't tag releases, so I just pointed it at the latest SHA.)
