### PR TITLE
JSONKit podspec fix for 64 bit deprecation issue and Xcode 5 issues.

### DIFF
--- a/JSONKit/1.6/JSONKit.podspec
+++ b/JSONKit/1.6/JSONKit.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name     = 'JSONKit'
+  s.version  = '1.6'
+  s.license  = 'BSD / Apache License, Version 2.0'
+  s.summary  = 'A Very High Performance Objective-C JSON Library.'
+  s.homepage = 'https://github.com/jstart/JSONKit'
+  s.author   = 'John Engelhart'
+  s.source   = { :git => 'https://github.com/jstart/JSONKit.git', :tag => '1.6' }
+
+  s.source_files   = 'JSONKit.*'
+end


### PR DESCRIPTION
Adding a JSONKit 1.6.  The owner of the repository is not responding to issues and JSONKit will now not compile due to changes to the Objective C runtime.  
