### PR TITLE
Update GoogleAnalytics-iOS-SDK.podspec

### DIFF
--- a/GoogleAnalytics-iOS-SDK/3.0.1/GoogleAnalytics-iOS-SDK.podspec
+++ b/GoogleAnalytics-iOS-SDK/3.0.1/GoogleAnalytics-iOS-SDK.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios
   s.ios.deployment_target = '5.0'
 
-  s.source_files = 'GoogleAnalytics/Library/*.h'
+  s.source_files = 'GoogleAnalytics/Library/*.h', 'GoogleTagManager/Library/*.h'
   s.preserve_paths = 'libGoogleAnalyticsServices.a'
 
   s.frameworks = 'CFNetwork', 'CoreData', 'SystemConfiguration'


### PR DESCRIPTION
Update to include header files for googleTagManager, by adding folder to source_files.

reason: `libGoogleAnalyticsServices.a` is now a combined SDK containing both google analytics and google tag manager. (See `readme` in the SDK [GoogleAnalyticsServicesiOS_3.01.zip](http://dl.google.com/googleanalyticsservices/GoogleAnalyticsServicesiOS_3.01.zip)
