### PR TITLE
New source distribution of SQLCipher 3.0.1

### DIFF
--- a/SQLCipher/3.0.1/SQLCipher.podspec
+++ b/SQLCipher/3.0.1/SQLCipher.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name     = 'SQLCipher'
+  s.version  = '3.0.1'
+  s.license  = 'BSD'
+  s.summary  = 'Full Database Encryption for SQLite.'
+  s.description  = 'SQLCipher is an open source extension to SQLite that provides transparent 256-bit AES encryption of database files.'
+  s.homepage = 'http://sqlcipher.net'
+  s.author       = 'Zetetic LLC'
+  s.source   = { :git => 'https://github.com/sqlcipher/sqlcipher.git', :tag => 'v3.0.1' }
+  s.platform = :ios
+  s.prepare_command = <<-CMD
+    ./configure --enable-tempstore=yes --with-crypto-lib=commoncrypto CFLAGS="-DSQLITE_HAS_CODEC -DSQLITE_TEMP_STORE=2"
+    make sqlite3.c
+  CMD
+  
+  s.default_subspec = 'standard'
+  
+  # standard compiler flags
+  s.subspec 'standard' do |ss|
+    ss.frameworks = 'Security'
+    ss.compiler_flags = '-DSQLITE_HAS_CODEC', '-DSQLITE_TEMP_STORE=2', '-DSQLITE_THREADSAFE', '-DSQLCIPHER_CRYPTO_CC'
+    ss.source_files = 'sqlite3.c', 'sqlite3.h'
+  end
+  
+  # for cases where you require unlock_notify to be available
+  s.subspec 'unlock_notify' do |ss|
+    ss.frameworks = 'Security'
+    ss.compiler_flags = '-DSQLITE_HAS_CODEC', '-DSQLITE_TEMP_STORE=2', '-DSQLITE_THREADSAFE', '-DSQLCIPHER_CRYPTO_CC', '-DSQLITE_ENABLE_UNLOCK_NOTIFY'
+    ss.source_files = 'sqlite3.c', 'sqlite3.h'
+  end
+end


### PR DESCRIPTION
I actually have push access, but I decided to do a pull request to make sure I didn't step on any toes with this one.

The previous podspec for this library was a binary distribution. I understand why it was done that way, as SQLCipher had a stupidly complex build process, owing to the inclusion of an OpenSSL sub-project.

However, OpenSSL is no longer required (new versions of SQLCipher default to using CommonCrypto instead). So I made this new podspec which updates the code to the latest version (3.0.1), and is distributed as a source build instead of as a binary.

I wasn't sure if I should notify someone of this change before making it. The creators of the library do not appear to have been involved with the previous podspec; it seems someone just built the binary themselves and put it on their personal Github account. And that person does not appear to be actively maintaining it (I sent them an unrelated pull request some time ago, and never heard back).

Anyway, this should be ready to go. I just wanted to check if, owing to procedure (or just courtesy), I should notify someone first.
