### PR TITLE
Adding Parse-iOS-SDK and Parse-OSX-SDK

### DIFF
--- a/Parse-OSX-SDK/1.2.15/Parse-OSX-SDK.podspec
+++ b/Parse-OSX-SDK/1.2.15/Parse-OSX-SDK.podspec
@@ -13,8 +13,6 @@ Pod::Spec.new do |s|
   s.library   = 'z', 'sqlite3'
   
   s.preserve_paths      = "ParseOSX.framework"
-  s.public_header_files = "ParseOSX.framework/Headers/*.h"
+  s.public_header_files = "ParseOSX.framework/**/*.h"
   s.vendored_frameworks = "ParseOSX.framework"
-  
-  s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/Parse-OSX-SDK"' }
 end

--- a/Parse-OSX-SDK/1.2.15/Parse-OSX-SDK.podspec
+++ b/Parse-OSX-SDK/1.2.15/Parse-OSX-SDK.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name      = "Parse-OSX-SDK"
+  s.version   = "1.2.15"
+  s.summary   = "Parse is a complete technology stack to power your app's backend."
+  s.homepage  = "http://www.parse.com"
+  s.author    = "Parse"
+  s.license   = { :type => 'Commercial', :text => 'See https://parse.com/about/terms' }
+  
+  s.platform  = :osx, '10.8'
+
+  s.source    = { :http => 'http://parse-ios.s3.amazonaws.com/9edd9a2a46aed61f02ed9a0b83528d1e/parse-osx-library-1.2.15.zip' }
+  s.framework = 'CFNetwork', 'CoreGraphics', 'CoreLocation', 'QuartzCore', 'Security', 'SystemConfiguration'
+  s.library   = 'z', 'sqlite3'
+  
+  s.preserve_paths      = "ParseOSX.framework"
+  s.public_header_files = "ParseOSX.framework/Headers/*.h"
+  
+  s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/Parse-OSX-SDK"' }
+end

--- a/Parse-OSX-SDK/1.2.15/Parse-OSX-SDK.podspec
+++ b/Parse-OSX-SDK/1.2.15/Parse-OSX-SDK.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   
   s.platform  = :osx, '10.8'
 
-  s.source    = { :http => 'http://parse-ios.s3.amazonaws.com/9edd9a2a46aed61f02ed9a0b83528d1e/parse-osx-library-1.2.15.zip' }
+  s.source    = { :http => "http://parse-ios.s3.amazonaws.com/9edd9a2a46aed61f02ed9a0b83528d1e/parse-osx-library-#{s.version}.zip" }
   s.framework = 'CFNetwork', 'CoreGraphics', 'CoreLocation', 'QuartzCore', 'Security', 'SystemConfiguration'
   s.library   = 'z', 'sqlite3'
   

--- a/Parse-OSX-SDK/1.2.15/Parse-OSX-SDK.podspec
+++ b/Parse-OSX-SDK/1.2.15/Parse-OSX-SDK.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   
   s.preserve_paths      = "ParseOSX.framework"
   s.public_header_files = "ParseOSX.framework/Headers/*.h"
+  s.vendored_frameworks = "ParseOSX.framework"
   
   s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/Parse-OSX-SDK"' }
 end

--- a/Parse-iOS-SDK/1.2.15/Parse-iOS-SDK.podspec
+++ b/Parse-iOS-SDK/1.2.15/Parse-iOS-SDK.podspec
@@ -14,11 +14,9 @@ Pod::Spec.new do |s|
   s.weak_frameworks = 'Accounts', 'AdSupport', 'Social'
   s.library         = 'z', 'sqlite3'
 
-  s.preserve_paths      = "Parse.framework"  
-  s.public_header_files = "Parse.framework/Headers/*.h"
+  s.preserve_paths      = "Parse.framework"
+  s.public_header_files = "Parse.framework/**/*.h"
   s.vendored_frameworks = "Parse.framework"
-  
-  s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/Parse-iOS-SDK"' }
   
   s.dependency 'Facebook-iOS-SDK', '~> 3.7'
 end

--- a/Parse-iOS-SDK/1.2.15/Parse-iOS-SDK.podspec
+++ b/Parse-iOS-SDK/1.2.15/Parse-iOS-SDK.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name      = "Parse-iOS-SDK"
+  s.version   = "1.2.15"
+  s.summary   = "Parse is a complete technology stack to power your app's backend."
+  s.homepage  = "http://www.parse.com"
+  s.author    = "Parse"
+  s.license   = { :type => 'Commercial', :text => 'See https://parse.com/about/terms' }
+
+  s.platform      = :ios, '5.0'
+  s.requires_arc  = true
+  
+  s.source          = { :http => 'http://parse-ios.s3.amazonaws.com/9edd9a2a46aed61f02ed9a0b83528d1e/parse-library-1.2.15.zip' }
+  s.framework       = 'AudioToolbox', 'CFNetwork', 'CoreGraphics', 'CoreLocation', 'MobileCoreServices', 'QuartzCore', 'Security', 'StoreKit', 'SystemConfiguration'
+  s.weak_frameworks = 'Accounts', 'AdSupport', 'Social'
+  s.library         = 'z', 'sqlite3'
+
+  s.preserve_paths      = "Parse.framework"  
+  s.public_header_files = "Parse.framework/Headers/*.h"
+
+  s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"${PODS_ROOT}/Parse-iOS-SDK"' }
+  
+  s.dependency 'Facebook-iOS-SDK', '~> 3.7'
+end

--- a/Parse-iOS-SDK/1.2.15/Parse-iOS-SDK.podspec
+++ b/Parse-iOS-SDK/1.2.15/Parse-iOS-SDK.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
 
   s.preserve_paths      = "Parse.framework"  
   s.public_header_files = "Parse.framework/Headers/*.h"
+  s.vendored_frameworks = "Parse.framework"
 
   s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"${PODS_ROOT}/Parse-iOS-SDK"' }
   

--- a/Parse-iOS-SDK/1.2.15/Parse-iOS-SDK.podspec
+++ b/Parse-iOS-SDK/1.2.15/Parse-iOS-SDK.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.platform      = :ios, '5.0'
   s.requires_arc  = true
   
-  s.source          = { :http => 'http://parse-ios.s3.amazonaws.com/9edd9a2a46aed61f02ed9a0b83528d1e/parse-library-1.2.15.zip' }
+  s.source          = { :http => "http://parse-ios.s3.amazonaws.com/9edd9a2a46aed61f02ed9a0b83528d1e/parse-library-#{s.version}.zip" }
   s.framework       = 'AudioToolbox', 'CFNetwork', 'CoreGraphics', 'CoreLocation', 'MobileCoreServices', 'QuartzCore', 'Security', 'StoreKit', 'SystemConfiguration'
   s.weak_frameworks = 'Accounts', 'AdSupport', 'Social'
   s.library         = 'z', 'sqlite3'
@@ -17,8 +17,8 @@ Pod::Spec.new do |s|
   s.preserve_paths      = "Parse.framework"  
   s.public_header_files = "Parse.framework/Headers/*.h"
   s.vendored_frameworks = "Parse.framework"
-
-  s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"${PODS_ROOT}/Parse-iOS-SDK"' }
+  
+  s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/Parse-iOS-SDK"' }
   
   s.dependency 'Facebook-iOS-SDK', '~> 3.7'
 end

--- a/Parse/1.2.15/Parse.podspec
+++ b/Parse/1.2.15/Parse.podspec
@@ -1,19 +1,19 @@
 Pod::Spec.new do |s|
-  s.name = 'Parse'
-  s.version = '1.2.15'
-  s.platform = :ios
+  s.name         = 'Parse'
+  s.version      = '1.2.15'
   s.license = { :type => 'Commercial', :text => 'See https://parse.com/about/terms' }
-  s.summary = 'iOS framework for developing apps using the Parse BaaS.'
-  s.homepage = 'http://parse.com'
-  s.authors = { 'Parse' => 'support@parse.com' }
-  s.source = { :http => 'http://parse-ios.s3.amazonaws.com/9edd9a2a46aed61f02ed9a0b83528d1e/parse-library-1.2.15.zip' }
+  s.platform = :ios
+  s.summary      = 'iOS framework for developing apps using the Parse BaaS.'
+  s.description  = 'To integrate after adding this pod, continue with step 9 in the QuickStart: (https://parse.com/apps/quickstart).'
+  s.homepage     = 'http://parse.com'
+  s.author = { 'Parse' => 'support@parse.com' }
+  s.source = { :git => 'https://github.com/jessbowers/Parse.git', :tag => "#{s.version}" }
+  s.source_files = 'ParseDummy.{m,h}'
+  s.preserve_paths = 'Parse.framework'
   s.requires_arc = true
-  s.framework = 'StoreKit', 'AudioToolbox', 'CFNetwork', 'SystemConfiguration', 'MobileCoreServices', 'CoreGraphics', 'Security', 'QuartzCore', 'CoreLocation'
+  s.frameworks =  'StoreKit', 'AudioToolbox', 'CFNetwork', 'SystemConfiguration', 'MobileCoreServices', 'CoreGraphics', 'Security', 'QuartzCore', 'CoreLocation', 'Parse'
   s.weak_frameworks = 'AdSupport','Social', 'Accounts'
-  s.library = 'z', 'sqlite3'
-  s.preserve_paths = "Parse.framework"
-  s.public_header_files = "Parse.framework/Headers/*.h"
-  s.vendored_frameworks = "Parse.framework"
   s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/Parse"' }
+  s.library = 'z', 'sqlite3'
   s.dependency 'Facebook-iOS-SDK', '~> 3.7'
 end


### PR DESCRIPTION
I decided it would be better to create new pods rather than replace the already existing Parse (iOS-only) pod. This pull request reverts the changes I made earlier and adds two new pods, Parse-iOS-SDK and Parse-OSX-SDK.
