### PR TITLE
Add MTFontIcon

### DIFF
--- a/MTFontIcon/1.0.0/MTFontIcon.podspec
+++ b/MTFontIcon/1.0.0/MTFontIcon.podspec
@@ -7,5 +7,6 @@ Pod::Spec.new do |s|
   s.author       = { "Giovanni Lodi" => "giovanni.lodi42@gmail.com" }
   s.source       = { :git => "https://github.com/mokagio/MTFontIcon.git", :tag => "1.0.0" }
   s.source_files = 'MTFontIcon'
+  s.platform     = :ios
   s.requires_arc = true
 end

--- a/MTFontIcon/1.0.0/MTFontIcon.podspec
+++ b/MTFontIcon/1.0.0/MTFontIcon.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name         = "MTFontIcon"
+  s.version      = "1.0.0"
+  s.summary      = "Speedup iOS app development with font based icons."
+  s.homepage     = "https://github.com/mokagio/MTFontIcon"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author       = { "Giovanni Lodi" => "giovanni.lodi42@gmail.com" }
+  s.source       = { :git => "https://github.com/mokagio/MTFontIcon.git", :tag => "1.0.0" }
+  s.source_files = 'MTFontIcon'
+  s.requires_arc = true
+end


### PR DESCRIPTION
A small framework to use font icons in our iOS apps, like we do everyday with CSS.

I have another couple of pods in the pipeline, one live already, and this one will see some updates soon-ish. I don't mind the PR, but if it's possible I'd like the push access. 

Thanks :)
