### PR TITLE
Updated NewRelicAgent podspec to rely on version parameter

### DIFF
--- a/NewRelicAgent/1.354/NewRelicAgent.podspec
+++ b/NewRelicAgent/1.354/NewRelicAgent.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source       		= { :http => "https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_#{s.version}.zip" }
   s.framework    		= 'SystemConfiguration', 'CoreTelephony'
   s.library      		= 'z'
-  s.source_files 		= "NewRelic_iOS_Agent_#{s.version}/NewRelicAgent.framework/**/*.h"
+  s.preserve_paths      = "NewRelic_iOS_Agent_#{s.version}/*.framework"  
   s.public_header_files = "NewRelic_iOS_Agent_#{s.version}/NewRelicAgent.framework/**/*.h"
   s.vendored_frameworks = "NewRelic_iOS_Agent_#{s.version}/NewRelicAgent.framework"
   s.documentation 		= { :appledoc => ['--company-id', 'com.newrelic'] }

--- a/NewRelicAgent/1.354/NewRelicAgent.podspec
+++ b/NewRelicAgent/1.354/NewRelicAgent.podspec
@@ -1,16 +1,16 @@
 Pod::Spec.new do |s|
-  s.name         = "NewRelicAgent"
-  s.version      = "1.354"
-  s.summary      = "Real-time performance data with your next iOS app release."
-  s.homepage     = "http://newrelic.com/mobile-monitoring"
-  s.license      = { :type => "Commercial", :file => "NewRelic_iOS_Agent_1.354/LICENSE" }
-  s.author       = { "New Relic, Inc." => "support@newrelic.com" }
-  s.source       = { :http => "https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_1.354.zip" }
-  s.platform     = :ios, "5.0"
-  s.public_header_files = "NewRelic_iOS_Agent_1.354/NewRelicAgent.framework/Headers/NewRelicAgent.h"
-  s.preserve_paths = "NewRelic_iOS_Agent_1.354/NewRelicAgent.framework"
-  s.frameworks   = "NewRelicAgent", "CoreTelephony", "SystemConfiguration"
-  s.library      = "z"
-  s.xcconfig     =  { "FRAMEWORK_SEARCH_PATHS" => '"$(PODS_ROOT)/NewRelicAgent/NewRelic_iOS_Agent_1.354"' }
-  s.documentation = { :appledoc => ['--company-id', 'com.newrelic'] }
+  s.name         		= 'NewRelicAgent'
+  s.version      		= '1.354'
+  s.platform     		= :ios, '5.0'
+  s.license      		= { :type => "Commercial", :file => "NewRelic_iOS_Agent_#{s.version}/LICENSE" }
+  s.summary      		= "Real-time performance data with your next iOS app release."
+  s.homepage     		= "http://newrelic.com/mobile-monitoring"  
+  s.authors      		= {'New Relic, Inc.' => 'support@newrelic.com'}
+  s.source       		= { :http => "https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_#{s.version}.zip" }
+  s.framework    		= 'SystemConfiguration', 'CoreTelephony'
+  s.library      		= 'z'
+  s.source_files 		= "NewRelic_iOS_Agent_#{s.version}/NewRelicAgent.framework/**/*.h"
+  s.public_header_files = "NewRelic_iOS_Agent_#{s.version}/NewRelicAgent.framework/**/*.h"
+  s.vendored_frameworks = "NewRelic_iOS_Agent_#{s.version}/NewRelicAgent.framework"
+  s.documentation 		= { :appledoc => ['--company-id', 'com.newrelic'] }
 end


### PR DESCRIPTION
Updated NewRelicAgent podspec so locations rely on version parameter so they don't have to be changed every time a new version is released.
