### PR TITLE
Added pod spec for RMHelpfulLabel

### DIFF
--- a/RMHelpfulLabel/1.0.0/LICENSE
+++ b/RMHelpfulLabel/1.0.0/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 robinmacharg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/RMHelpfulLabel/1.0.0/RMHelpfulLabel.podspec
+++ b/RMHelpfulLabel/1.0.0/RMHelpfulLabel.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+	s.name = 'RMHelpfulLabel'
+	s.version = '1.0.0'
+	s.summary = 'A customisable UILabel implementation that allows easily adding pop-up, context-sensitive help'
+	s.author = {
+		'Robin Macharg' => 'robin.macharg@gmail.com'
+	}
+	s.homepage     = "https://github.com/robinmacharg/RMHelpfulLabel"
+	s.license      = { :type => 'MIT', :file => 'LICENSE' }
+	s.platform     = :ios, '5.0'
+	s.ios.deployment_target = '5.0'
+	s.source = {
+		:git => 'https://github.com/robinmacharg/RMHelpfulLabel.git',
+		:tag => 'v1.0.0'
+	}
+	s.source_files = 'RMHelpfulLabelDemo/RMHelpfulLabelDemo/RMHelpfulLabel/*.{h,m}'
+	s.requires_arc = true
+end


### PR DESCRIPTION
A customisable UILabel implementation that allows easily adding pop-up, context-sensitive help.  Initial podspec created.
