### PR TITLE
Bumped RPFloatingPlaceholders to v0.2.2

### DIFF
--- a/RPFloatingPlaceholders/0.2.2/RPFloatingPlaceholders.podspec
+++ b/RPFloatingPlaceholders/0.2.2/RPFloatingPlaceholders.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = "RPFloatingPlaceholders"
+  s.version      = "0.2.2"
+  s.summary      = "UITextField and UITextView subclasses with floating placeholder labels."
+  s.homepage     = "https://github.com/iwasrobbed/RPFloatingPlaceholders"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author       = 'Rob Phillips'
+  s.source       = { :git => "https://github.com/iwasrobbed/RPFloatingPlaceholders.git", :tag => "v" + s.version.to_s }
+  s.platform     = :ios, '7.0'
+  s.source_files = 'RPFloatingPlaceholders'
+  s.requires_arc = true
+end


### PR DESCRIPTION
``` shell
$ pod spec lint RPFloatingPlaceholders.podspec

 -> RPFloatingPlaceholders (0.2.2)

Analyzed 1 podspec.

RPFloatingPlaceholders.podspec passed validation.
```
