### PR TITLE
Adding back 2.0beta4 Google Analytics

### DIFF
--- a/GoogleAnalytics-iOS-SDK/2.0beta4/GoogleAnalytics-iOS-SDK.podspec
+++ b/GoogleAnalytics-iOS-SDK/2.0beta4/GoogleAnalytics-iOS-SDK.podspec
@@ -1,0 +1,33 @@
+Pod::Spec.new do |s|
+  s.name         = "GoogleAnalytics-iOS-SDK"
+  s.version      = "2.0beta4"
+  s.summary      = "GoogleAnalytics for iOS SDK."
+  s.description  = <<-DESC
+  The Google Analytics SDK for iOS makes it easy for native iOS developers to collect user engagement data form their applications. Developers can then use the Google Analytics reports to measure:
+
+      * The number of active users are using their applications.
+      * From where in the world the application is being used.
+      * Adoption and usage of specific features.
+      * In-app purchases and transactions.
+      * And many other useful metrics...
+  DESC
+  s.homepage     = "https://developers.google.com/analytics/devguides/collection/ios/v2/"
+
+  s.license      = {
+    :type => 'Copyright',
+    :text => <<-LICENSE
+      Copyright 2009 - 2012 Google, Inc. All rights reserved.
+      LICENSE
+  }
+  s.author       = 'Google Inc.'
+  s.source       = { :git => "https://github.com/mutualmobile/Google-Analytics.git", :tag => "2.0beta4" }
+  s.platform     = :ios
+
+  s.source_files = 'GoogleAnalytics-iOS-SDK/Library/*.h'
+  s.preserve_paths = 'GoogleAnalytics-iOS-SDK/Library/*.a'
+
+  s.frameworks = 'CFNetwork', 'CoreData', 'SystemConfiguration'
+  s.library   = 'GoogleAnalytics'
+
+  s.xcconfig  =  { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/GoogleAnalytics-iOS-SDK/Library"' }
+end


### PR DESCRIPTION
Commit 198cfac761398f1bd3faa0d039c83f76085b2a50 broke older versions of GA.

I took the old source, uploaded to Github, and modified the old spec to point to that repo.
