### PR TITLE
Changed cocoapods description that AFNetworking no longer warning you wh...

### DIFF
--- a/AFOAuth1Client/0.2.1/AFOAuth1Client.podspec
+++ b/AFOAuth1Client/0.2.1/AFOAuth1Client.podspec
@@ -20,5 +20,14 @@ Pod::Spec.new do |s|
 #ifdef __OBJC__
   #import <Security/Security.h>
 #endif /* __OBJC__*/
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+  #import <SystemConfiguration/SystemConfiguration.h>
+  #import <MobileCoreServices/MobileCoreServices.h>
+#else
+  #import <SystemConfiguration/SystemConfiguration.h>
+  #import <CoreServices/CoreServices.h>
+#endif
+
 EOS
 end


### PR DESCRIPTION
After installing AFOAuth1Client from cocoapods it automatically install AFNetworking, but warnings appear while building AFOAuth1Client with its .pch file:

AFHTTPClient.h:84:9: SystemConfiguration framework not found in project, or not included in precompiled header. Network reachability functionality will not be available.

AFHTTPClient.h:89:9: MobileCoreServices framework not found in project, or not included in precompiled header. Automatic MIME type detection when uploading files in multipart requests will not be available.

It happens because AFOAuth1Client doesn't include SystemConfiguration.h and CoreServices.h into its pch file.

I beleive this simple solution will help not only me, but others, who don't want to change external .pch files.
