### PR TITLE
Remove conflict Default.png file & localizable file

### DIFF
--- a/vfrReader/2.6.2/vfrReader.podspec
+++ b/vfrReader/2.6.2/vfrReader.podspec
@@ -12,7 +12,9 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Sources/**/*.{h,m}'
 
-  s.resources = 'Resources/*', 'Graphics/*.png'
+  s.resources = 'Resources/*.{pdf}', 'Graphics/*.png'
+
+  s.exclude_files = 'Graphics/Default-568h@2x.png'
 
   s.requires_arc = true
 


### PR DESCRIPTION
Reasons : 
1. Default-568h@2x.png is a black image , when device is run on iPhone5 or 5s it make dark splash screen.
2. Localizable.string is not in bundle file, It'll make localizable file in my project do not work

thanks
