### PR TITLE
Updated JSONkit to a fixed version

### DIFF
--- a/JSONKit/1.5.1/JSONKit.podspec
+++ b/JSONKit/1.5.1/JSONKit.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name     = 'JSONKit'
+  s.version  = '1.5pre'
+  s.license  = 'BSD / Apache License, Version 2.0'
+  s.summary  = 'A Very High Performance Objective-C JSON Library.'
+  s.homepage = 'https://github.com/johnezang/JSONKit'
+  s.author   = 'John Engelhart'
+  s.source   = { :git => 'https://github.com/jmjeong/JSONKit.git', :commit => '2f4e169cb8b42f09c1cb29dfd3cc4a889451433b' }
+
+  s.source_files   = 'JSONKit.*'
+end

--- a/JSONKit/1.5.1/JSONKit.podspec
+++ b/JSONKit/1.5.1/JSONKit.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary  = 'A Very High Performance Objective-C JSON Library.'
   s.homepage = 'https://github.com/johnezang/JSONKit'
   s.author   = 'John Engelhart'
-  s.source   = { :git => 'https://github.com/jmjeong/JSONKit.git', :commit => '2f4e169cb8b42f09c1cb29dfd3cc4a889451433b' }
+  s.source   = { :git => 'https://github.com/jrmiddle/JSONKit.git', :commit => 'ccc0565f0ae4a27371d18309ccb982a9f1f21b63' }
 
   s.source_files   = 'JSONKit.*'
 end


### PR DESCRIPTION
Unfortunately JSONkit breaks when compiled with the iOS 7 SDK.

Also unfortunately, JSONkit seems to no longer be maintained so it seems necessary to move to a fork
