### PR TITLE
Add CouchbaseLiteListener.framework to couchbase-lite-ios.podspec

### DIFF
--- a/couchbase-lite-ios/1.0-beta/couchbase-lite-ios.podspec
+++ b/couchbase-lite-ios/1.0-beta/couchbase-lite-ios.podspec
@@ -3,13 +3,13 @@ Pod::Spec.new do |s|
   s.version      = "1.0-beta"
   s.summary      = "Couchbase Lite is an embedded lightweight, document-oriented (NoSQL), syncable database engine."
   s.homepage     = "http://www.couchbase.com/communities/couchbase-lite"
-  s.license      = { :type => 'Apache License, Version 2.0' }
+  s.license      = { :type => 'Apache License, Version 2.0', :file => 'LICENSE.txt' }
   s.author       = { "Jens Alfke" => "jens@couchbase.com" }
   s.platform     = :ios, '6.0'
   s.source       = { :http => "http://packages.couchbase.com/releases/couchbase-lite/ios/1.0-beta/couchbase-lite-community-ios_1.0-beta.zip" }
 
-  s.preserve_paths = "*.framework"
-  s.vendored_frameworks = "CouchbaseLite.framework"
+  s.preserve_paths = "*.framework", "LICENSE.txt"
+  s.vendored_frameworks = "CouchbaseLite.framework", "CouchbaseLiteListener.framework"
   s.public_header_files = "**/*.h"
   s.library   = 'sqlite3'
 


### PR DESCRIPTION
This adds `CouchbaseLiteListener.framework` to `couchbase-lite-ios.podspec` which should hopefully be all that's needed for https://github.com/couchbase/couchbase-lite-ios/issues/39#issuecomment-27607889.  At least on the iOS side.

This is what I modified for locally testing this podspec.
https://github.com/davidquon/Grocery-Sync-iOS/tree/cocoapod_test_v2

My apologies for the back-to-back pull requests.  I wasn't sure how hard it was going to be to get the CouchbaseLiteListener.framework included and I wasn't sure how long the PR process was going to take so I want to make sure I got in the part that I needed.  Luckily it was as easy as I had hoped.  :wink:
