### PR TITLE
[Add/Rename] IntentKit (0.2.0)

### DIFF
--- a/IntentKit/0.2.0/IntentKit.podspec
+++ b/IntentKit/0.2.0/IntentKit.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name      = 'IntentKit'
+  s.version   = '0.2.0'
+  s.license   = { :type => 'MIT', :file => "LICENSE" }
+  s.summary   = "An easier way to handle third-party URL schemes in iOS apps."
+  s.homepage  = 'http://intentkit.github.io'
+  s.authors   = { 'Mike Walker' => 'michael@lazerwalker.com' }
+  s.source    = { :git => 'https://github.com/intentkit/IntentKit.git', :tag => '0.2.0' }
+  s.requires_arc = true
+  s.platform  = :ios, '7.0'
+
+  s.source_files = 'IntentKit', 'IntentKit/**/*.{h,m}'
+  s.resource_bundles = { 'IntentKit' => "IntentKit/**/*.{plist,png}" }
+end


### PR DESCRIPTION
This is a newly-renamed version of MWOpenInKit. I'm assuming the appropriate thing to do is leave the previous versions of the old pod in place and just push all future version updates here?
