### PR TITLE
Only include headers and impls

### DIFF
--- a/FBSnapshotTestCase/1.0/FBSnapshotTestCase.podspec
+++ b/FBSnapshotTestCase/1.0/FBSnapshotTestCase.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.framework    = 'XCTest'
 
-  s.source_files = 'FBSnapshotTestCase.*', 'FBTestSnapshotController.*'
+  s.source_files = 'FBSnapshotTestCase.{h,m}', 'FBTestSnapshotController.{h,m}'
 
   fb_def = 'FB_REFERENCE_IMAGE_DIR'
   fb_val = '"$(SOURCE_ROOT)/$(PROJECT_NAME)Tests/ReferenceImages"'


### PR DESCRIPTION
Fix bug where FBSnapshotTestCase.podspec was accidentally included.

In lieu of ci:

<pre>
$ pod spec lint FBSnapshotTestCase.podspec 

 -> FBSnapshotTestCase (1.0)

Analyzed 1 podspec.

FBSnapshotTestCase.podspec passed validation.
</pre>
