### PR TITLE
Add TRVSEventSource (0.0.1)

### DIFF
--- a/TRVSEventSource/0.0.1/TRVSEventSource.podspec
+++ b/TRVSEventSource/0.0.1/TRVSEventSource.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "TRVSEventSource"
+  s.version      = "0.0.1"
+  s.summary      = "Server-sent events EventSource implementation in ObjC for iOS and OS X using NSURLSession."
+  s.homepage     = "https://github.com/travisjeffery/TRVSEventSource"
+  s.license      = { :type => 'MIT', :file => 'LICENSE.md' }
+  s.author       = { "Travis Jeffery" => "tj@travisjeffery.com" }
+  s.ios.deployment_target = '7.0'
+  s.osx.deployment_target = '10.9'
+  s.source       = { :git => "https://github.com/travisjeffery/TRVSEventSource.git", :tag => "0.0.1" }
+  s.source_files  = 'TRVSEventSource', 'TRVSEventSource/**/*.{h,m}'
+  s.requires_arc = true
+end


### PR DESCRIPTION
Server-sent events EventSource implementation in ObjC for iOS and OS X using NSURLSession.
