### PR TITLE
Add missing dependencies to couchbase-lite-ios

### DIFF
--- a/couchbase-lite-ios/1.0-beta/couchbase-lite-ios.podspec
+++ b/couchbase-lite-ios/1.0-beta/couchbase-lite-ios.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   s.preserve_paths = "*.framework", "LICENSE.txt"
   s.vendored_frameworks = "CouchbaseLite.framework", "CouchbaseLiteListener.framework"
   s.public_header_files = "**/*.h"
-  s.library   = 'sqlite3'
+  s.frameworks   = 'SystemConfiguration', 'CFNetwork', 'Security'
+  s.libraries    = 'sqlite3', 'z'
 
   s.description  = <<-DESC
   **Couchbase Lite** is an embedded lightweight, document-oriented (NoSQL), syncable database engine. 


### PR DESCRIPTION
This PR fixes some potential dependency issues by explicitly including the required library and frameworks as discussed in https://github.com/couchbase/couchbase-lite-ios/issues/39#issuecomment-27607889.
