### PR TITLE
Fix Simple-KML dependencies

### DIFF
--- a/Simple-KML/0.1.0/Simple-KML.podspec
+++ b/Simple-KML/0.1.0/Simple-KML.podspec
@@ -10,6 +10,8 @@ Pod::Spec.new do |s|
   s.source_files = 'source/*.{h,m}'
   s.requires_arc = true
   s.framework = 'UIKit'
+  s.library      = 'xml2'
+  s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
   s.dependency 'TouchXML'
-  s.dependency 'objective-zip'
+  s.dependency 'objective-zip', '0.0.1'
 end


### PR DESCRIPTION
Simple-KML depends on a specific version of objective-zip and needs the libxml headers
