### PR TITLE
Updated the Parse podspec to include itself as a framework.

### DIFF
--- a/Parse/1.2.15/Parse.podspec
+++ b/Parse/1.2.15/Parse.podspec
@@ -1,19 +1,19 @@
 Pod::Spec.new do |s|
-  s.name         = 'Parse'
-  s.version      = '1.2.15'
-  s.license = { :type => 'Commercial', :text => 'See https://parse.com/about/terms' }
+  s.name = 'Parse'
+  s.version = '1.2.15'
   s.platform = :ios
-  s.summary      = 'iOS framework for developing apps using the Parse BaaS.'
-  s.description  = 'To integrate after adding this pod, continue with step 9 in the QuickStart: (https://parse.com/apps/quickstart).'
-  s.homepage     = 'http://parse.com'
-  s.author = { 'Parse' => 'support@parse.com' }
-  s.source = { :git => 'https://github.com/jessbowers/Parse.git', :tag => "#{s.version}" }
-  s.source_files = 'ParseDummy.{m,h}'
-  s.preserve_paths = 'Parse.framework'
+  s.license = { :type => 'Commercial', :text => 'See https://parse.com/about/terms' }
+  s.summary = 'iOS framework for developing apps using the Parse BaaS.'
+  s.homepage = 'http://parse.com'
+  s.authors = { 'Parse' => 'support@parse.com' }
+  s.source = { :http => 'http://parse-ios.s3.amazonaws.com/9edd9a2a46aed61f02ed9a0b83528d1e/parse-library-1.2.15.zip' }
   s.requires_arc = true
-  s.frameworks =  'StoreKit', 'AudioToolbox', 'CFNetwork', 'SystemConfiguration', 'MobileCoreServices', 'CoreGraphics', 'Security', 'QuartzCore', 'CoreLocation', 'Parse'
+  s.framework = 'StoreKit', 'AudioToolbox', 'CFNetwork', 'SystemConfiguration', 'MobileCoreServices', 'CoreGraphics', 'Security', 'QuartzCore', 'CoreLocation'
   s.weak_frameworks = 'AdSupport','Social', 'Accounts'
-  s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/Parse"' }
   s.library = 'z', 'sqlite3'
+  s.preserve_paths = "Parse.framework"
+  s.public_header_files = "Parse.framework/Headers/*.h"
+  s.vendored_frameworks = "Parse.framework"
+  s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/Parse"' }
   s.dependency 'Facebook-iOS-SDK', '~> 3.7'
 end


### PR DESCRIPTION
The current implementation of the Parse pod uses hosted cloned version of the framework instead of a link directly from the Parse website. In addition, the framework isn't included properly. With this version, the Parse.framework is included as a framework should be and includes the public headers in the right place.
