### PR TITLE
Fix podspec for LDProgressView [1.0]

### DIFF
--- a/LDProgressView/1.0/LDProgressView.podspec
+++ b/LDProgressView/1.0/LDProgressView.podspec
@@ -4,9 +4,9 @@ Pod::Spec.new do |s|
 	s.summary = 'A configurable progress view with a single color setter written in CoreGraphics'
 	s.description = 'A flat or gradient progress view with a simple color setter and customizable options written in pure Core Graphics.'
 	s.homepage = 'https://github.com/lightdesign/LDProgressView'
-	s.license = {type: 'MIT', file: 'LICENSE'}
+	s.license = {:type => 'MIT', :file => 'LICENSE'}
 	s.author = {'Light Design' => 'lightdesigncoding@icloud.com', 'Christian Di Lorenzo' => 'rcddeveloper@icloud.com'}
-	s.source = {git: 'https://github.com/lightdesign/LDProgressView.git', tag: s.version.to_s}
+	s.source = {:git => 'https://github.com/lightdesign/LDProgressView.git', :tag => s.version.to_s}
 	s.platform = :ios, '6.0'
 	s.source_files = 'LDProgressView/LDProgressView.*', 'LDProgressView/UIColor+RGBValues.*'
 	s.framework = 'CoreGraphics'


### PR DESCRIPTION
The travis ci build failed because I was using the newer ruby has syntax. Here's a link to the [build failure](http://mandrillapp.com/track/click.php?u=30007208&id=a6b62c5b493b42019d92188380c1bf10&url=https%3A%2F%2Ftravis-ci.org%2FCocoaPods%2FSpecs%2Fbuilds%2F11957323&url_id=5ca76ac97d9bcaa67cb11f4e8db47cf794849a4b).
