### PR TITLE
Update 1.3.3 Spec to remove SSL Pinning macro

### DIFF
--- a/AFNetworking/1.3.3/AFNetworking.podspec
+++ b/AFNetworking/1.3.3/AFNetworking.podspec
@@ -18,8 +18,6 @@ Pod::Spec.new do |s|
   s.prefix_header_contents = <<-EOS
 #import <Availability.h>
 
-#define _AFNETWORKING_PIN_SSL_CERTIFICATES_
-
 #if __IPHONE_OS_VERSION_MIN_REQUIRED
   #import <SystemConfiguration/SystemConfiguration.h>
   #import <MobileCoreServices/MobileCoreServices.h>


### PR DESCRIPTION
Update the 1.3.3 podspec to correctly reflect the 1.3.3 podspec listed on the official tag: https://github.com/AFNetworking/AFNetworking/blob/1.3.3/AFNetworking.podspec
