### PR TITLE
Fixed invalid homepage URL in UIImage+BlurAndDarken

### DIFF
--- a/UIImage+BlurAndDarken/0.0.1/UIImage+BlurAndDarken.podspec
+++ b/UIImage+BlurAndDarken/0.0.1/UIImage+BlurAndDarken.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name         = "UIImage+BlurAndDarken"
   s.version      = "0.0.1"
   s.summary      = "A category on UIImage to return a blurred and/or darkened copy of the receiver."
-  s.homepage     = "http://EXAMPLE/UIImage+BlurAndDarken"
+  s.homepage     = "https://github.com/bryanjclark/ios-darken-image-with-cifilter"
   s.license      = 'MIT'
   s.author       = { "Bryan Clark" => "bryan@bryanjclark.com" }
   s.platform     = :ios


### PR DESCRIPTION
Fixed homepage URL to go to the git repo, instead of EXAMPLE.
