### PR TITLE
update PKAnimations to version 0.2.0

### DIFF
--- a/PKAnimations/0.2.0/PKAnimations.podspec
+++ b/PKAnimations/0.2.0/PKAnimations.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name         = "PKAnimations"
+  s.version      = "0.2.0"
+  s.summary      = "A convenient way to run UIKit Animations in sequence and/or parallel using different easing equations."
+  s.homepage     = "https://github.com/patrickkulling/PKAnimations"
+  s.license      = 'MIT'
+  s.author       = { "Patrick Kulling" => "kontakt@patrickkulling.de" }
+  s.source       = { :git => "https://github.com/patrickkulling/PKAnimations.git", :tag => "0.2.0" }
+  s.platform     = :ios, '5.0'
+  s.ios.deployment_target = '5.0'
+  s.source_files = 'PKAnimations/**/*.{h,m}'
+  s.requires_arc = true
+  s.dependency 'MGCommand', '0.2.0'
+  s.ios.frameworks = 'Foundation', 'QuartzCore', 'CoreGraphics', 'UIKit'
+end


### PR DESCRIPTION
0.2.0 (10-07-2013)

[FIX] Retain cycle with using CAAnimation
[FIX] Compiler warnings
[INFO] bump MGCommand dependency to version 0.2.0 to fix memory leaks
