### PR TITLE
Added DPGraphView

### DIFF
--- a/DPGraphView/0.1/DPGraphView.podspec
+++ b/DPGraphView/0.1/DPGraphView.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+
+  s.name         = "DPGraphView"
+  s.version      = "0.1"
+  s.summary      = "A reusable graphing view for iOS to easily plot continuous functions."
+  s.homepage     = "https://github.com/donald-pinckney/DPGraphView"
+
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+
+  s.author       = { "Donald Pinckney" => "donald_pinckney@icloud.com" }
+
+  s.platform     = :ios, '6.0'
+
+  s.source       = { 
+    :git => "https://github.com/donald-pinckney/DPGraphView.git", 
+    :tag => "0.1" 
+  }
+
+  s.source_files  = '*.{h,m}'
+
+  s.requires_arc = true
+
+end


### PR DESCRIPTION
A (so far) very basic reusable view to render continuous functions.  I created this because in looking for other pods, all other plotting pods focused on plotting discrete data for non-mathematic use (such as stock prices).
