### PR TITLE
Added libzmq 3.2.3

### DIFF
--- a/libzmq/3.2.3/libzmq.podspec
+++ b/libzmq/3.2.3/libzmq.podspec
@@ -1,0 +1,27 @@
+Pod::Spec.new do |s|
+   s.name            = 'libzmq'
+   s.version         = '3.2.3'
+   s.platform        = :osx
+   s.summary         = 'Zero MQ, The Simplest Way to Connect Pieces, sockets on steroids.'
+   s.author          = 'iMatix'
+   s.homepage        = 'zeromq.org'
+   s.license         = { 
+      :type => 'LGPL',
+      :file => 'COPYING.LESSER'
+   }
+
+   s.source          = {
+      :git => 'https://github.com/zeromq/zeromq3-x.git',
+      :tag => 'v3.2.3'
+   }
+   s.prepare_command = <<-CMD
+         sh autogen.sh
+         ./configure
+         make
+CMD
+   
+   s.public_header_files = 'include/*.h'
+   s.xcconfig        =  { 'LIBRARY_SEARCH_PATHS' => '$(PODS_ROOT)/zeromq/src/.libs' }
+   s.preserve_paths  = 'src/.libs/libzmq.a','include/*.h'
+   s.libraries       = 'zmq','stdc++'
+end


### PR DESCRIPTION
This pulls from the official stable 3.x repository.
It just runs the official build instructions on pod install
