### PR TITLE
MWPhotoBrowser: Fix unnecessarily specific dependency

### DIFF
--- a/MWPhotoBrowser/1.1.4/MWPhotoBrowser.podspec
+++ b/MWPhotoBrowser/1.1.4/MWPhotoBrowser.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   s.frameworks = 'MessageUI', 'ImageIO', 'QuartzCore', 'AssetsLibrary'
 
-  s.dependency 'SDWebImage', '3.5'
+  s.dependency 'SDWebImage', '~> 3.5'
   s.dependency 'MBProgressHUD'
   s.dependency 'DACircularProgress'
 end


### PR DESCRIPTION
According to semver, x.Y.z updates should be backwards-compatible. At the very least, x.y.Z updates (~> 3.5.0) should be allowed in order to obtain bug fixes.
