### PR TITLE
Builds Google Protobuf 2.5.0 targeting iOS 7.

### DIFF
--- a/GoogleProtobuf/2.5.0/GoogleProtobuf.podspec
+++ b/GoogleProtobuf/2.5.0/GoogleProtobuf.podspec
@@ -6,8 +6,12 @@ Pod::Spec.new do |s|
         :type => 'BSD',
         :file => 'COPYING.txt'
     }
-    s.summary  = "Protocol buffers are Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data – think XML, but smaller, faster, and simpler."
+    s.summary  = "Protocol buffers are Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data."
     s.description = <<-DESC
+        Protocol buffers are Google's language-neutral, platform-neutral, 
+        extensible mechanism for serializing structured data – think XML, but 
+        smaller, faster, and simpler.
+
         Produces a stand-alone build of the Google Protocol Buffer library for
         use in iOS applications built with Xcode 5 and iOS 7.  A copy of the
         protoc compiler is also built and placed in the Pods/GoogleProtobuf folder.

--- a/GoogleProtobuf/2.5.0/GoogleProtobuf.podspec
+++ b/GoogleProtobuf/2.5.0/GoogleProtobuf.podspec
@@ -1,0 +1,41 @@
+Pod::Spec.new do |s|
+    s.platform = :ios, '7.0'
+    s.name     = 'GoogleProtobuf'
+    s.version  = '2.5.0'
+    s.license = {
+        :type => 'BSD',
+        :file => 'COPYING.txt'
+    }
+    s.summary  = "Protocol buffers are Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data – think XML, but smaller, faster, and simpler."
+    s.description = <<-DESC
+        Produces a stand-alone build of the Google Protocol Buffer library for
+        use in iOS applications built with Xcode 5 and iOS 7.  A copy of the
+        protoc compiler is also built and placed in the Pods/GoogleProtobuf folder.
+        It may be used in a custom build rule to generate C++ files based on the 
+        .proto files.
+        DESC
+    s.authors  = { 'Google' => 'protobuf@googlegroups.com' }
+    s.source   = { :http => "http://protobuf.googlecode.com/files/protobuf-2.5.0.tar.gz" }
+    s.homepage     = "https://developers.google.com/protocol-buffers/"
+    s.source_files = "config.h", "src/google/protobuf/**/*.{h,cc}"
+
+    s.compiler_flags = '-D_THREAD_SAFE'
+
+    s.exclude_files = "src/**/compiler/cpp/**", "src/**/compiler/python/**", "src/**/compiler/java/**", "src/**/compiler/**", "src/**/*unittest*", "src/**/*test_util*"
+    
+    s.header_mappings_dir = "src"
+    s.preserve_path = "bin", "lib"
+
+    s.requires_arc = false
+    s.prepare_command = <<-CMD
+        (
+            ./configure --prefix=$PWD
+            make
+            make check
+            make install
+            sed -i .orig 's/tr1\\///g' config.h
+            sed -i .orig 's/::tr1//g' config.h
+        ) | tee "/tmp/$(basename $0).$$.tmp"
+    CMD
+
+end


### PR DESCRIPTION
Fetches the latest release of Google Protobuf from Google, builds
using Xcode 5 and targeting iOS 7.  Builds both the protoc compiler
for use on Mac OS X and provides all protobuf runtime files needed
to build a project using protobuf generated C++ files.

The protoc compiler is left in the Pods/GoogleProtobuf/bin folder. It
can be used in a custom build rule to teach Xcode how .proto files are
turned into .h/.cc files.
