### PR TITLE
An implementation of the in-app tutorial as seen e.g. in Path 3

### DIFF
--- a/ICETutorial/1.0.2/ICETutorial.podspec
+++ b/ICETutorial/1.0.2/ICETutorial.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name = 'ICETutorial'
+  s.version = '1.0.2'
+  s.summary = 'An implementation of the in-app tutorial as seen e.g. in Path 3'
+  s.homepage = 'http://icepat.github.io/ICETutorial'
+  s.license = {
+    :type => 'MIT',
+    :file => 'LICENSE'
+  }
+  s.author = 'Patrick Trillsam'
+  s.source = {
+    :git => 'https://github.com/DaGaMs/ICETutorial.git',
+    :tag => '1.0.2'
+  }
+  s.platform = :ios, '6.0'
+  s.source_files = 'ICETutorial/Libraries'
+  s.public_header_files = 'ICETutorial/Libraries'
+  s.frameworks = 'UIKit', 'CoreGraphics'
+  s.requires_arc = true
+end


### PR DESCRIPTION
This small project is an implementation of the newly tutorial introduced by the Path 3.X app. Very simple and efficient tutorial, composed with N full-screen pictures that you can swipe for switching to the next/previous page.
