### PR TITLE
CocoaLumberjack 1.6.1 podspec was missing the platform specifications

### DIFF
--- a/CocoaLumberjack/1.6.1/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.6.1/CocoaLumberjack.podspec
@@ -14,5 +14,7 @@ Pod::Spec.new do |s|
                   'atomic operations, and the dynamic nature of the objective-c runtime.'
 
   s.requires_arc = true
+  s.ios.platform = :ios, '5.0'
+  s.osx.platform = :osx, '10.7'
   s.source_files = 'Lumberjack'
 end


### PR DESCRIPTION
(accidental upgrades occured)
