### PR TITLE
Adding ARSwipeToSelectGestureRecognizer Podspec

### DIFF
--- a/ARSwipeToSelectGestureRecognizer/0.2/ARSwipeToSelectGestureRecognizer.podspec
+++ b/ARSwipeToSelectGestureRecognizer/0.2/ARSwipeToSelectGestureRecognizer.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "ARSwipeToSelectGestureRecognizer"
+  s.version      = "0.2"
+  s.summary      = "Swipe-to-Select/Deselect gestures with UICollectionView."
+  s.description  = "A UIGestureRecognizer subclass to enable Swipe-to-Select/Deselect with a UICollectionView."
+  s.homepage     = "https://github.com/ayn/ARSwipeToSelectGestureRecognizer"
+  s.license      = 'MIT'
+  s.authors      = { "Andrew Ng" => "ayn@andrewng.com", "Ray Tsaihong" => "ray.tsaihong@gmail.com" }
+  s.source       = { :git => "https://github.com/ayn/ARSwipeToSelectGestureRecognizer.git", :tag => s.version.to_s }
+  s.platform     = :ios, '6.0'
+  s.source_files = 'Classes', 'Classes/*.{h,m}'
+  s.requires_arc = true
+end


### PR DESCRIPTION
[ARSwipeToSelectGestureRecognizer](https://github.com/ayn/ARSwipeToSelectGestureRecognizer) is a custom gesture recognizer that allow selecting multiple cells by swiping. After this Spec is merged into the master repo, I'll submit [ARSwipeToSelectPickerController](https://github.com/ayn/ARSwipeToSelectPickerController), which is a UIImagePickerController replacement that uses this gesture recognizer.
