### PR TITLE
TLIndexPathTools 0.1.1

### DIFF
--- a/TLIndexPathTools/0.1.1/TLIndexPathTools.podspec
+++ b/TLIndexPathTools/0.1.1/TLIndexPathTools.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name         = "TLIndexPathTools"
+  s.version      = "0.1.1"
+  s.summary      = "TLIndexPathTools makes it easy to build rich, dynamic table and collection views on iOS."
+  s.description  = <<-DESC
+					TLIndexPathTools is a set of components designed to greatly simplify building
+					rich, dynamic table and collection views. Here are some of the awesome things that TLIndexPathTools does:
+
+					* Automatically calculate and perform animated inserts, deletes and moves.
+					* Automatically organize the data model into sections.
+					* Simplify implementing data source and delegate methods via rich data model APIs.
+					* Provide a simpler alternative to Core Data's `NSFetchedResultsController`
+                    DESC
+  s.homepage     = "tlindexpathtools.com"
+  s.license      = { :type => "MIT" }
+  s.author       = { "wtmoose" => "wtm@tractablelabs.com" }
+  s.source       = { :git => "https://github.com/wtmoose/TLIndexPathTools.git", :tag => '0.1.0' }
+  s.platform     = :ios, '6.0'
+  s.ios.deployment_target = '6.0'
+  s.source_files = 'TLIndexPathTools/**/*.{h,m}'
+  s.frameworks = 'UIKit', 'QuartzCore', 'CoreData', 'Foundation'
+  s.requires_arc = true
+end

--- a/TLIndexPathTools/0.1.1/TLIndexPathTools.podspec
+++ b/TLIndexPathTools/0.1.1/TLIndexPathTools.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.homepage     = "tlindexpathtools.com"
   s.license      = { :type => "MIT" }
   s.author       = { "wtmoose" => "wtm@tractablelabs.com" }
-  s.source       = { :git => "https://github.com/wtmoose/TLIndexPathTools.git", :tag => '0.1.0' }
+  s.source       = { :git => "https://github.com/wtmoose/TLIndexPathTools.git", :tag => '0.1.1' }
   s.platform     = :ios, '6.0'
   s.ios.deployment_target = '6.0'
   s.source_files = 'TLIndexPathTools/**/*.{h,m}'


### PR DESCRIPTION
UITableView uses NSIndexPath and UIMutableIndexPath at different times and isEqual does not work across classes
