### PR TITLE
Prevent crashes by including TagManager headers

### DIFF
--- a/GoogleAnalytics-iOS-SDK/3.0.1/GoogleAnalytics-iOS-SDK.podspec
+++ b/GoogleAnalytics-iOS-SDK/3.0.1/GoogleAnalytics-iOS-SDK.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios
   s.ios.deployment_target = '5.0'
 
-  s.source_files = 'GoogleAnalytics/Library/*.h'
+  s.source_files = ['GoogleAnalytics/Library/*.h', 'GoogleTagManager/Library/*.h']
   s.preserve_paths = 'libGoogleAnalyticsServices.a'
 
   s.frameworks = 'CFNetwork', 'CoreData', 'SystemConfiguration'


### PR DESCRIPTION
The libGoogleAnalyticsServices.a also includes the GoogleTagManager files. Because the headers were not included my application would crash on launch because the tag manager attempts to call non-existing selectors in `+initialize`.
