### PR TITLE
Update gtm-oauth2 to use an appropriate version of SBJson

### DIFF
--- a/gtm-oauth2/0.0.2/gtm-oauth2.podspec
+++ b/gtm-oauth2/0.0.2/gtm-oauth2.podspec
@@ -5,12 +5,12 @@ Pod::Spec.new do |s|
   s.summary      = "Google Toolbox for Mac - OAuth 2 Controllers."
   s.description = "The Google Toolbox for Mac OAuth 2 Controllers make it easy for Cocoa applications "\
                   "to sign in to services using OAuth 2 for authentication and authorization."
-  s.homepage     = "http://code.google.com/p/gtm-oauth2"
+  s.homepage     = "https://code.google.com/p/gtm-oauth2"
   s.author   = { 'The Google Data APIs team' => 'https://code.google.com/p/google-api-objectivec-client' }
-  s.source       = { :svn => 'http://gtm-oauth2.googlecode.com/svn/trunk/', :revision => 'r118' }
+  s.source       = { :svn => 'https://gtm-oauth2.googlecode.com/svn/trunk/', :revision => 'r118' }
   s.requires_arc = false
+  s.dependency    'SBJson', '~> 3.2'
   s.dependency   'GTMHTTPFetcher'
-  s.dependency    'SBJson'
   s.frameworks = 'Security', 'SystemConfiguration'
   s.ios.deployment_target = '3.0'
   s.osx.deployment_target = '10.6'

--- a/gtm-oauth2/0.0.2/gtm-oauth2.podspec
+++ b/gtm-oauth2/0.0.2/gtm-oauth2.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.6'
 
   s.subspec 'Core' do |oa2|
-    oa2.source_files   = 'Source/*.{h,m}'
+    oa2.source_files   = 'Source/**.{h,m}'
     
     oa2.subspec 'Mac' do |mac|
       mac.osx.source_files = 'Source/Mac/**.{h,m}'

--- a/gtm-oauth2/0.0.3/gtm-oauth2.podspec
+++ b/gtm-oauth2/0.0.3/gtm-oauth2.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.6'
 
   s.subspec 'Core' do |oa2|
-    oa2.source_files   = 'Source/*.{h,m}'
+    oa2.source_files   = 'Source/**.{h,m}'
     
     oa2.subspec 'Mac' do |mac|
       mac.osx.source_files = 'Source/Mac/**.{h,m}'

--- a/gtm-oauth2/0.0.3/gtm-oauth2.podspec
+++ b/gtm-oauth2/0.0.3/gtm-oauth2.podspec
@@ -9,8 +9,8 @@ Pod::Spec.new do |s|
   s.author   = { 'The Google Data APIs team' => 'https://code.google.com/p/google-api-objectivec-client' }
   s.source       = { :svn => 'https://gtm-oauth2.googlecode.com/svn/trunk/', :revision => 'r120' }
   s.requires_arc = false
+  s.dependency    'SBJson', '~> 3.2'
   s.dependency   'GTMHTTPFetcher'
-  s.dependency    'SBJson'
   s.frameworks = 'Security', 'SystemConfiguration'
   s.ios.deployment_target = '3.0'
   s.osx.deployment_target = '10.6'


### PR DESCRIPTION
Also switches sources over to using HTTPS for Google Code repository.
