### PR TITLE
[Update] ReactiveCocoa 2.1.5, reset deployment targets to 5.0.

### DIFF
--- a/ReactiveCocoa/2.1.1/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/2.1.1/ReactiveCocoa.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description  = "ReactiveCocoa (RAC) is an Objective-C framework for Functional Reactive Programming. It provides APIs for composing and transforming streams of values."
  
   s.requires_arc = true
-  s.ios.deployment_target = '6.0'
+  s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
   s.compiler_flags = '-DOS_OBJECT_USE_OBJC=0'
 

--- a/ReactiveCocoa/2.1.2/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/2.1.2/ReactiveCocoa.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description  = "ReactiveCocoa (RAC) is an Objective-C framework for Functional Reactive Programming. It provides APIs for composing and transforming streams of values."
  
   s.requires_arc = true
-  s.ios.deployment_target = '6.0'
+  s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
   s.compiler_flags = '-DOS_OBJECT_USE_OBJC=0'
 

--- a/ReactiveCocoa/2.1.3/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/2.1.3/ReactiveCocoa.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description  = "ReactiveCocoa (RAC) is an Objective-C framework for Functional Reactive Programming. It provides APIs for composing and transforming streams of values."
  
   s.requires_arc = true
-  s.ios.deployment_target = '6.0'
+  s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
   s.compiler_flags = '-DOS_OBJECT_USE_OBJC=0'
 

--- a/ReactiveCocoa/2.1.4/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/2.1.4/ReactiveCocoa.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description  = "ReactiveCocoa (RAC) is an Objective-C framework for Functional Reactive Programming. It provides APIs for composing and transforming streams of values."
  
   s.requires_arc = true
-  s.ios.deployment_target = '6.0'
+  s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
   s.compiler_flags = '-DOS_OBJECT_USE_OBJC=0'
 

--- a/ReactiveCocoa/2.1.5/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/2.1.5/ReactiveCocoa.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description  = "ReactiveCocoa (RAC) is an Objective-C framework for Functional Reactive Programming. It provides APIs for composing and transforming streams of values."
  
   s.requires_arc = true
-  s.ios.deployment_target = '6.0'
+  s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
   s.compiler_flags = '-DOS_OBJECT_USE_OBJC=0'
 


### PR DESCRIPTION
This reverts part of commit e5542fd17db90ddd34ff998f3dd8766547be7067.

As discussed in the mentioned commit, pod spec deployment target can be reverted back to 5.0.
