### PR TITLE
The S3 subspec no longer requires DynamoDB.  

### DIFF
--- a/AWSiOSSDK/1.7.0/AWSiOSSDK.podspec
+++ b/AWSiOSSDK/1.7.0/AWSiOSSDK.podspec
@@ -21,13 +21,23 @@ Pod::Spec.new do |s|
 
   s.subspec 'Runtime' do |ss|
     ss.source_files = "src/Amazon.Runtime/**/*.m", "src/include", "src/ThirdParty/**/*.m", "src/ThirdParty/**/*.h"
-    ss.dependency 'AWSiOSSDK/DynamoDB'
   end
 
-  %w[ AutoScaling CloudWatch DynamoDB EC2 ElasticLoadBalancing S3 SES SNS SQS STS SimpleDB ].each do |name|
+  s.subspec 'DynamoDB' do |ss|
+      ss.source_files = "src/Amazon.DynamoDB/**/*.m", "src/include/DynamoDB"
+      ss.dependency 'AWSiOSSDK/Runtime'
+  end
+
+  s.subspec 'S3' do |ss|
+       ss.source_files = "src/Amazon.S3/**/*.m", "src/include/S3"
+       ss.dependency 'AWSiOSSDK/Runtime'
+  end
+    
+  %w[ AutoScaling CloudWatch EC2 ElasticLoadBalancing SES SNS SQS STS SimpleDB ].each do |name|
     s.subspec name do |ss|
       ss.source_files = "src/Amazon.#{name}/**/*.m", "src/include/#{name}"
       ss.dependency 'AWSiOSSDK/Runtime'
+      ss.dependency 'AWSiOSSDK/DynamoDB'
     end
   end
 end


### PR DESCRIPTION
The DynamoDB requirement was unnecessary to use the S3 SDK.
