### PR TITLE
Fixes missing lib requirements in Parse 1.2.16

### DIFF
--- a/Parse/1.2.16/Parse.podspec
+++ b/Parse/1.2.16/Parse.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/jessbowers/Parse.git', :tag => "#{s.version}" }
   s.requires_arc = true
   s.frameworks = 'AudioToolbox', 'CFNetwork', 'CoreGraphics', 'CoreLocation', 'MobileCoreServices', 'QuartzCore', 'Security', 'StoreKit', 'SystemConfiguration'
+  s.library = 'z', 'sqlite3'
   s.vendored_frameworks = 'Parse.framework'
   s.dependency 'Facebook-iOS-SDK', '~> 3.9'
 end


### PR DESCRIPTION
Restores missing s.library = 'z', 'sqlite3'
Fixes link errors in projects that don't already require libz and libsqlite3.
