### PR TITLE
Added Pdef v1.0.0.

### DIFF
--- a/Pdef/1.0.0/Pdef.podspec
+++ b/Pdef/1.0.0/Pdef.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name         = "Pdef"
+  s.version      = "1.0.0"
+  s.summary      = "Pdef Objective-C descriptors, formats and rpc."
+  s.homepage     = "https://github.com/pdef/pdef-objc"
+  s.license      = 'Apache License 2.0'
+
+  s.author       = { "Ivan Korobkov" => "ivan.korobkov@gmail.com" }
+  s.source       = { :git => "https://github.com/pdef/pdef-objc.git", :tag => "v1.0.0" }
+  s.requires_arc = true
+
+  s.ios.deployment_target = '6.0'
+  s.osx.deployment_target = '10.8'
+
+  s.source_files  = 'Pdef', 'Pdef/*.{h,m}'
+  s.public_header_files = 'Pdef/*.h'
+
+  s.dependency 'AFNetworking', '~> 2.0'
+end
+


### PR DESCRIPTION
Objective-C Pdef descriptors, formats and rpc.

[Pdef](https://github.com/pdef/pdef) (pi:def, stands for "protocol definition [language]") is a statically typed interface definition language. It allows to write interfaces and data structures once and then to generate code and RPC clients/servers for different languages. It is suitable for public APIs, internal service-oriented APIs, configuration files, as a format for persistence, cache, message queues, logs, etc.
