### PR TITLE
missing "http://" on homepage link.

### DIFF
--- a/DLCImagePickerController/0.0.1/DLCImagePickerController.podspec
+++ b/DLCImagePickerController/0.0.1/DLCImagePickerController.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
                     DLCImagePickerController is a fast, beautiful and fun way to filter and capture your photos with OpenGL and your iPhone.
                     The majority of the praise should be directed towards BradLarson for his GPUImage library.
                    DESC
-  s.homepage     = "www.backspac.es"
+  s.homepage     = "http://www.backspac.es/"
   s.license      = 'BSD'
   s.author       = { "Dmitri Cherniak" => "dmitric@gmail.com" }
   s.source       = { :git => "https://github.com/gobackspaces/DLCImagePickerController.git", :tag => "0.0.1" }


### PR DESCRIPTION
get wrong link if missing "http://" on homepage link.

![dlcimagepickercontroller-1](https://f.cloud.github.com/assets/876461/1092162/8d5f2388-1676-11e3-907e-87b445830719.png)
