### PR TITLE
[New Pod] FISWebViewPreloader 1.0

### DIFF
--- a/FISWebViewPreloader/1.0/FISWebViewPreloader.podspec
+++ b/FISWebViewPreloader/1.0/FISWebViewPreloader.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |s|
+
+  s.name         = "FISWebViewPreloader"
+  s.version      = "1.0"
+  s.summary      = "Preloading UIWebviews in UIViewControllers for faster loadtime."
+  s.homepage     = "https://github.com/jameslin101/FISWebViewPreloader"
+
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+
+  s.authors       = { "Basar Akyelli" => "bakyelli@gmail.com", "James Lin" => "jameslin101@gmail.com" }
+
+  s.platform     = :ios, '5.0'
+
+  s.source       = { :git => "https://github.com/jameslin101/FISWebViewPreloader.git", 
+                     :tag => "1.0" }
+
+  s.source_files  = 'FISWebViewPreloader/*.{h,m}'
+
+  s.requires_arc = true
+  
+end


### PR DESCRIPTION
New Pod: FISWebViewPreloader

This Pod allows you to preload and manage UIWebViews in your project. Currently UIWebViews are loaded on demand without caching, which causes performance lags in an app that heavily depends on UIWebViews. Comes with example app, XCTests, and documentation.
