### PR TITLE
Updates the GoogleTagManager podspec to use the 3.02 release

### DIFF
--- a/GoogleTagManager/3.02/GoogleTagManager.podspec
+++ b/GoogleTagManager/3.02/GoogleTagManager.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name = 'GoogleTagManager'
+  s.version = '3.02'
+  s.summary = 'Google Tag Manager SDK.'
+  s.description = 'Google Tag Manager enables developers to change configuration values in their mobile applications using the Google Tag Manager interface without having to rebuild and resubmit application binaries to app marketplaces.'
+  s.homepage = 'http://developers.google.com/tag-manager/ios'
+  s.license = {
+    :type => 'Copyright',
+    :text => <<-LICENSE
+Copyright 2013 Google, Inc. All rights reserved.
+LICENSE
+  }
+
+  s.author = 'Google Inc.'
+  s.source = { :http => 'http://dl.google.com/googleanalyticsservices/GoogleAnalyticsServicesiOS_3.02.zip', :flatten => true }
+  s.platform = :ios
+  s.frameworks = 'CFNetwork', 'CoreData', 'SystemConfiguration', 'AdSupport'
+  s.source_files = 'GoogleTagManager/Library/*.h'
+  s.preserve_path = 'libGoogleAnalyticsServices.a'
+  s.library = 'GoogleAnalyticsServices'
+  s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' , 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/GoogleTagManager"'}
+end


### PR DESCRIPTION
Updates the GoogleTagManager podspec to use the 3.02 release, this is to work around a known bug with the Google Analytics SDK 3.00 release and iOS 7 (https://code.google.com/p/analytics-issues/issues/detail?id=338)
