### PR TITLE
Typo. Spec.homepage was missing 'https'

### DIFF
--- a/BTButton/1.0.0/BTButton.podspec
+++ b/BTButton/1.0.0/BTButton.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name         = "BTButton"
   s.version      = "1.0.0"
   s.summary      = "Custom UIButton implementation with image and text."
-  s.homepage     = "://github.com/borut-t/BTButton"
+  s.homepage     = "https://github.com/borut-t/BTButton"
   s.screenshots  = "https://raw.github.com/borut-t/BTButton/master/Screenshots/preview.png"
   s.license      = { :type => 'zlib', :file => 'LICENCE.md' }
   s.author       = { "Borut Tomažin" => "borut.tomazin@gmail.com" }


### PR DESCRIPTION
spec.homepage was ://github.com/borut-t/BTButton

changed to http://github.com/borut-t/BTButton

link was broken on cocoapods.org.
