### PR TITLE
Adding version 6.6.0 of the rebranded Google Mobile Ads SDK (from Google...

### DIFF
--- a/Google-Mobile-Ads-SDK/6.6.0/Google-Mobile-Ads-SDK.podspec
+++ b/Google-Mobile-Ads-SDK/6.6.0/Google-Mobile-Ads-SDK.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+  s.name = "Google-Mobile-Ads-SDK"
+  s.version = "6.6.0"
+  s.summary = "Monetize your mobile applications with Google ads"
+  s.description = <<-DESC
+    The Google Mobile Ads SDK is the latest generation in Google mobile advertising
+    featuring refined ad formats and streamlined APIs for access to mobile ad networks
+    and advertising solutions.
+  DESC
+  s.homepage = "https://developers.google.com/mobile-ads-sdk/"
+
+  s.license = {
+    :type => "Copyright",
+    :text => "Copyright 2011 Google Inc. All Rights Reserved."
+  }
+
+  s.author = "Google Inc."
+  s.platform = :ios, "4.3"
+  s.source = { :http => "http://dl.google.com/googleadmobadssdk/googlemobileadssdkios-6.6.0.zip" }
+
+  s.source_files = "GoogleAdMobAdsSDKiOS-6.6.0/*.h", "GoogleAdMobAdsSDKiOS-6.6.0/Add-ons/Search/*.h", "GoogleAdMobAdsSDKiOS-6.6.0/Add-ons/Mediation/*.h", "GoogleAdMobAdsSDKiOS-6.6.0/Add-ons/DoubleClick/*.h"
+  s.preserve_paths = "GoogleAdMobAdsSDKiOS-6.6.0"
+
+  s.frameworks = "AdSupport", "AudioToolbox", "AVFoundation", "CoreGraphics", "MessageUI", "StoreKit", "SystemConfiguration" 
+  s.library = "GoogleAdMobAds"
+  s.xcconfig = {
+    "OTHER_LDFLAGS" => "-ObjC",
+    "LIBRARY_SEARCH_PATHS" => '"$(SRCROOT)/Pods/Google-Mobile-Ads-SDK/GoogleAdMobAdsSDKiOS-6.6.0"'
+  }
+end


### PR DESCRIPTION
... AdMob Ads SDK)

I work on the Mobile Ads Developer Relations team at Google, and we've rebranded the "AdMob Ads SDK" to "Mobile Ads SDK" since it encompasses multiple Google Mobile Ads products, not just AdMob. I'd like to remove or deprecate the Google-AdMob-Ads-SDK pod, and use this name going forward, but I don't want to break anybody still referencing the old pod. I'm not sure how well the other one works now anyways, since it uses a version-less zip name, it'll probably always pull the latest version. Starting with 6.6.0, we'll add versioned downloads to be compatible with Cocoapods.
