### PR TITLE
Missing spec.ios.vendored_frameworks

### DIFF
--- a/Parse/1.2.16/Parse.podspec
+++ b/Parse/1.2.16/Parse.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'Parse.framework'
   s.requires_arc = true
   s.frameworks =  'StoreKit', 'AudioToolbox', 'CFNetwork', 'SystemConfiguration', 'MobileCoreServices', 'CoreGraphics', 'Security', 'QuartzCore', 'CoreLocation', 'Parse'
+  s.vendored_frameworks = 'Parse/Parse.framework'
   s.weak_frameworks = 'AdSupport','Social', 'Accounts'
   s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/Parse"' }
   s.library = 'z', 'sqlite3'


### PR DESCRIPTION
When I install the pod on my machine the `Parse.framework` is not linked properly.

I was suggested I add line [15](https://github.com/CocoaPods/CocoaPods/issues/1613).

Please verify that it works as I'm not sure it will fix it.
