### PR TITLE
[Discussion] ReactiveCocoa 2.1.5, moved iOS6 stuff to dedicated subspec

### DIFF
--- a/ReactiveCocoa/2.1.1/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/2.1.1/ReactiveCocoa.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description  = "ReactiveCocoa (RAC) is an Objective-C framework for Functional Reactive Programming. It provides APIs for composing and transforming streams of values."
  
   s.requires_arc = true
-  s.ios.deployment_target = '5.0'
+  s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.7'
   s.compiler_flags = '-DOS_OBJECT_USE_OBJC=0'
 

--- a/ReactiveCocoa/2.1.2/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/2.1.2/ReactiveCocoa.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description  = "ReactiveCocoa (RAC) is an Objective-C framework for Functional Reactive Programming. It provides APIs for composing and transforming streams of values."
  
   s.requires_arc = true
-  s.ios.deployment_target = '5.0'
+  s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.7'
   s.compiler_flags = '-DOS_OBJECT_USE_OBJC=0'
 

--- a/ReactiveCocoa/2.1.4/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/2.1.4/ReactiveCocoa.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description  = "ReactiveCocoa (RAC) is an Objective-C framework for Functional Reactive Programming. It provides APIs for composing and transforming streams of values."
  
   s.requires_arc = true
-  s.ios.deployment_target = '5.0'
+  s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.7'
   s.compiler_flags = '-DOS_OBJECT_USE_OBJC=0'
 

--- a/ReactiveCocoa/2.1.5/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/2.1.5/ReactiveCocoa.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ReactiveCocoa"
-  s.version      = "2.1.3"
+  s.version      = "2.1.5"
   s.summary      = "A framework for composing and transforming streams of values."
   s.homepage     = "https://github.com/blog/1107-reactivecocoa-is-now-open-source"
   s.author       = { "Josh Abernathy" => "josh@github.com" }
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
     sp.private_header_files = '**/*Private.h', '**/*EXTRuntimeExtensions.h'
     sp.exclude_files = 'ReactiveCocoaFramework/ReactiveCocoa/RACObjCRuntime.{h,m}'
     sp.ios.exclude_files = '**/*{AppKit,NSControl,NSText}*'
-    sp.osx.exclude_files = '**/*{UIActionSheet,UIAlertView,UIBarButtonItem,UIButton,UICollectionViewCell,UIControl,UIDatePicker,UIGestureRecognizer,UISegmentedControl,UISlider,UIStepper,UISwitch,UITableViewCell,UIText}*'
+    sp.osx.exclude_files = '**/*{UIActionSheet,UIAlertView,UIBarButtonItem,UIButton,UICollectionViewCell,UIControl,UIDatePicker,UIGestureRecognizer,UIRefreshControl,UISegmentedControl,UISlider,UIStepper,UISwitch,UITableViewCell,UIText}*'
     sp.header_dir = 'ReactiveCocoa'
   end
 end


### PR DESCRIPTION
I moved all stuff that needs iOS 6 to separate subspec. Actually I should have done this when UICollectionView category was introduced.

I didn't push it right to @CocoaPods/Specs because this might break existing installations (i.e. `pod update` may lead to compilation failure).

/cc @tonyarnold
