### PR TITLE
Changed Google Ad dependency based on changes in #5265

### DIFF
--- a/LARSAdController/2.1.1/LARSAdController.podspec
+++ b/LARSAdController/2.1.1/LARSAdController.podspec
@@ -10,5 +10,5 @@ Pod::Spec.new do |s|
   s.source_files = 'LARSAdController.{h,m}'
   s.license = 'MIT'
   s.frameworks = 'iAd'
-  s.dependency 'AdMob'
+  s.dependency 'Google-Mobile-Ads-SDK'
 end

--- a/LARSAdController/3.0.0/LARSAdController.podspec
+++ b/LARSAdController/3.0.0/LARSAdController.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   
   s.subspec 'GoogleAds' do |g|
       g.source_files = 'Source/TOLAdAdapterGoogleAds.{h,m}'
-      g.dependency 'AdMob'
+      g.dependency 'Google-Mobile-Ads-SDK'
       g.dependency 'LARSAdController/Core'
       g.weak_frameworks = 'AdSupport'
       g.frameworks = 'AudioToolbox', 'MessageUI', 'SystemConfiguration', 'CoreGraphics', 'StoreKit'

--- a/LARSAdController/3.0.1/LARSAdController.podspec
+++ b/LARSAdController/3.0.1/LARSAdController.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   
   s.subspec 'GoogleAds' do |g|
       g.source_files = 'Source/TOLAdAdapterGoogleAds.{h,m}'
-      g.dependency 'AdMob'
+      g.dependency 'Google-Mobile-Ads-SDK'
       g.dependency 'LARSAdController/Core'
       g.weak_frameworks = 'AdSupport'
       g.frameworks = 'AudioToolbox', 'MessageUI', 'SystemConfiguration', 'CoreGraphics', 'StoreKit'

--- a/LARSAdController/3.0.2/LARSAdController.podspec
+++ b/LARSAdController/3.0.2/LARSAdController.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   
   s.subspec 'GoogleAds' do |g|
       g.source_files = 'Source/TOLAdAdapterGoogleAds.{h,m}'
-      g.dependency 'AdMob'
+      g.dependency 'Google-Mobile-Ads-SDK'
       g.dependency 'LARSAdController/Core'
       g.weak_frameworks = 'AdSupport'
       g.frameworks = 'AudioToolbox', 'MessageUI', 'SystemConfiguration', 'CoreGraphics', 'StoreKit'


### PR DESCRIPTION
Since old AdMob/Google duped pods were removed in #5265, this is to change to the new, versioned dependency to prevent breaking existing pod installs.
