### PR TITLE
Add versioned QuadCurveMenu

### DIFF
--- a/QuadCurveMenu/1.0.0/QuadCurveMenu.podspec
+++ b/QuadCurveMenu/1.0.0/QuadCurveMenu.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name         = "QuadCurveMenu"
+  s.version      = "1.0.0"
+  s.summary      = "Path 2.0 menu (configurable, extendable, and composable)."
+  s.homepage     = "https://github.com/burtlo/QuadCurveMenu"
+  s.license      = 'MIT'
+  s.author       = { "Franklin Webber" => "franklin.webber@gmail.com" }
+  s.source       = { :git => "https://github.com/burtlo/QuadCurveMenu.git", :tag => "1.0.0" }
+  s.platform     = :ios
+  s.source_files = 'AwesomeMenu/QuadCurveMenu/*.{h,m}','AwesomeMenu/AGMedallionView.{h,m}'
+  s.resources    = "AwesomeMenu/Images/*.png"
+  s.framework    = 'QuartzCore'
+  s.requires_arc = true
+end


### PR DESCRIPTION
Repo is now tagged to support CocoaPods versioning. Lint passed. :-)

```
** BUILD SUCCEEDED **

 -> QuadCurveMenu (1.0.0)

Analyzed 1 podspec.

QuadCurveMenu.podspec passed validation.
```
