### PR TITLE
Changed the source_file regex for CocosDenshion to work with the cocos2D 2.1 release

### DIFF
--- a/cocos2d/2.1/cocos2d.podspec
+++ b/cocos2d/2.1/cocos2d.podspec
@@ -14,9 +14,9 @@ Pod::Spec.new do |s|
   s.xcconfig   =  { 'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/cocos2d/external/kazmath/include"' }
   s.frameworks =  ["OpenGLES", "QuartzCore", "GameKit", "CoreText"]
   s.library    =  'z'
-  
+
   s.subspec 'CocosDenshion' do |p|
-    p.source_files =  'CocosDenshion/{CocosDenshion,CocosDenshionExtras}/*.{h,m}'
+    p.source_files =  'CocosDenshion/*.{h,m}'
     p.frameworks   =  ["OpenAL", "AVFoundation", "AudioToolbox"]
   end
 


### PR DESCRIPTION
@jaisanth's [update](https://github.com/CocoaPods/Specs/commit/445ee661695f34d6f86b53d901662b5aec9bd7ef) of the cocos2D podspec seemed to break CocosDenshion support for me as the subspec source_files regex wasn't compatible with the directory structure of [release-2.1](https://github.com/cocos2d/cocos2d-iphone/tree/release-2.1/CocosDenshion). It seems that the subspec is using the directory structure of [Steve Oldmeadow's fork](https://github.com/steveoldmeadow/cocos2d-iphone/tree/develop/CocosDenshion)

This slight change should fix that and allow CocoaPods user to keep on using CocosDenshion.
