### PR TITLE
FlurrySDK 4.2.3 needs `Security` framework

### DIFF
--- a/FlurrySDK/4.2.3/FlurrySDK.podspec
+++ b/FlurrySDK/4.2.3/FlurrySDK.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'Flurry/**/*.a'
   s.library = 'Flurry_4.2.3'
   s.xcconfig  =  { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/FlurrySDK/Flurry"' }
-  s.framework = 'SystemConfiguration', 'UIKit'
+  s.framework = 'SystemConfiguration', 'UIKit', 'Security'
 end


### PR DESCRIPTION
As of 4.2.3, FlurrySDK requires the `Security` framework. 

Please see Release Notes on Flurry's site:
http://support.flurry.com/index.php?title=Analytics/Code/ReleaseNotes

> iOS Security framework is now required for Flurry Analytics

Related to #3548
