### PR TITLE
Update PBWebViewController to version 0.1

### DIFF
--- a/PBWebViewController/0.1/PBWebViewController.podspec
+++ b/PBWebViewController/0.1/PBWebViewController.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "PBWebViewController"
+  s.version      = "0.1"
+  s.summary      = "A light-weight, simple and extendible web browser component for iOS."
+  s.homepage     = "https://github.com/kmikael/PBWebViewController"
+  s.screenshots  = "http://cl.ly/SECz"
+  s.license      = { :type => "MIT", :file => "LICENSE.txt" }
+  s.author       = { "Mikael Konutgan" => "mkonutgan@gmail.com" }
+  s.source       = { :git => "https://github.com/kmikael/PBWebViewController.git", :tag => "0.1" }
+  s.platform     = :ios, '6.0'
+  s.source_files = "PBWebViewController/"
+  s.requires_arc = true
+end


### PR DESCRIPTION
- Dismiss the activity popover with action button
- Fixes/improvements for iOS 7
- The web view controller manages it's own toolbar state and doesn't affect the rest of the app
- Also, there is an option to not show a navigation toolbar
- Add Xcode-style documentation
