### PR TITLE
[add] ShipLib 1.7

### DIFF
--- a/ShipLib/1.7/ShipLib.podspec
+++ b/ShipLib/1.7/ShipLib.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name  = 'ShipLib'
+  s.version = '1.7'
+  s.platform = :ios
+  s.summary = 'Allow users to send printed photos from your app.'
+  s.author = { 'Sincerely' => 'devsupport@sincerely.com' }
+  s.homepage = 'https://github.com/sincerely/shiplib-ios-framework'
+  s.license = { :file => 'LICENSE', :type => 'Commercial' }
+  s.source = {
+    :git => 'https://github.com/sincerely/shiplib-ios-framework.git',
+    :tag => s.version.to_s
+  }
+  s.frameworks = 'AddressBook', 'AddressBookUI', 'SystemConfiguration'
+  s.ios.vendored_frameworks = 'ShipLib.framework'
+  s.resources = 'ShipLibResources.bundle'
+end


### PR DESCRIPTION
ShipLib is an iOS framework that lets your customers print and ship real postcards right from your app.
