### PR TITLE
Fixed Mixpanel 2.1.0 podspec

### DIFF
--- a/Mixpanel/2.1.0/Mixpanel.podspec
+++ b/Mixpanel/2.1.0/Mixpanel.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/mixpanel/mixpanel-iphone.git", :tag => "v#{s.version}" }
   s.source_files  = 'Mixpanel/**/*.{m,h}'
   s.private_header_files =  'Mixpanel/Library/**/*.h'
+  s.resources 	 = ["Mixpanel/**/*.{png,storyboard}"]
   s.frameworks = 'UIKit', 'Foundation', 'SystemConfiguration', 'CoreTelephony', 'AdSupport', 'Accelerate', 'CoreGraphics', 'QuartzCore'
   s.requires_arc = false
 end


### PR DESCRIPTION
The current Mixpanel 2.1.0 podspec does not include the resources. This causes a runtime crash.
