### PR TITLE
Update ReactiveViewModel podspec with semantic versioning dependency

### DIFF
--- a/ReactiveViewModel/0.1.1/ReactiveViewModel.podspec
+++ b/ReactiveViewModel/0.1.1/ReactiveViewModel.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/ReactiveCocoa/ReactiveViewModel.git", :tag => "#{s.version}" }
   s.source_files = 'ReactiveViewModel/*.{h,m}'
   s.requires_arc = true
-  s.dependency   'ReactiveCocoa', '2.1.4'
+  s.dependency   'ReactiveCocoa', '~> 2.1'
   s.prepare_command = <<-'END'
     find . \( -regex '.*EXT.*\.[mh]$' -o -regex '.*metamacros\.[mh]$' \) -execdir mv {} RAC{} \;
     find . -regex '.*\.[hm]' -exec sed -i '' -E 's@"(EXT.*|metamacros)\.h"@"RAC\1.h"@' {} \;


### PR DESCRIPTION
RVM will now use 2.x versions of RAC.
