### PR TITLE
Updating gtm-oauth2, GTMHTTPFetcher, StaticDataTableViewController, and MWPhotoBrowser

### DIFF
--- a/GTMHTTPFetcher/0.0.2/GTMHTTPFetcher.podspec
+++ b/GTMHTTPFetcher/0.0.2/GTMHTTPFetcher.podspec
@@ -1,0 +1,35 @@
+Pod::Spec.new do |s|
+  s.name     = 'GTMHTTPFetcher'
+  s.version  = '0.0.2'
+  s.license      = {
+    :type => 'Apache License, Version 2.0',
+    :text => <<-LICENSE
+                Copyright (c) 2011 Google Inc.
+
+                Licensed under the Apache License, Version 2.0 (the "License");
+                you may not use this file except in compliance with the License.
+                You may obtain a copy of the License at
+
+                    http://www.apache.org/licenses/LICENSE-2.0
+
+                Unless required by applicable law or agreed to in writing, software
+                distributed under the License is distributed on an "AS IS" BASIS,
+                WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                See the License for the specific language governing permissions and
+                limitations under the License.
+    LICENSE
+  }
+  s.summary = "GTM HTTP Fetcher makes it easy for Cocoa applications to perform http operations."
+  s.description  = "The fetcher is implemented as a wrapper on NSURLConnection, so its behavior "\
+               "is asynchronous and uses operating-system settings on iOS and Mac OS X."
+  s.homepage = 'https://code.google.com/p/gtm-http-fetcher'
+  s.author   = { 'The Google Data APIs team' => 'https://code.google.com/p/google-api-objectivec-client' }
+  s.source   = { :svn => 'https://gtm-http-fetcher.googlecode.com/svn/trunk', :revision => 'r134' }
+  s.requires_arc = false
+  s.dependency    'SBJson'
+  s.ios.deployment_target = '3.0'
+  s.osx.deployment_target = '10.6'
+  s.ios.framework = 'UIKit'
+  s.source_files   = 'Source/*.{h,m}'
+  s.osx.exclude_files = '**/GTMHTTPFetcherLogViewController.*'
+end

--- a/MWPhotoBrowser/1.2.0/MWPhotoBrowser.podspec
+++ b/MWPhotoBrowser/1.2.0/MWPhotoBrowser.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+  s.name     = 'MWPhotoBrowser'
+  s.version  = '1.2.0'
+  s.license  = 'MIT'
+  s.summary  = 'A simple iOS photo browser.'
+  s.homepage = 'https://github.com/mwaterfall/MWPhotoBrowser'
+  s.author   = { 'Michael Waterfall' => 'mw@d3i.com' }
+  s.source   = { :git => 'https://github.com/mwaterfall/MWPhotoBrowser.git', :tag => '1.2.0' }
+  s.platform = :ios, '5.0'
+  
+  s.subspec 'ARC' do |arc|
+    arc.source_files = 'MWPhotoBrowser/Classes/*.{h,m}'
+    arc.requires_arc = true
+    arc.prefix_header_contents = '#import "MWPreprocessor.h"'
+  end
+  
+  s.resources = "MWPhotoBrowser/MWPhotoBrowser.bundle"
+
+  s.frameworks = 'MessageUI', 'ImageIO', 'QuartzCore', 'AssetsLibrary'
+
+  s.dependency 'SDWebImage'
+  s.dependency 'MBProgressHUD'
+  s.dependency 'DACircularProgress'
+end

--- a/gtm-oauth2/0.0.3/gtm-oauth2.podspec
+++ b/gtm-oauth2/0.0.3/gtm-oauth2.podspec
@@ -1,0 +1,51 @@
+Pod::Spec.new do |s|
+
+  s.name         = "gtm-oauth2"
+  s.version      = "0.0.3"
+  s.summary      = "Google Toolbox for Mac - OAuth 2 Controllers."
+  s.description = "The Google Toolbox for Mac OAuth 2 Controllers make it easy for Cocoa applications "\
+                  "to sign in to services using OAuth 2 for authentication and authorization."
+  s.homepage     = "https://code.google.com/p/gtm-oauth2"
+  s.author   = { 'The Google Data APIs team' => 'https://code.google.com/p/google-api-objectivec-client' }
+  s.source       = { :svn => 'https://gtm-oauth2.googlecode.com/svn/trunk/', :revision => 'r120' }
+  s.requires_arc = false
+  s.dependency   'GTMHTTPFetcher'
+  s.dependency    'SBJson'
+  s.frameworks = 'Security', 'SystemConfiguration'
+  s.ios.deployment_target = '3.0'
+  s.osx.deployment_target = '10.6'
+
+  s.subspec 'Core' do |oa2|
+    oa2.source_files   = 'Source/*.{h,m}'
+    
+    oa2.subspec 'Mac' do |mac|
+      mac.osx.source_files = 'Source/Mac/**.{h,m}'
+      mac.osx.resources = 'Source/Mac/**.xib'
+    end
+    
+    oa2.subspec 'Touch' do |touch|
+      touch.ios.source_files = 'Source/Touch/**.{h,m}'
+      touch.ios.resources = 'Source/Touch/**.xib'
+    end
+  end
+
+  s.license = {
+    :type => 'Apache License, Version 2.0',
+    :text => <<-LICENSE
+      Copyright (c) 2010 Google Inc.
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+    LICENSE
+  }
+
+end


### PR DESCRIPTION
Updating GTMHTTPFetcher from 0.0.1 to 0.0.2, changing svn to https and bumping revision from r119 to r134
Updating gtm-oauth2 from 0.0.2 to 0.0.3, changing svn to https and bumping revision from r118 to r120
Updating MWPhotoBrowser from 1.1.4 to 1.2.0, removing specific dependency on SDWebImage
Updating StaticDataTableViewController from 0.0.1 to 2.0.2 and moving from commit cf913ff5085b1ce5ea7375ada7863ef68ae3fe77 to commit fba85240c768214c5e4de775b89ce8f4b948016d
