### PR TITLE
Update VEVerbalExpressions to version 0.1.1

### DIFF
--- a/VEVerbalExpressions/0.1.1/VEVerbalExpressions.podspec
+++ b/VEVerbalExpressions/0.1.1/VEVerbalExpressions.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name         = "VEVerbalExpressions"
+  s.version      = "0.1.1"
+  s.summary      = "Objective-C Regular Expressions made easy"
+  s.homepage     = "https://github.com/VerbalExpressions/ObjectiveCVerbalExpressions"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author       = { "kishikawakatsumi" => "kishikawakatsumi@mac.com" }
+  s.authors      = { "kishikawakatsumi" => "kishikawakatsumi@mac.com" }
+  s.source       = { :git => "https://github.com/VerbalExpressions/ObjectiveCVerbalExpressions.git", :tag => "v0.1.1" }
+  s.ios.deployment_target = '4.0'
+  s.osx.deployment_target = '10.7'
+  s.source_files = 'Lib/*'
+  s.requires_arc = true
+end


### PR DESCRIPTION
Update VEVerbalExpressions to version 0.1.1
- Add JavaScript constructor like initializer
- Move repogitory reference to official => https://github.com/VerbalExpressions/ObjectiveCVerbalExpressions
