### PR TITLE
Update the homepage link in the old ISO 8601 Date Formatter podspecs

### DIFF
--- a/ISO8601DateFormatter/0.5/ISO8601DateFormatter.podspec
+++ b/ISO8601DateFormatter/0.5/ISO8601DateFormatter.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version  = '0.5'
   s.license  = 'BSD'
   s.summary  = 'A Cocoa NSFormatter subclass to convert dates to and from ISO-8601-formatted strings. Supports calendar, week, and ordinal formats.'
-  s.homepage = 'https://bitbucket.org/boredzo/iso-8601-parser-unparser/'
+  s.homepage = 'http://boredzo.org/iso8601dateformatter/'
   s.author   = 'Peter Hosey'
   s.source   = { :git => 'https://github.com/boredzo/iso-8601-date-formatter.git', :tag => '0.5' }
 

--- a/ISO8601DateFormatter/0.6/ISO8601DateFormatter.podspec
+++ b/ISO8601DateFormatter/0.6/ISO8601DateFormatter.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version  = '0.6'
   s.license  = 'BSD'
   s.summary  = 'A Cocoa NSFormatter subclass to convert dates to and from ISO-8601-formatted strings. Supports calendar, week, and ordinal formats.'
-  s.homepage = 'https://bitbucket.org/boredzo/iso-8601-parser-unparser/'
+  s.homepage = 'http://boredzo.org/iso8601dateformatter/'
   s.author   = 'Peter Hosey'
   s.source   = { :git => 'https://github.com/boredzo/iso-8601-date-formatter.git', :tag => '0.6' }
 


### PR DESCRIPTION
The old Bitbucket repo is unuseful, bordering on misleading, as a home page; Bitbucket's current display of it doesn't show the formerly-prominent notice that “THIS REPO WILL NEVER BE UPDATED” anymore.

Anyone who goes to the Bitbucket repo thinking that they'll get current information and/or recent source code will not get either, and may not even realize their mistake.

The 0.7 podspec already contains the correct homepage; this change retroactively updates the two older podspecs to point to that same page.

The proper homepage includes historical as well as current\* information, so it's the more correct homepage for all versions.

*As soon as I update it for 0.7, which should happen tomorrow or the day after.
