### PR TITLE
Updated repo links for UA repos

### DIFF
--- a/UAAppReviewManager/0.1.0/UAAppReviewManager.podspec
+++ b/UAAppReviewManager/0.1.0/UAAppReviewManager.podspec
@@ -5,14 +5,14 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                    UAAppReviewManager is a simple and lightweight App review prompting tool for iOS and Mac App Store apps. It allows you to use it on iOS and Mac targets, allows affiliate links and it rewritten from the ground up for the modern, primetime app.
                    DESC
-  s.homepage     = "https://github.com/coneybeare/UAAppReviewManager"
+  s.homepage     = "https://github.com/urbanapps/UAAppReviewManager"
   s.license      = 'MIT'
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.7'
   s.requires_arc          = true
   s.frameworks            = 'CFNetwork', 'SystemConfiguration', 'StoreKit'
   s.author       = { "Matt Coneybeare" => "coneybeare@urbanapps.com" }
-  s.source       = { :git => "https://github.com/coneybeare/UAAppReviewManager.git", :tag => s.version.to_s }
+  s.source       = { :git => "https://github.com/urbanapps/UAAppReviewManager.git", :tag => s.version.to_s }
   s.source_files  = 'UAAppReviewManager.h', 'UAAppReviewManager.m'
   s.resource_bundles = { 'UAAppReviewManager' => ['Localization/*.lproj'] }
 end

--- a/UALogger/0.2.2/UALogger.podspec
+++ b/UALogger/0.2.2/UALogger.podspec
@@ -5,9 +5,9 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                    UALogger is a logging tool for iOS and Mac apps. It allows you to customize the log format, when to log to the console, and allows collection of the console log for your application.
                    DESC
-  s.homepage     = "https://github.com/coneybeare/UALogger"
+  s.homepage     = "https://github.com/urbanapps/UALogger"
   s.license      = 'MIT'
   s.author       = { "Matt Coneybeare" => "coneybeare@urbanapps.com" }
-  s.source       = { :git => "https://github.com/coneybeare/UALogger.git", :tag => s.version.to_s }
+  s.source       = { :git => "https://github.com/urbanapps/UALogger.git", :tag => s.version.to_s }
   s.source_files  = 'UALogger.h', 'UALogger.m'
 end

--- a/UALogger/0.2.3/UALogger.podspec
+++ b/UALogger/0.2.3/UALogger.podspec
@@ -5,9 +5,9 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                    UALogger is a logging tool for iOS and Mac apps. It allows you to customize the log format, when to log to the console, and allows collection of the console log for your application.
                    DESC
-  s.homepage     = "https://github.com/coneybeare/UALogger"
+  s.homepage     = "https://github.com/urbanapps/UALogger"
   s.license      = 'MIT'
   s.author       = { "Matt Coneybeare" => "coneybeare@urbanapps.com" }
-  s.source       = { :git => "https://github.com/coneybeare/UALogger.git", :tag => s.version.to_s }
+  s.source       = { :git => "https://github.com/urbanapps/UALogger.git", :tag => s.version.to_s }
   s.source_files  = 'UALogger.h', 'UALogger.m'
 end

--- a/UAModalPanel/1.1.1/UAModalPanel.podspec
+++ b/UAModalPanel/1.1.1/UAModalPanel.podspec
@@ -3,10 +3,10 @@ Pod::Spec.new do |s|
   s.version  = '1.1.1'
   s.license  = 'BSD'
   s.summary  = 'An animated modal panel alternative for iOS.'
-  s.homepage = 'http://coneybeare.net'
-  s.author   = { 'Matt Coneybeare' => 'coneybeare@gmail.com' }
-  s.source   = { :git => 'https://github.com/coneybeare/UAModalPanel.git', :tag => '1.1.1' }
-  s.platform = :ios  
+  s.homepage = 'https://github.com/urbanapps/UAModalPanel'
+  s.author   = { 'Matt Coneybeare' => 'coneybeare@urbanapps.com' }
+  s.source   = { :git => 'https://github.com/urbanapps/UAModalPanel.git', :tag => '1.1.1' }
+  s.platform = :ios
   s.source_files = 'UAModalPanel/Panel/Categories/UIView+JMNoise.{h,m}' , 'UAModalPanel/Panel/Panels/*.{h,m}' , 'UAModalPanel/Panel/Views/*.{h,m}'
   s.resources = "UAModalPanel/Panel/Images/*.png"
   s.framework = 'UIKit' , 'QuartzCore'


### PR DESCRIPTION
moved UALogger, UAAppReviewManager and UAModalPanel from `coneybeare` to `urbanapps` 
