### PR TITLE
Redefine google to google_public in common.h

### DIFF
--- a/GoogleProtobuf/2.5.0/GoogleProtobuf.podspec
+++ b/GoogleProtobuf/2.5.0/GoogleProtobuf.podspec
@@ -39,6 +39,7 @@ Pod::Spec.new do |s|
             make install
             sed -i .orig 's/tr1\\///g' config.h
             sed -i .orig 's/::tr1//g' config.h
+            perl -i.bak -pe '$_ = qq[#define google google_public\n\n$_] if $_ eq qq[#include <assert.h>\n]' src/google/protobuf/stubs/common.h
         ) | tee "/tmp/$(basename $0).$$.tmp"
     CMD
 


### PR DESCRIPTION
There is a runtime exception when using google namespace on iPhone 5s and iPad Air since Apple has its own copy of protobuf. See http://stackoverflow.com/questions/19848118/weird-ios-libprotobuf-dylib-cause-crash/20586291 for more info.
