### PR TITLE
PonyDebugger uses CoreGraphics

### DIFF
--- a/PonyDebugger/0.3.0/PonyDebugger.podspec
+++ b/PonyDebugger/0.3.0/PonyDebugger.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   
   s.dependency 'SocketRocket'
   # The readme says that it is needed but it lints without
-  s.frameworks   = 'CoreData'
+  s.frameworks   = 'CoreData', 'CoreGraphics'
 end


### PR DESCRIPTION
PonyDebuger uses CGRectContainsPoint(), CGRectGetMidX(), CGRectGetMidY(), CGRectIntegral(), and CGRectZero, which all fit under the umbrella of CoreGraphics.  However, the podspec currently doesn't note that it needs CoreGraphics, so if your project doesn't include the framework already, you'll get linker errors.

E.G.:
![screen shot 2013-09-26 at 1 32 39 pm](https://f.cloud.github.com/assets/74679/1219920/3eeb3044-26d3-11e3-8a4d-051a013e694b.png)

This adds it under `s.frameworks` in PonyDebugger's 0.3.0 podspec.
