### PR TITLE
GTCyclePageView and GTTableViewController

### DIFF
--- a/GTCyclePageView/1.0.0/GTCyclePageView.podspec
+++ b/GTCyclePageView/1.0.0/GTCyclePageView.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+
+  s.name         = "GTCyclePageView"
+  s.version      = "1.0.0"
+  s.summary      = "Display page content circularly in UIScrollView"
+
+  s.homepage     = "https://github.com/gongtao/GTCyclePageView"
+  s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }
+
+  s.author       = { "gongtao" => "gongtao@jike.com" }
+  
+  s.platform     = :ios
+
+  s.source       = { :git => "https://github.com/gongtao/GTCyclePageView.git", :tag => "1.0.0" }
+
+  s.source_files  = 'Class/*.{h,m}'
+
+  s.framework  = 'UIKit'
+
+  s.requires_arc = true
+
+end

--- a/GTTableViewController/1.0.0/GTTableViewController.podspec
+++ b/GTTableViewController/1.0.0/GTTableViewController.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+
+  s.name         = "GTTableViewController"
+  s.version      = "1.0.0"
+  s.summary      = "CoreData Display in CoreData"
+
+  s.homepage     = "https://github.com/gongtao/GTTableViewController"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+
+  s.author       = { "gongtao" => "gongtao@jike.com" }
+  
+  s.platform     = :ios, '5.0'
+
+  s.source       = { :git => "https://github.com/gongtao/GTTableViewController.git", :commit => "e7dc5f1cd4c7a4ca71c88cc970988fd9e6cb3ade", :tag => "1.0.0" }
+
+  s.source_files  = 'Class/*.{h,m}'
+
+  s.framework  = 'CoreData', 'UIKit'
+
+  s.requires_arc = true
+
+end


### PR DESCRIPTION
GTCyclePageView is a view that can circularly scroll pages. The way that GTCyclePageView uses datasource to load each page view is almost the same way as UITableView.

It's based on UIScrollView, and its delegate inherit from UIScrollViewDelegate.

GTTableViewController is a light weight subclass of UIViewController that integrates NSFetchedResultsController and UITableView to display data of CoreData. It has a good scalability, and can be integrated to your project either by inheritance or as a child viewController using datasource methods. To display the data in UITableView, all you need to do is to customize your own NSFetchRequest and UITableViewCell objects.

I hope that these two project could help other developers. Thank you.
