### PR TITLE
Improves how background operations are handled.

### DIFF
--- a/ObjectiveHAL/1.2.0/ObjectiveHAL.podspec
+++ b/ObjectiveHAL/1.2.0/ObjectiveHAL.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |s|
+    s.name         = "ObjectiveHAL"
+    s.version      = "1.2.0"
+    s.license      = { :type => 'MIT', :file => 'LICENSE' }
+
+    s.homepage     = "https://github.com/ObjectiveHAL/ObjectiveHAL"
+
+    s.summary      = "Objective-C implementation of the JSON Hypertext Application Language."
+
+    s.authors      = { 'Bennett Smith' => 'bennett@focalshift.com',
+                     'Andre Musie' => 'andre@wonderful.com' }
+
+    s.source       = { :git => "https://github.com/ObjectiveHAL/ObjectiveHAL.git", 
+                       :tag => "1.2.0" }
+
+    s.platform = :ios
+    s.ios.deployment_target = '6.1'
+
+    s.source_files = 'ObjectiveHAL', 'ObjectiveHAL/**/*.{h,m}'
+    s.public_header_files = 'ObjectiveHAL/*.h'
+
+    s.requires_arc = true
+
+    s.dependency 'CSURITemplate'
+    s.dependency 'AFNetworking', '~> 1.3'
+
+    s.frameworks   = 'Security', 'SystemConfiguration', 'MobileCoreServices', 'CoreGraphics'    
+end


### PR DESCRIPTION
All background operations are now queued to a single NSOperationQueue.
Previously the code was constructing separate NSOperationQueue instances
for each traversal. This made it difficult to debug background tasks
because there was an explosion of threads.

Switched the default handling of embedded resources on by default. In
earlier versions the default was to ignore embedded resources unless
the caller explicitly turned them on.  This seemed backwards.
