### PR TITLE
add LDScrollViewForm Project

### DIFF
--- a/LDScrollViewForm/0.1.0/LDScrollViewForm.podspec
+++ b/LDScrollViewForm/0.1.0/LDScrollViewForm.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name         = "LDScrollViewForm"
+  s.version      = "0.1.0"
+  s.summary      = "Controller helping to manage a form on iOS by avoiding the keyboard and adapte the size of UITextViews"
+  s.homepage     = "https://github.com/snoozeman/LDScrollViewForm"
+  s.license      = 'MIT'
+  s.author       = 'Damien Legrand'
+  s.social_media_url = 'https://twitter.com/damien_legrand'
+  s.source       = { :git => "https://github.com/snoozeman/LDScrollViewForm.git", :tag => s.version.to_s }
+
+  s.platform     = :ios, '5.0'
+  s.requires_arc = true
+
+  s.source_files = 'Classes/ios/*'
+end


### PR DESCRIPTION
Hi!
I send this pull request to add my project LDScrollViewForm to cocoapod.

This is a View controller that can be extended to handle easily a form, by avoiding the keyboard, going to the next field when the return key is touched and by adapting the size of a UITextView to the content.

Thanks!
