### PR TITLE
CocoaLumberjack: updating all podspecs to use new repository

### DIFF
--- a/CocoaLumberjack/1.0/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.0/CocoaLumberjack.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
   s.homepage = 'http://code.google.com/p/cocoalumberjack/'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
-  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+  s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
                  :tag => '1.0' }
 
   s.source_files = 'Lumberjack'

--- a/CocoaLumberjack/1.1/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.1/CocoaLumberjack.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
   s.homepage = 'http://code.google.com/p/cocoalumberjack/'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
-  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+  s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
                  :tag => '1.1' }
 
   s.source_files = 'Lumberjack'

--- a/CocoaLumberjack/1.2.1/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.2.1/CocoaLumberjack.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
   s.homepage = 'http://code.google.com/p/cocoalumberjack/'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
-  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+  s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
                  :tag => '1.2.1' }
 
   s.description = 'It is similar in concept to other popular logging frameworks such as log4j, '   \

--- a/CocoaLumberjack/1.2.2/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.2.2/CocoaLumberjack.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
   s.homepage = 'http://code.google.com/p/cocoalumberjack/'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
-  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+  s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
                  :tag => '1.2.2' }
 
   s.description = 'It is similar in concept to other popular logging frameworks such as log4j, '   \

--- a/CocoaLumberjack/1.2.3/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.2.3/CocoaLumberjack.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
   s.homepage = 'http://code.google.com/p/cocoalumberjack/'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
-  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+  s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
                  :tag => '1.2.3' }
 
   s.description = 'It is similar in concept to other popular logging frameworks such as log4j, '   \

--- a/CocoaLumberjack/1.2/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.2/CocoaLumberjack.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
   s.homepage = 'http://code.google.com/p/cocoalumberjack/'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
-  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+  s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
                  :tag => '1.2' }
 
   s.source_files = 'Lumberjack'

--- a/CocoaLumberjack/1.3.1/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.3.1/CocoaLumberjack.podspec
@@ -3,9 +3,9 @@ Pod::Spec.new do |s|
   s.version  = '1.3.1'
   s.license  = 'BSD'
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
-  s.homepage = 'https://github.com/robbiehanson/CocoaLumberjack'
+  s.homepage = 'https://github.com/CocoaLumberjack/CocoaLumberjack'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
-  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+  s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
                  :tag => '1.3.1' }
 
   s.description = 'It is similar in concept to other popular logging frameworks such as log4j, '   \

--- a/CocoaLumberjack/1.3.2/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.3.2/CocoaLumberjack.podspec
@@ -3,9 +3,9 @@ Pod::Spec.new do |s|
   s.version  = '1.3.2'
   s.license  = 'BSD'
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
-  s.homepage = 'https://github.com/robbiehanson/CocoaLumberjack'
+  s.homepage = 'https://github.com/CocoaLumberjack/CocoaLumberjack'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
-  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+  s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
                  :tag => '1.3.2' }
 
   s.description = 'It is similar in concept to other popular logging frameworks such as log4j, '   \

--- a/CocoaLumberjack/1.3.3/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.3.3/CocoaLumberjack.podspec
@@ -3,9 +3,9 @@ Pod::Spec.new do |s|
   s.version  = '1.3.3'
   s.license  = 'BSD'
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
-  s.homepage = 'https://github.com/robbiehanson/CocoaLumberjack'
+  s.homepage = 'https://github.com/CocoaLumberjack/CocoaLumberjack'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
-  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+  s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
                  :tag => '1.3.3' }
 
   s.description = 'It is similar in concept to other popular logging frameworks such as log4j, '   \

--- a/CocoaLumberjack/1.3/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.3/CocoaLumberjack.podspec
@@ -3,9 +3,9 @@ Pod::Spec.new do |s|
   s.version  = '1.3'
   s.license  = 'BSD'
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
-  s.homepage = 'https://github.com/robbiehanson/CocoaLumberjack'
+  s.homepage = 'https://github.com/CocoaLumberjack/CocoaLumberjack'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
-  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+  s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
                  :tag => '1.3' }
 
   s.description = 'It is similar in concept to other popular logging frameworks such as log4j, '   \

--- a/CocoaLumberjack/1.6.1/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.6.1/CocoaLumberjack.podspec
@@ -3,9 +3,9 @@ Pod::Spec.new do |s|
   s.version = '1.6.1'
   s.license = 'BSD'
   s.summary = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
-  s.homepage = 'https://github.com/robbiehanson/CocoaLumberjack'
+  s.homepage = 'https://github.com/CocoaLumberjack/CocoaLumberjack'
   s.author = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
-  s.source = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+  s.source = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
                  :tag => '1.6.1' }
 
   s.description = 'It is similar in concept to other popular logging frameworks such as log4j, ' \

--- a/CocoaLumberjack/1.6.2/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.6.2/CocoaLumberjack.podspec
@@ -3,9 +3,9 @@ Pod::Spec.new do |s|
   s.version  = '1.6.2'
   s.license  = 'BSD'
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
-  s.homepage = 'https://github.com/robbiehanson/CocoaLumberjack'
+  s.homepage = 'https://github.com/CocoaLumberjack/CocoaLumberjack'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
-  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+  s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
                  :tag => "#{s.version}" }
 
   s.description = 'It is similar in concept to other popular logging frameworks such as log4j, '   \

--- a/CocoaLumberjack/1.6.3/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.6.3/CocoaLumberjack.podspec
@@ -3,9 +3,9 @@ Pod::Spec.new do |s|
   s.version  = '1.6.3'
   s.license  = 'BSD'
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
-  s.homepage = 'https://github.com/robbiehanson/CocoaLumberjack'
+  s.homepage = 'https://github.com/CocoaLumberjack/CocoaLumberjack'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
-  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+  s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
                  :tag => "#{s.version}" }
 
   s.description = 'It is similar in concept to other popular logging frameworks such as log4j, '   \

--- a/CocoaLumberjack/1.6.4/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.6.4/CocoaLumberjack.podspec
@@ -3,9 +3,9 @@ Pod::Spec.new do |s|
   s.version  = '1.6.4'
   s.license  = 'BSD'
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
-  s.homepage = 'https://github.com/robbiehanson/CocoaLumberjack'
+  s.homepage = 'https://github.com/CocoaLumberjack/CocoaLumberjack'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
-  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+  s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
                  :tag => "#{s.version}" }
 
   s.description = 'It is similar in concept to other popular logging frameworks such as log4j, '   \

--- a/CocoaLumberjack/1.6.5.1/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.6.5.1/CocoaLumberjack.podspec
@@ -3,9 +3,9 @@ Pod::Spec.new do |s|
   s.version  = '1.6.5.1'
   s.license  = 'BSD'
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
-  s.homepage = 'https://github.com/robbiehanson/CocoaLumberjack'
+  s.homepage = 'https://github.com/CocoaLumberjack/CocoaLumberjack'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
-  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+  s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
                  :tag => "#{s.version}" }
 
   s.description = 'It is similar in concept to other popular logging frameworks such as log4j, '   \

--- a/CocoaLumberjack/1.6.5/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.6.5/CocoaLumberjack.podspec
@@ -3,9 +3,9 @@ Pod::Spec.new do |s|
   s.version  = '1.6.5'
   s.license  = 'BSD'
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
-  s.homepage = 'https://github.com/robbiehanson/CocoaLumberjack'
+  s.homepage = 'https://github.com/CocoaLumberjack/CocoaLumberjack'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
-  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+  s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
                  :tag => "#{s.version}" }
 
   s.description = 'It is similar in concept to other popular logging frameworks such as log4j, '   \

--- a/CocoaLumberjack/1.6/CocoaLumberjack.podspec
+++ b/CocoaLumberjack/1.6/CocoaLumberjack.podspec
@@ -3,9 +3,9 @@ Pod::Spec.new do |s|
   s.version  = '1.6'
   s.license  = 'BSD'
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
-  s.homepage = 'https://github.com/robbiehanson/CocoaLumberjack'
+  s.homepage = 'https://github.com/CocoaLumberjack/CocoaLumberjack'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
-  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+  s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
                  :tag => '1.6' }
 
   s.description = 'It is similar in concept to other popular logging frameworks such as log4j, '   \


### PR DESCRIPTION
CocoaLumberjack has moved to organization repository, the new url is https://github.com/CocoaLumberjack/CocoaLumberjack
