### PR TITLE
Allowing Airbrake-iOS to be used with OS X

### DIFF
--- a/Airbrake-iOS/3.1.0/Airbrake-iOS.podspec
+++ b/Airbrake-iOS/3.1.0/Airbrake-iOS.podspec
@@ -50,7 +50,6 @@ Pod::Spec.new do |s|
 
 LICENSE
 }  
-  s.platform     = :ios
   s.source       = { :git => "https://github.com/airbrake/airbrake-ios.git", :tag => "3.1.0" }
   s.source_files = 'Airbrake/{notifier,gcalertview}/*.{h,m}'
   s.resources    = "Airbrake/notifier/*.lproj"


### PR DESCRIPTION
Even thought it's named Airbrake-iOS, it works with OS X too.  They have an OS X sample project in their repo:
https://github.com/airbrake/airbrake-ios/tree/master/Xcode/Hoptoad%20Mac
