### PR TITLE
Fix jsoncpp podspec

### DIFF
--- a/jsoncpp/0.6.0.rc2/jsoncpp.podspec
+++ b/jsoncpp/0.6.0.rc2/jsoncpp.podspec
@@ -14,20 +14,18 @@ Pod::Spec.new do |s|
   s.preserve_paths = "amalgamate.py", "include", "src"
   s.header_mappings_dir = 'dist'
 
-  def s.pre_install(pod, target_definition)
-    Dir.chdir(pod.root) do
-      # jsoncpp is designed to be "amalgamated" for deployment, but some of the
-      # paths in this version of amalagamate.py are incorrect, we need to fix
-      # them first:
-      `perl -pi -e 's/lib_json\\\\/lib_json\\//g' amalgamate.py`
+  s.prepare_command = <<-CMD
+    # jsoncpp is designed to be "amalgamated" for deployment, but some of the
+    # paths in this version of amalagamate.py are incorrect, we need to fix
+    # them first:
+    perl -pi -e 's/lib_json\\\\/lib_json\\//g' amalgamate.py
 
-      # Run amalgamate.py to combine the jsoncpp files and output them to the
-      # 'dist' directory:
-      `python amalgamate.py`
+    # Run amalgamate.py to combine the jsoncpp files and output them to the
+    # 'dist' directory:
+    python amalgamate.py
 
-      # The generated json.h does not have the 'JSON_IS_AMALGAMATION' define
-      # uncommented as it should be, lets do that now:
-      `perl -pi -e 's/^.+(#\\s*define\\s+JSON_IS_AMALGAMATION)/$1/g' dist/json/json.h`
-    end
-  end
+    # The generated json.h does not have the 'JSON_IS_AMALGAMATION' define
+    # uncommented as it should be, lets do that now:
+    perl -pi -e 's/^.+(#\\s*define\\s+JSON_IS_AMALGAMATION)/$1/g' dist/json/json.h
+  CMD
 end

--- a/jsoncpp/0.6.0.rc2/jsoncpp.podspec
+++ b/jsoncpp/0.6.0.rc2/jsoncpp.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.homepage     = "http://jsoncpp.sourceforge.net/"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Baptiste Lepilleur" => "blep@users.sourceforge.net" }
-  s.source       = { :svn => 'https://jsoncpp.svn.sourceforge.net/svnroot/jsoncpp/tags/jsoncpp/0.6.0-rc2/' }
+  s.source       = { :svn => 'https://svn.code.sf.net/p/jsoncpp/code/tags/jsoncpp/0.6.0-rc2/' }
   s.source_files = 'dist', 'dist/**/*.{h,cpp}'
   s.preserve_paths = "amalgamate.py", "include", "src"
   s.header_mappings_dir = 'dist'

--- a/jsoncpp/0.6.0.rc2/jsoncpp.podspec
+++ b/jsoncpp/0.6.0.rc2/jsoncpp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "jsoncpp"
-  s.version      = "0.6.2.rc2"
+  s.version      = "0.6.0.rc2"
   s.summary      = "jsoncpp is an implementation of a JSON (http://json.org) reader and writer in C++."
   s.description  = <<-DESC
                      JSON (JavaScript Object Notation) is a lightweight data-interchange format.


### PR DESCRIPTION
This pull request fixes three things:
- Somehow we accidentally categorised this under version `0.6.2.rc2` which doesn't even exist, it should be `0.6.0.rc2`.
- The SVN repo url has changed.
- The podspec was using the deprecated `pre_install` hook rather than `prepare_command`.
