### PR TITLE
Added icons folder to podspec

### DIFF
--- a/MessageBarManager/1.0.0/MessageBarManager.podspec
+++ b/MessageBarManager/1.0.0/MessageBarManager.podspec
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   }
 
   s.platform     = :ios, '6.1'
-  s.source_files  = 'Classes', 'Classes/**/*.{h,m}'
+  s.source_files  = 'Classes', 'Classes/**/*.{h,m}', 'Classes/Icons/*'
   s.requires_arc = true
 end


### PR DESCRIPTION
I forgot to add the /Icons folder (located under /Classes) to the podspec. 

Does the formatting look correct ('Classes/Icons/*')? 

Please advise

Thanks!
