### PR TITLE
PhysicsDebugger

### DIFF
--- a/PhysicsDebugger/1.0.0/PhysicsDebugger.podspec
+++ b/PhysicsDebugger/1.0.0/PhysicsDebugger.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "PhysicsDebugger"
+  s.version      = "1.0.0"
+  s.summary      = "iOS 7 Sprite Kit PhysicsDebugger"
+  s.description  = "Developing in iOS 7 Sprite Kit with physicsBodies is fun and easy. There are no debugging options for the physics engine. You will reach the point where you have to see the physicsBodies you created to expect their behaviour. Including this PhysicsDebugger files, make an init and a render call and all your physicsBodies will be displayed. The Debugger will draw the real physicsBody, not just the shape dimensions."
+  s.homepage     = "http://www.ymc.ch/en/category/mobile-en"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author       = { "Thomas Zinnbauer" => "thomas.zinnbauer@ymc.ch" }
+  s.source       = { :git => "https://github.com/ymc-thzi/physicsDebugger.git", :tag => "1.0.0" }
+  s.platform     = :ios, '7.0'
+  s.source_files = 'PhysicsDebugger/YMCPhysicsDebugger'
+  s.requires_arc = true
+end

--- a/PhysicsDebugger/1.0.0/PhysicsDebugger.podspec
+++ b/PhysicsDebugger/1.0.0/PhysicsDebugger.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name         = "PhysicsDebugger"
   s.version      = "1.0.0"
   s.summary      = "iOS 7 Sprite Kit PhysicsDebugger"
-  s.description  = "Developing in iOS 7 Sprite Kit with physicsBodies is fun and easy. There are no debugging options for the physics engine. You will reach the point where you have to see the physicsBodies you created to expect their behaviour. Include this PhysicsDebugger files, make an init and a render call and all your physicsBodies will be displayed. The Debugger will draw the real physicsBody, not just the shape dimensions."
+  s.description  = "Developing in iOS 7 Sprite Kit with physicsBodies is fun and easy. There are no debugging options for the physics engine. You will reach the point where you have to see the physicsBodies you created to expect their behaviour. Include this PhysicsDebugger files, make an init and a render call and all your physicsBodies will be displayed. The Debugger will draw the real physicsBody, not just the shape dimensions. "
   s.homepage     = "http://www.ymc.ch/en/category/mobile-en"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Thomas Zinnbauer" => "thomas.zinnbauer@ymc.ch" }

--- a/PhysicsDebugger/1.0.0/PhysicsDebugger.podspec
+++ b/PhysicsDebugger/1.0.0/PhysicsDebugger.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.author       = { "Thomas Zinnbauer" => "thomas.zinnbauer@ymc.ch" }
   s.source       = { :git => "https://github.com/ymc-thzi/physicsDebugger.git", :tag => "1.0.0" }
   s.platform     = :ios, '7.0'
-  s.source_files = 'YMCPhysicsDebugger'
+  s.source_files = 'PhysicsDebugger/YMCPhysicsDebugger'
+  s.source_files = 'Classes', 'PhysicsDebugger/YMCPhysicsDebugger/*.{h,m}'
   s.requires_arc = true
 end

--- a/PhysicsDebugger/1.0.0/PhysicsDebugger.podspec
+++ b/PhysicsDebugger/1.0.0/PhysicsDebugger.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name         = "PhysicsDebugger"
   s.version      = "1.0.0"
   s.summary      = "iOS 7 Sprite Kit PhysicsDebugger"
-  s.description  = "Developing in iOS 7 Sprite Kit with physicsBodies is fun and easy. There are no debugging options for the physics engine. You will reach the point where you have to see the physicsBodies you created to expect their behaviour. Include this PhysicsDebugger files, make an init and a render call and all your physicsBodies will be displayed. The Debugger will draw the real physicsBody, not just the shape dimensions. "
+  s.description  = "Developing in iOS 7 Sprite Kit with physicsBodies is fun and easy. There are no debugging options for the physics engine. You will reach the point where you have to see the physicsBodies you created to expect their behaviour. Include this PhysicsDebugger files, make an init and a render call and all your physicsBodies will be displayed. The Debugger will draw the real physicsBody, not just the shape dimensions."
   s.homepage     = "http://www.ymc.ch/en/category/mobile-en"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Thomas Zinnbauer" => "thomas.zinnbauer@ymc.ch" }

--- a/PhysicsDebugger/1.0.0/PhysicsDebugger.podspec
+++ b/PhysicsDebugger/1.0.0/PhysicsDebugger.podspec
@@ -8,6 +8,6 @@ Pod::Spec.new do |s|
   s.author       = { "Thomas Zinnbauer" => "thomas.zinnbauer@ymc.ch" }
   s.source       = { :git => "https://github.com/ymc-thzi/physicsDebugger.git", :tag => "1.0.0" }
   s.platform     = :ios, '7.0'
-  s.source_files = 'PhysicsDebugger/YMCPhysicsDebugger'
+  s.source_files = 'YMCPhysicsDebugger'
   s.requires_arc = true
 end

--- a/PhysicsDebugger/1.0.0/PhysicsDebugger.podspec
+++ b/PhysicsDebugger/1.0.0/PhysicsDebugger.podspec
@@ -6,10 +6,10 @@ Pod::Spec.new do |s|
   s.homepage     = "http://www.ymc.ch/en/category/mobile-en"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Thomas Zinnbauer" => "thomas.zinnbauer@ymc.ch" }
-  s.source       = { :git => "https://github.com/ymc-thzi/physicsDebugger.git", :tag => "1.0.0" }
+  s.source       = { :git => "https://github.com/ymc-thzi/PhysicsDebugger.git", :tag => "1.0.0" }
   s.platform     = :ios, '7.0'
-  s.source_files = 'PhysicsDebugger/YMCPhysicsDebugger'
-  s.source_files = 'Classes', 'PhysicsDebugger/YMCPhysicsDebugger/*.{h,m}'
+  s.ios.deployment_target = "7.0"
+  s.source_files = 'PhysicsDebugger/YMCPhysicsDebugger/*.{h,m}'
   s.frameworks = 'SpriteKit'
   s.requires_arc = true
 end

--- a/PhysicsDebugger/1.0.0/PhysicsDebugger.podspec
+++ b/PhysicsDebugger/1.0.0/PhysicsDebugger.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name         = "PhysicsDebugger"
   s.version      = "1.0.0"
   s.summary      = "iOS 7 Sprite Kit PhysicsDebugger"
-  s.description  = "Developing in iOS 7 Sprite Kit with physicsBodies is fun and easy. There are no debugging options for the physics engine. You will reach the point where you have to see the physicsBodies you created to expect their behaviour. Including this PhysicsDebugger files, make an init and a render call and all your physicsBodies will be displayed. The Debugger will draw the real physicsBody, not just the shape dimensions."
+  s.description  = "Developing in iOS 7 Sprite Kit with physicsBodies is fun and easy. There are no debugging options for the physics engine. You will reach the point where you have to see the physicsBodies you created to expect their behaviour. Include this PhysicsDebugger files, make an init and a render call and all your physicsBodies will be displayed. The Debugger will draw the real physicsBody, not just the shape dimensions."
   s.homepage     = "http://www.ymc.ch/en/category/mobile-en"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Thomas Zinnbauer" => "thomas.zinnbauer@ymc.ch" }

--- a/PhysicsDebugger/1.0.0/PhysicsDebugger.podspec
+++ b/PhysicsDebugger/1.0.0/PhysicsDebugger.podspec
@@ -10,5 +10,6 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '7.0'
   s.source_files = 'PhysicsDebugger/YMCPhysicsDebugger'
   s.source_files = 'Classes', 'PhysicsDebugger/YMCPhysicsDebugger/*.{h,m}'
+  s.frameworks = 'SpriteKit'
   s.requires_arc = true
 end


### PR DESCRIPTION
Developing in iOS 7 Sprite Kit with physicsBodies is fun and easy. There are no debugging options for the physics engine. 
You will reach the point where you have to see the physicsBodies you created to expect their behaviour.
Including this PhysicsDebugger files, make an init and a render call and all your physicsBodies will be displayed.
The Debugger will draw the real physicsBody, not just the shape dimensions.
