### PR TITLE
Added podspecs for NRGramKit 1.1 and 1.4

### DIFF
--- a/NRGramKit/1.1/NRGramKit.podspec
+++ b/NRGramKit/1.1/NRGramKit.podspec
@@ -1,0 +1,29 @@
+Pod::Spec.new do |s|
+  s.name         = "NRGramKit"
+  s.version      = "1.1"
+  s.summary      = "A simple block-based library to access all the functions of the Instagram API."
+  s.homepage     = "https://github.com/NextRoot/NRGramKit"
+  s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }
+  s.author       = { "Raul Andrisan" => "raul@nextroot.com" }
+  s.source       = { :git => "https://github.com/NextRoot/NRGramKit.git", :tag=>s.version.to_s }
+  s.platform     = :ios, '5.0'
+
+  s.source_files = 'NRGramKit/*.{h,m}','NRGramKit/Model/*.{h,m}'
+  #s.exclude_files = 'NRGramKit/*.pch'
+
+  s.frameworks = 'SystemConfiguration', 'CFNetwork','Security'
+
+  # If this Pod uses ARC, specify it like so.
+  #
+  s.requires_arc = true
+  s.dependency 'AFNetworking', '~> 1.3.1'
+    
+    def s.post_install(target)
+    puts <<-TEXT
+    * NRGramKit note *
+    Don't forget to create and add NRGramKitConfigs.plist file to you project.
+    You can find an example here: https://github.com/NextRoot/NRGramKit/blob/master/NRGramKitConfigs.plist
+    TEXT
+    end
+
+end

--- a/NRGramKit/1.4/NRGramKit.podspec
+++ b/NRGramKit/1.4/NRGramKit.podspec
@@ -1,0 +1,29 @@
+Pod::Spec.new do |s|
+  s.name         = "NRGramKit"
+  s.version      = "1.4"
+  s.summary      = "A simple block-based library to access all the functions of the Instagram API."
+  s.homepage     = "https://github.com/NextRoot/NRGramKit"
+  s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }
+  s.author       = { "Raul Andrisan" => "raul@nextroot.com" }
+  s.source       = { :git => "https://github.com/NextRoot/NRGramKit.git", :tag=>s.version.to_s }
+  s.platform     = :ios, '5.0'
+
+  s.source_files = 'NRGramKit/*.{h,m}','NRGramKit/Model/*.{h,m}'
+  #s.exclude_files = 'NRGramKit/*.pch'
+
+  s.frameworks = 'SystemConfiguration', 'CFNetwork','Security'
+
+  # If this Pod uses ARC, specify it like so.
+  #
+  s.requires_arc = true
+  s.dependency 'AFNetworking', '~> 1.3.1'
+    
+    def s.post_install(target)
+    puts <<-TEXT
+    * NRGramKit note *
+    Don't forget to create and add NRGramKitConfigs.plist file to you project.
+    You can find an example here: https://github.com/NextRoot/NRGramKit/blob/master/NRGramKitConfigs.plist
+    TEXT
+    end
+
+end


### PR DESCRIPTION
Strangely, they were missing from CocoaPods Specs repo— who knows why the author of NRGramKit never added them for any version of NRGramKit past 1.0.

• Added NRGramKit 1.1 podspec (copied from NextRoot/NRGramKit@8960fb8d6ecec00b586fb18c5ca37b590ea4efb3)
• Added NRGramKit 1.4 podspec (copied from NextRoot/NRGramKit@791bbb8d3c908985092718666bf3d4f063823075)
