### PR TITLE
removed .framework from the frameworks entry

### DIFF
--- a/ABCustomUINavigationController/1.0/ABCustomUINavigationController.podspec
+++ b/ABCustomUINavigationController/1.0/ABCustomUINavigationController.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
 
   s.source_files  = 'CustomUINavigationController/**/*.{h,m}'
 
-  s.frameworks = 'QuartzCore.framework', 'CoreGraphics.framework'
+  s.frameworks = 'QuartzCore', 'CoreGraphics'
   s.requires_arc = true
 
 end


### PR DESCRIPTION
Removed ".framework" extension from each entry in the frameworks list so an entry like "X.framework" does not resolve to "X.framework.framework" and instead resolves to X.framework, from X.  

This error was not reported in "pod spec lint" nor is it taken care of in the code.  
