### PR TITLE
[update] JYRadarChart: change the word transparency to opacity

### DIFF
--- a/JYRadarChart/0.3.1/JYRadarChart.podspec
+++ b/JYRadarChart/0.3.1/JYRadarChart.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "JYRadarChart"
+  s.version      = "0.3.1"
+  s.summary      = "an iOS open source Radar Chart implementation"
+  s.homepage     = "https://github.com/johnnywjy/JYRadarChart"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author       = { "Johnny Wu" => "johnny.wjy07@gmail.com" }
+  s.platform     = :ios, '5.0'
+  s.source       = { :git => "https://github.com/johnnywjy/JYRadarChart.git", :tag => s.version.to_s }
+  s.source_files = '*.{h,m}'
+  s.framework    = 'CoreGraphics'
+  s.requires_arc = true
+end


### PR DESCRIPTION
The word "opacity" is more appropriate. Reason: if the property has value of 1.0, it means "opaque", not "transparent"
