### PR TITLE
TwistedOakCollapsingFutures v0.7.0 podspec file

### DIFF
--- a/TwistedOakCollapsingFutures/0.7.0/TwistedOakCollapsingFutures.podspec
+++ b/TwistedOakCollapsingFutures/0.7.0/TwistedOakCollapsingFutures.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |s|
+  s.name         = "TwistedOakCollapsingFutures"
+  s.version      = "0.7.0"
+  s.summary      = "Futures without nesting issues."
+  s.description  = <<-DESC
+                   Makes representing and consuming asynchronous results simpler.
+                   
+                   * Eventual results and failures are represented as a TOCFuture.
+                   * Produce and control a TOCFuture with a new TOCFutureSource.
+                   * Hook work-to-eventually-do onto a future using then/catch/finally methods.
+                   * Chain more work onto the future results of then/catch/finally.
+                   * No need to track if a TOCFuture has a result of type TOCFuture: always automatically flattened.
+                   * Cancel operations on the fly by giving them a TOCCancelToken controlled by a TOCCancelTokenSource.
+                   DESC
+  s.homepage     = "https://github.com/Strilanc/ObjC-CollapsingFutures"
+  s.license      = { :type => 'BSD', :file => 'License.txt' }
+  s.author       = { "Craig Gidney" => "craig.gidney@gmail.com" }
+  s.source       = { :git => "https://github.com/Strilanc/ObjC-CollapsingFutures.git", :tag => "v0.7.0" }
+  s.source_files  = 'src', 'src/**/*.{h,m}'
+  s.requires_arc = true
+end


### PR DESCRIPTION
For more information about the library, you can check the repo:
- https://github.com/Strilanc/ObjC-CollapsingFutures

or these blog posts:
- [Usage and benefits of collapsing futures](http://twistedoakstudios.com/blog/Post7149_collapsing-futures-in-objective-c)
- [Usage and benefits of cancellation tokens](http://twistedoakstudios.com/blog/Post7391_cancellation-tokens-and-collapsing-futures-for-objective-c)
- [How immortality detection works](http://twistedoakstudios.com/blog/Post7525_using-immortality-to-kill-accidental-callback-cycles)

Hopefully I did my due diligence on getting it up to snuff enough for inclusion. I've tested that the podspec passes validation, and that pointing directly at it in a podfile successfully lets me use it from other projects.
