### PR TITLE
Fix TwilioSDK 1.1.2 so it points to proper folders

### DIFF
--- a/TwilioSDK/1.1.2/TwilioSDK.podspec
+++ b/TwilioSDK/1.1.2/TwilioSDK.podspec
@@ -8,13 +8,13 @@ Pod::Spec.new do |s|
   s.source       = { :http => "http://static.twilio.com/sdk/ios/twilioclient-ios-1.1.2-a755dee.tar.bz2" }
   s.description  = 'Twilio Client has the features that make it easy to embed VoIP directly into your web, iOS or Android apps. Easily make and receive calls from the browser.'
   s.platform     = :ios
-  s.source_files = '**/*.h'
-  s.preserve_paths = '**/*.a'
+  s.source_files = 'Headers/*.h'
+  s.preserve_paths = 'Libraries/*.a'
   s.libraries = 'TwilioClient', 'ssl', 'crypto'
   s.frameworks = 'AudioToolbox', 'AVFoundation', 'CFNetwork', 'SystemConfiguration'
   s.xcconfig  =  {
-                  'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/TwilioSDK/Twilio"',
+                  'LIBRARY_SEARCH_PATHS' => '$(PODS_ROOT)/TwilioSDK/Libraries',
                   'OTHER_LD_FLAGS' => '$(inherited) -ObjC -all_load'
                 }
-  s.resources = ["**/Resources/*.*"]
+  s.resources = ["Resources/*.*"]
 end


### PR DESCRIPTION
Prior submission referenced incorrect paths and pulled in unneeded files.
