### PR TITLE
Decreased GoogleProtobuf 2.4.1 deployment target from 7.0 to 5.0

### DIFF
--- a/GoogleProtobuf/2.4.1/GoogleProtobuf.podspec
+++ b/GoogleProtobuf/2.4.1/GoogleProtobuf.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.platform = :ios, '7.0'
+  s.platform = :ios, '5.0'
   s.name     = 'GoogleProtobuf'
   s.version  = '2.4.1'
   s.summary  = 'Google Protocol Buffers serialization library'


### PR DESCRIPTION
protobuf itself doesn't depend on iOS SDK. I guess it should work with any iOS version/SDK, but I didn't check those prior to 5.0
