### PR TITLE
ZXing 2.2 spec, Fixes to ZXing 2.1 spec

### DIFF
--- a/ZXing/2.1/ZXing.podspec
+++ b/ZXing/2.1/ZXing.podspec
@@ -19,6 +19,12 @@ Pod::Spec.new do |s|
 #endif
 EOS
 
+  # ZXing won't compile in c++11 included in Xcode 5
+  s.xcconfig = {
+    'CLANG_CXX_LANGUAGE_STANDARD' => 'c++98',
+    'CLANG_CXX_LIBRARY' => 'libstdc++'
+  }
+
   s.libraries                   = 'stdc++', 'iconv'
   s.frameworks                  = 'AddressBook', 'AudioToolbox', 'AVFoundation', 'CoreGraphics', 'CoreMedia', 'CoreVideo', 'ImageIO'
 
@@ -26,7 +32,7 @@ EOS
     ios.platform                = :ios, '4.3'
     ios.ios.deployment_target   = '4.3'
 
-    ios.preserve_paths              = 'cpp/core/src/zxing/**/*.h', 'objc/src/ZXing/*.h'
+    ios.preserve_paths          = 'cpp/core/src/zxing/**/*.h', 'objc/src/ZXing/*.h'
     ios.source_files            = 'cpp/core/src/zxing/**/*.cpp', 'objc/src/ZXing/*.{m,mm}', 'iphone/ZXingWidget/Classes/**/*.{h,m,mm}'
     ios.compiler_flags          = '-IZXing/cpp/core/src/ -IZXing/objc/src/', '-IZXing/cpp/core/src/zxing/', '-IZXing/iphone/ZXingWidget/Classes/'
 

--- a/ZXing/2.2/ZXing.podspec
+++ b/ZXing/2.2/ZXing.podspec
@@ -1,0 +1,37 @@
+Pod::Spec.new do |s|
+  s.name                        = "ZXing"
+  s.version                     = "2.2"
+  s.summary                     = "Multi-format 1D/2D barcode image processing library."
+  s.homepage                    = "http://code.google.com/p/zxing/"
+  s.author                      = "ZXing team (http://code.google.com/p/zxing/people/list)"
+  s.license                     = { :type => 'Apache License 2.0', :file => 'COPYING' }
+  s.source                      = { :svn => "http://zxing.googlecode.com/svn/", :tag => "2.2" }
+
+  s.preserve_paths              = 'cpp/core/src/zxing/**/*.h', 'objc/src/ZXing/*.h', 'cpp/core/src/bigint/*.hh'
+  s.source_files                = 'cpp/core/src/zxing/**/*.cpp', 'objc/src/ZXing/*.{m,mm}', 'cpp/core/src/bigint/*.cc'
+  s.compiler_flags              = '-IZXing/cpp/core/src/ -IZXing/objc/src/'
+  s.requires_arc                = false
+
+# workaround for a missing import in objc/src/ZXing/ZXImage.mm
+  s.prefix_header_contents      = <<-EOS
+#ifdef __OBJC__
+  #import <ImageIO/CGImageSource.h>
+#endif
+EOS
+
+  s.libraries                   = 'stdc++', 'iconv'
+  s.frameworks                  = 'AddressBook', 'AudioToolbox', 'AVFoundation', 'CoreGraphics', 'CoreMedia', 'CoreVideo', 'ImageIO'
+
+  s.subspec 'ios' do |ios|
+    ios.platform                = :ios, '4.3'
+    ios.ios.deployment_target   = '4.3'
+
+    ios.preserve_paths              = 'cpp/core/src/zxing/**/*.h', 'objc/src/ZXing/*.h', 'iphone/ZXingWidget/Classes/**/*.h'
+    ios.source_files            = 'cpp/core/src/zxing/**/*.cpp', 'objc/src/ZXing/*.{m,mm}', 'iphone/ZXingWidget/Classes/**/*.{m,mm}'
+    ios.compiler_flags          = '-IZXing/cpp/core/src/ -IZXing/objc/src/', '-IZXing/cpp/core/src/zxing/', '-IZXing/iphone/ZXingWidget/Classes/'
+
+#   must use xcconfig additional to compiler_flag -I to make this header path also available for the including project
+    ios.xcconfig                = { 'HEADER_SEARCH_PATHS' => '${PODS_ROOT}/ZXing/cpp/core/src/ ${PODS_ROOT}/ZXing/iphone/ZXingWidget/Classes/**' }
+    ios.frameworks              = 'AddressBookUI', 'QuartzCore'
+  end
+end

--- a/ZXing/2.2/ZXing.podspec
+++ b/ZXing/2.2/ZXing.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary                     = "Multi-format 1D/2D barcode image processing library."
   s.homepage                    = "http://code.google.com/p/zxing/"
   s.author                      = "ZXing team (http://code.google.com/p/zxing/people/list)"
-  s.license                     = { :type => 'Apache License 2.0', :file => 'COPYING' }
+  s.license                     = { :type => 'Apache License, Version 2.0', :file => 'COPYING' }
   s.source                      = { :svn => "http://zxing.googlecode.com/svn/", :tag => "2.2" }
 
   s.preserve_paths              = 'cpp/core/src/zxing/**/*.h', 'objc/src/ZXing/*.h', 'cpp/core/src/bigint/*.hh'
@@ -19,6 +19,12 @@ Pod::Spec.new do |s|
 #endif
 EOS
 
+  # ZXing won't compile with c++11, default as of Xcode 5
+  s.xcconfig = {
+    'CLANG_CXX_LANGUAGE_STANDARD' => 'c++98',
+    'CLANG_CXX_LIBRARY' => 'libstdc++'
+  }
+
   s.libraries                   = 'stdc++', 'iconv'
   s.frameworks                  = 'AddressBook', 'AudioToolbox', 'AVFoundation', 'CoreGraphics', 'CoreMedia', 'CoreVideo', 'ImageIO'
 
@@ -26,9 +32,11 @@ EOS
     ios.platform                = :ios, '4.3'
     ios.ios.deployment_target   = '4.3'
 
-    ios.preserve_paths              = 'cpp/core/src/zxing/**/*.h', 'objc/src/ZXing/*.h', 'iphone/ZXingWidget/Classes/**/*.h'
-    ios.source_files            = 'cpp/core/src/zxing/**/*.cpp', 'objc/src/ZXing/*.{m,mm}', 'iphone/ZXingWidget/Classes/**/*.{m,mm}'
+    ios.preserve_paths          = 'cpp/core/src/zxing/**/*.h', 'objc/src/ZXing/*.h', 'cpp/core/src/bigint/*.hh'
+    ios.source_files            = 'cpp/core/src/zxing/**/*.cpp', 'objc/src/ZXing/*.{m,mm}', 'iphone/ZXingWidget/Classes/**/*.{h,m,mm}', 'cpp/core/src/bigint/*.cc'
     ios.compiler_flags          = '-IZXing/cpp/core/src/ -IZXing/objc/src/', '-IZXing/cpp/core/src/zxing/', '-IZXing/iphone/ZXingWidget/Classes/'
+    # There are two MultiFormatReader.h files, it appears this one is unused
+    ios.exclude_files           = 'iphone/ZXingWidget/Classes/MultiFormatReader.h'
 
 #   must use xcconfig additional to compiler_flag -I to make this header path also available for the including project
     ios.xcconfig                = { 'HEADER_SEARCH_PATHS' => '${PODS_ROOT}/ZXing/cpp/core/src/ ${PODS_ROOT}/ZXing/iphone/ZXingWidget/Classes/**' }


### PR DESCRIPTION
Add a new spec for ZXing 2.2.

ZXing won't compile under c++11, which is now the default. This updates both the 2.1 spec and the new 2.2 spec to use c++98.

Specs pass linter, however ZXing is full of warnings, especially when targeting 64 bit architectures. C'est la vie.
