### PR TITLE
~ added version VLBCameraView 2.0 which fixed a retain cycle and a typo ...

### DIFF
--- a/VLBCameraView/2.0/VLBCameraView.podspec
+++ b/VLBCameraView/2.0/VLBCameraView.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name         = "VLBCameraView"
+  s.version      = "2.0"
+  s.summary      = "A UIVIew that shows a live feed of the camera, can be used to take a picture, preview the picture and return a UIImage of that preview." 
+  s.homepage     = "https://github.com/verylargebox/VLBCameraView"
+  s.license			 = "MIT"
+
+  s.author       = { "Markos Charatzas" => "markos@qnoid.com" }
+  s.source       = { :git => "https://github.com/verylargebox/VLBCameraView.git", :tag => "2.0" }
+  s.platform     = :ios, '6.0'
+
+  s.source_files = 'VLBCameraView/**/*.{h,m}'
+  s.resources = 'VLBCameraView/**/*.xib'
+  s.prefix_header_file = 'VLBCameraView/VLBCameraView-Prefix.pch'
+  s.frameworks = 'Foundation', 'UIKit', 'AVFoundation', 'CoreImage', 'CoreMedia', 'CoreGraphics', 'AssetsLibrary'
+  s.dependency 'CocoaLumberjack', '1.6.2'
+  s.dependency 'VLBFoundation'
+  s.requires_arc = true
+
+end


### PR DESCRIPTION
Apparently version 1.0 [also broke](https://github.com/verylargebox/VLBCameraView/issues/1) at some point between the release of [VLBCameraViewApp](https://github.com/verylargebox/VLBCameraViewApp) and now which means clients can't really use it as a dependency.

Thanks and happy 2014 :)
