### PR TITLE
FTCoreText - added forgotten ARC definition to Podspec file

### DIFF
--- a/FTCoreText/1.0/FTCoreText.podspec
+++ b/FTCoreText/1.0/FTCoreText.podspec
@@ -14,5 +14,6 @@ Pod::Spec.new do |s|
   }
   s.source_files  = 'FTCoreText/*.{h,m}'
   s.framework  = 'CoreText'
+  s.requires_arc = true
 
 end


### PR DESCRIPTION
Forgotten ARC definition. Sorry about this.
