### PR TITLE
Added latest version of calabash 0.9.162

### DIFF
--- a/Calabash/0.9.162/Calabash.podspec
+++ b/Calabash/0.9.162/Calabash.podspec
@@ -22,7 +22,7 @@ this software.'
 			tar xzf data.tar.gz
 			unzip staticlib/calabash.framework.zip
                    CMD
-  s.preserve_paths = 'calabash.framework/'
+  s.preserve_paths = 'calabash.framework'
   s.source_files = 'calabash.framework/Versions/A/Headers/*'
   s.xcconfig = { 'OTHER_LDFLAGS' => '-force_load "$(PODS_ROOT)/Calabash/calabash.framework/calabash" -lstdc++' } 
   s.framework = 'CFNetwork'

--- a/Calabash/0.9.162/Calabash.podspec
+++ b/Calabash/0.9.162/Calabash.podspec
@@ -1,0 +1,29 @@
+Pod::Spec.new do |s|
+  s.name     = 'Calabash'
+  s.version  = '0.9.162'
+  s.license       = {
+    :type => 'Eclipse Public License 1.0',
+    :text => 'Calabash-ios Copyright (2012) Karl Krukow. All rights reserved.
+The use and distribution terms for this software are covered by the
+Eclipse Public License 1.0
+(http://opensource.org/licenses/eclipse-1.0.php) which can be found in
+the file epl-v10.html at the root of this distribution.  By using this
+software in any fashion, you are agreeing to be bound by the terms of
+this license.  You must not remove this notice, or any other, from
+this software.'
+  }
+  s.platform = :ios
+  s.summary  = 'Calabash is an automated testing technology for Android and iOS native and hybrid applications.'
+  s.homepage = 'https://github.com/calabash/calabash-ios'
+  s.author   = { 'Karl Krukow' => 'karl.krukow@gmail.com' }
+  s.source   = { :http => 'http://rubygems.org/gems/calabash-cucumber-0.9.162.gem',
+		 :type => :tgz }
+  s.prepare_command = <<-CMD
+			tar xzf data.tar.gz
+			unzip staticlib/calabash.framework.zip
+                   CMD
+  s.preserve_paths = 'calabash.framework/'
+  s.source_files = 'calabash.framework/Versions/A/Headers/*'
+  s.xcconfig = { 'OTHER_LDFLAGS' => '-force_load "$(PODS_ROOT)/Calabash/calabash.framework/calabash" -lstdc++' } 
+  s.framework = 'CFNetwork'
+end


### PR DESCRIPTION
I created a podspec for the latest calabash version 0.9.162
Unfortunatelly the framework is not published in a zip anymore but we can extract it from the gem file of calabash-cucumber.
