### PR TITLE
Add GoogleProtobuf 2.4.1 version ( c++ library)

### DIFF
--- a/GoogleProtobuf/2.4.1/GoogleProtobuf.podspec
+++ b/GoogleProtobuf/2.4.1/GoogleProtobuf.podspec
@@ -9,4 +9,5 @@ Pod::Spec.new do |s|
   s.license = { :type => 'BSD', :file => 'LICENSE'}
   s.source_files = 'config.h', 'google/**/*.{h,cc}'
   s.header_mappings_dir = './'
+  s.requires_arc = false
 end

--- a/GoogleProtobuf/2.4.1/GoogleProtobuf.podspec
+++ b/GoogleProtobuf/2.4.1/GoogleProtobuf.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.platform = :ios, '7.0'
+  s.name     = 'GoogleProtobuf'
+  s.version  = '2.4.1'
+  s.summary  = 'Google Protocol Buffers serialization library'
+  s.authors  = { 'Michal Laskowski' => 'michal.laskowski.dev@gmail.com' }
+  s.source   = { :git => 'https://github.com/michallaskowski/protobuf-pod.git', :tag => '2.4.1' }
+  s.homepage     = "https://github.com/michallaskowski/protobuf-pod"
+  s.license = { :type => 'BSD', :file => 'LICENSE'}
+  s.source_files = 'config.h', 'google/**/*.{h,cc}'
+  s.header_mappings_dir = './'
+end


### PR DESCRIPTION
Hi,
this is pod specification for Google Protocol Buffers 2.4.1 library (c++), that is working under iOS 7, with standard c++ compiler settings.
I am new to CocoaPods and Git, so if there are problems please bear with me.

Regards,
Michal
