### PR TITLE
Add files needed to run Cedar template generators.

### DIFF
--- a/Cedar/0.9.1/Cedar.podspec
+++ b/Cedar/0.9.1/Cedar.podspec
@@ -10,8 +10,8 @@ Pod::Spec.new do |s|
 
   s.osx.deployment_target = '10.7'
   s.ios.deployment_target = '5.0'
-  s.source_files = 'Source/**/*.{h,m,mm}'
-  s.ios.exclude_files = '**/CDROTestRunner.m'
+  s.source_files = 'Source/**/*.{h,m,mm,d}'
+  s.resources = ['Rakefile', 'installCodeSnippetsAndTemplates', 'Cedar-Info.plist', 'Cedar.xcodeproj/*', 'CodeSnippetsAndTemplates/*']
   s.osx.exclude_files = '**/iPhone/**'
   s.ios.header_dir = 'Cedar-iOS'
 


### PR DESCRIPTION
This adds all the files required to run the `installCodeSnippetsAndTemplates` script for the initial setup.
