### PR TITLE
create AutoCompleteSuffixView.podspec file for 0.1 version 

### DIFF
--- a/AutoCompleteSuffixView/0.1/AutoCompleteSuffixView.podspec
+++ b/AutoCompleteSuffixView/0.1/AutoCompleteSuffixView.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = "AutoCompleteSuffixView"
+  s.version      = "0.1"
+  s.summary      = "complete account's suffix automatically when user inputs in UITextField."
+  s.homepage     = "https://github.com/jianpx/AutoCompleteSuffixView"
+  s.license      = 'MIT'
+  s.author       = { "jianpeixin" => "jianpx86@gmail.com" }
+  s.platform     = :ios, '5.0'
+  s.source       = { :git => "https://github.com/jianpx/AutoCompleteSuffixView.git", :tag => "0.1" }
+  s.source_files  = 'AutoCompleteSuffixExample/AutoCompleteSuffixExample/AutoCompleteSuffixView.{h,m}'
+  s.requires_arc = true
+end


### PR DESCRIPTION
I am creating a podspec file for my shared AutoCompleteSuffixView that can be used in iOS development.  This AutoCompleteSuffixView helps to complete account's suffix automatically when user type characters in UITextField, for more details , you can review it with the image below.
![autocompletesuffix](https://f.cloud.github.com/assets/235581/1579691/2d30d3a8-51a4-11e3-9eba-5473520ba4c6.gif)
