### PR TITLE
Fixed an issue with source extensions

### DIFF
--- a/usbmuxd/1.0.0/usbmuxd.podspec
+++ b/usbmuxd/1.0.0/usbmuxd.podspec
@@ -18,8 +18,7 @@ LICENSE
  s.author = 'Chris Stroud' 
  s.platform = :osx, '10.7' 
  s.source = { :git => "https://github.com/Clstroud/usbmuxd.git", :tag => "v#{s.version}"}
- s.source_files = 'libusbmuxd/*.{h,m}', 'include/*.h', 'common/*.{h,m}', 'daemon/*.{h,m}'
+ s.source_files = 'libusbmuxd/*.{h,c,m,cpp}', 'include/*.h', 'common/*.{h,c,m,cpp}', 'daemon/*.{h,c,m,cpp}'
  s.public_header_files = 'libusbmuxd/usbmuxd.h'
 
 end
-


### PR DESCRIPTION
This issue was forcing the pod library to only include the header
files, leaving the symbols unfound.

As best I can tell, this should resolve the issue. At this time I don't believe there are any similar issues in the other two specs I submitted yesterday.
