### PR TITLE
removing .framework extension from list of frameworks

### DIFF
--- a/ABCustomUINavigationController/1.0/ABCustomUINavigationController.podspec
+++ b/ABCustomUINavigationController/1.0/ABCustomUINavigationController.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
 
   s.source_files  = 'CustomUINavigationController/**/*.{h,m}'
 
-  s.frameworks = 'QuartzCore.framework', 'CoreGraphics.framework'
+  s.frameworks = 'QuartzCore', 'CoreGraphics'
   s.requires_arc = true
 
 end


### PR DESCRIPTION
Removed ".framework" extension from s.frameworks because CoreGraphics.framework resolves to CoreGraphics.framework.framework, which is incorrect.  

This did not show up in the pod spec lint command and should probably be added.  The other option is to recognize .framework endings and strip them off.  
