### PR TITLE
Revert "Add Cedar template generators."

### DIFF
--- a/Cedar/0.9.1/Cedar.podspec
+++ b/Cedar/0.9.1/Cedar.podspec
@@ -10,8 +10,8 @@ Pod::Spec.new do |s|
 
   s.osx.deployment_target = '10.7'
   s.ios.deployment_target = '5.0'
-  s.source_files = 'Source/**/*.{h,m,mm,d}'
-  s.resources = ['Rakefile', 'installCodeSnippetsAndTemplates', 'Cedar-Info.plist', 'Cedar.xcodeproj/*', 'CodeSnippetsAndTemplates/*']
+  s.source_files = 'Source/**/*.{h,m,mm}'
+  s.ios.exclude_files = '**/CDROTestRunner.m'
   s.osx.exclude_files = '**/iPhone/**'
   s.ios.header_dir = 'Cedar-iOS'
 


### PR DESCRIPTION
This reverts commit 12c3c9f806498ad25087c534c086eebdcea5a15d.

People were running into build failures because of a duplicate symbol.
