### PR TITLE
Fixes tagmanager spec.

### DIFF
--- a/GoogleTagManager/3.0b1/GoogleTagManager.podspec
+++ b/GoogleTagManager/3.0b1/GoogleTagManager.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name = 'GoogleTagManager'
+  s.version = '3.0b1'
+  s.summary = 'Google Tag Manager SDK.'
+  s.description = 'Google Tag Manager enables developers to change configuration values in their mobile applications using the Google Tag Manager interface without having to rebuild and resubmit application binaries to app marketplaces.'
+  s.homepage = 'http://developers.google.com/tag-manager/ios'
+  s.license = {
+    :type => 'Copyright',
+    :text => <<-LICENSE
+Copyright 2013 Google, Inc. All rights reserved.
+LICENSE
+  }
+
+  s.author = 'Google Inc.'
+  s.source = { :http => 'http://dl.google.com/GoogleTagManager/GoogleTagManageriOS.zip', :flatten => true }
+  s.platform = :ios
+  s.frameworks = 'CFNetwork', 'CoreData', 'SystemConfiguration', 'AdSupport'
+  s.source_files = 'GoogleTagManager/Library/*.h'
+  s.preserve_path = 'libGoogleAnalyticsServices.a'
+  s.library = 'GoogleAnalyticsServices'
+  s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' , 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/GoogleTagManager"'}
+end


### PR DESCRIPTION
Since tagmanager is now bundled in the analytics sdk, and the download links
redirect to the new bundled sdk, the old tag manager pod nolonger works.
This spec handles the new way tagmanager is bundled.

Remark: This spec should be removed in favor of a subspec on the google analytics spec.
The reason is that the libGoogleAnalyticsServices.a will be installed twice if an app
requires both analytics and tagmanager. However that is very unlikely. Instead of having
a broken tagmanager spec, this is better then nothing.
