### PR TITLE
Remove line which was cause of build errors in Xcode5

### DIFF
--- a/YandexMapKit/1.0.5/YandexMapKit.podspec
+++ b/YandexMapKit/1.0.5/YandexMapKit.podspec
@@ -12,7 +12,6 @@ Pod::Spec.new do |s|
   s.resource   = 'YandexMapKit.bundle'
   s.frameworks = 'AudioToolbox', 'OpenAL', 'AVFoundation', 'CoreData', 'CoreLocation', 'CoreTelephony', 'QuartzCore', 'MessageUI', 'OpenGLES', 'Security', 'SystemConfiguration'
   s.libraries  = 'sqlite3', 'stdc++', 'xml2', 'z'
-  s.library  = 'YandexMapKit'
   s.preserve_paths = 'libYandexMapKit.a'
   s.xcconfig = { 
     'HEADER_SEARCH_PATHS'  => '"$(SDKROOT)/usr/include/libxml2"',


### PR DESCRIPTION
s.library  = 'YandexMapKit'

This line overwrite correct settings for build (s.libraries  = 'sqlite3', 'stdc++', 'xml2', 'z') and was cause of build errors in Xcode5
