### PR TITLE
Update Igor from 0.5.0 to 1.0

### DIFF
--- a/Igor/0.5.0/Igor.podspec
+++ b/Igor/0.5.0/Igor.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage = "https://github.com/dhemery/igor"
   s.author = { "Dale Emery" => "dale@dhemery.com"}
 
-  s.source = { :git => "https://github.com/dhemery/igor.git", :tag => "0.5.0" }
+  s.source = { :git => "https://github.com/dhemery/igor.git", :tag => "igor-1.0" }
   s.platform = :ios, '6.0'
   s.source_files = 'igor/**/*.{h,m}'
   s.exclude_files = 'igor/engine/DEIgorSelfRegisteringSelectorEngine.m'


### PR DESCRIPTION
The 0.5.0 tag was made over a year ago, and that version doesn't work with XCode 5 out of the box.

This updates to the "igor-1.0" tag.
