### PR TITLE
[Updated] GoogleConversionTracking v2.1.0

### DIFF
--- a/GoogleConversionTracking/1.2.0/GoogleConversionTracking.podspec
+++ b/GoogleConversionTracking/1.2.0/GoogleConversionTracking.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   }
   s.author = 'Google Inc.'
 
-  s.source = { :http => 'https://github.com/ArtFeel/GoogleConversionTracking.git', :tag => '1.2.0' }
+  s.source = { :git => 'https://github.com/ArtFeel/GoogleConversionTracking.git', :tag => '1.2.0' }
   s.platform = :ios
 
   s.preserve_paths = '*.a'

--- a/GoogleConversionTracking/2.1.0/GoogleConversionTracking.podspec
+++ b/GoogleConversionTracking/2.1.0/GoogleConversionTracking.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   }
   s.author = 'Google Inc.'
 
-  s.source = { :http => 'https://github.com/ArtFeel/GoogleConversionTracking.git', :tag => '2.1.0' }
+  s.source = { :git => 'https://github.com/ArtFeel/GoogleConversionTracking.git', :tag => '2.1.0' }
   s.platform = :ios
 
   s.preserve_paths = '*.a'

--- a/GoogleConversionTracking/2.1.0/GoogleConversionTracking.podspec
+++ b/GoogleConversionTracking/2.1.0/GoogleConversionTracking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'GoogleConversionTracking'
-  s.version = '1.2.0'
+  s.version = '2.1.0'
   
   s.summary = 'Google Conversion Tracking SDK for iOS.'
   s.description = 'If you\'d like to know which of your keywords best leads to clicks and conversions, such as sales, AdWords Conversion Tracking can help you.'
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   }
   s.author = 'Google Inc.'
 
-  s.source = { :http => 'https://github.com/ArtFeel/GoogleConversionTracking.git', :tag => '1.2.0' }
+  s.source = { :http => 'https://github.com/ArtFeel/GoogleConversionTracking.git', :tag => '2.1.0' }
   s.platform = :ios
 
   s.preserve_paths = '*.a'


### PR DESCRIPTION
I've create a repo for caching Google Conversion Tracking library, because Google does not support versioning and even sometimes changing download URL and file structure inside Zip file.
