### PR TITLE
Fixed directory path for Google Analytics

### DIFF
--- a/GoogleAnalytics-iOS-SDK/2.0beta4/GoogleAnalytics-iOS-SDK.podspec
+++ b/GoogleAnalytics-iOS-SDK/2.0beta4/GoogleAnalytics-iOS-SDK.podspec
@@ -29,5 +29,5 @@ Pod::Spec.new do |s|
   s.frameworks = 'CFNetwork', 'CoreData', 'SystemConfiguration'
   s.library   = 'GoogleAnalytics'
 
-  s.xcconfig  =  { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/GoogleAnalytics-iOS-SDK/Library"' }
+  s.xcconfig  =  { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/GoogleAnalytics-iOS-SDK/GoogleAnalytics-iOS-SDK/Library"' }
 end


### PR DESCRIPTION
Not sure why `pod spec lint` worked on the first one I submitted, but the path appears to have been incorrect.

This PR fixes that. (I think, but again `pod spec lint` says I passed...)
