### PR TITLE
Updates Fare to 1.0.2

### DIFF
--- a/Fare/1.0.1/Fare.podspec
+++ b/Fare/1.0.1/Fare.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name         = "Fare"
+  s.version      = "1.0.1"
+  s.summary      = "A networking library for the University of Michigan's bus dispatch system."
+  s.description  = <<-DESC
+                   The University of Michigan has an awesome [live bus tracking system](http://mbus.pts.umich.edu/) for students.  This is an Objective-C wrapper around their API.
+                   DESC
+  s.homepage     = "https://github.com/jonahgrant/fare"
+  s.license      = 'MIT'
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author       = { "Jonah Grant" => "jonah@jonahgrant.com" }
+  s.source       = { :git => "https://github.com/jonahgrant/fare.git", :tag => "1.0.1" }
+  s.platform     = :ios, '6.0'
+  s.source_files  = 'Fare/Source/**/*.{h,m}'
+  s.exclude_files = '.gitignore'
+  s.resource  = "Fare/Resources/Misc/Fare-Info.plist"
+  s.requires_arc = true
+  s.dependency 'Mantle', '~> 1.3'
+  s.dependency 'AFNetworking', '~> 2.0.3'
+  s.dependency 'ReactiveCocoa', '~> 2.1'
+  s.dependency 'XMLDictionary', '~> 1.3'
+
+end

--- a/Fare/1.0.2/Fare.podspec
+++ b/Fare/1.0.2/Fare.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Fare"
-  s.version      = "1.0.1"
+  s.version      = "1.0.2"
   s.summary      = "A networking library for the University of Michigan's bus dispatch system."
   s.description  = <<-DESC
                    The University of Michigan has an awesome [live bus tracking system](http://mbus.pts.umich.edu/) for students.  This is an Objective-C wrapper around their API.
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.license      = 'MIT'
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Jonah Grant" => "jonah@jonahgrant.com" }
-  s.source       = { :git => "https://github.com/jonahgrant/fare.git", :tag => "1.0.1" }
+  s.source       = { :git => "https://github.com/jonahgrant/fare.git", :tag => "1.0.2" }
   s.platform     = :ios, '6.0'
   s.source_files  = 'Fare/Source/**/*.{h,m}'
   s.exclude_files = '.gitignore'


### PR DESCRIPTION
With 1.0, I left the project as an app target.  This caused all sorts of compiler errors when being built into another project.  This redacts that.
