### PR TITLE
Add libzmq.podspec

### DIFF
--- a/libzmq/3.3.0-alpha1/libzmq.podspec
+++ b/libzmq/3.3.0-alpha1/libzmq.podspec
@@ -1,0 +1,35 @@
+Pod::Spec.new do |s|
+
+  s.name         = "libzmq"
+  s.version      = "3.3.0-alpha1"
+  s.summary      = "The Simplest Way to Connect Pieces."
+
+  s.description  = <<-DESC
+*  The socket library that acts as a concurrency framework.
+*  Carries messages across inproc, IPC, TCP, and multicast.
+*  Connect N-to-N via fanout, pubsub, pipeline, request-reply.
+*  Asynch I/O for scalable multicore message-passing apps.
+*  Large and active open source community.
+*  40+ languages including C, C++, Java, .NET, Python.
+*  Most OSes including Linux, Windows, OS X.
+*  Free software with full commercial support.
+                   DESC
+
+  s.homepage     = "http://zeromq.org/"
+
+  s.license      = { :type => 'LGPL', :file => 'COPYING' }
+  s.author       = 'iMatix Corporation', 'Contributors'
+
+
+  s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.7'
+
+
+  s.source = { :git => "https://github.com/phere/libzmq-pod.git", :tag => "pod-3.3.0-alpha1" }
+
+
+  s.source_files  = 'src/*.{cpp,hpp}', 'include/*.h'
+
+  s.public_header_files = 'include/*.h'
+
+end


### PR DESCRIPTION
Creates a CocoaPod for [ZeroMQ](http://zeromq.org)'s libzmq library.

This is the low-level C API, written in C++.  This pod is intended as a
dependency for a set of high-level bindings I'm currently building into
another pod.

---

The target repo is based on the current master (to be 3.3.0, when released) with the minimal changes required to build in a CocoaPods environment (the autoconf-generated `platform.hpp`).  This file is a build product of the upstream configuration system, and so will not (ever) be merged into mainline.

Because this is based on unreleased code, it is given the **-alpha** suffix; and because the pod version may need to iterate independently to the upstream library version, it is given a trailing `1` to delineate this as the first release.
