### PR TITLE
Zip Archive disappear

### DIFF
--- a/InMobiSDK/4.1.0/InMobiSDK.podspec
+++ b/InMobiSDK/4.1.0/InMobiSDK.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name         = "InMobiSDK"
+  s.version      = "4.1.0"
+  s.summary      = "InMobi iOS SDK."
+  s.homepage     = "https://www.inmobi.com"
+  s.license      = {
+     :type => 'proprietary',
+     :text => <<-LICENSE
+               Copyright (C) InMobi. All Right Reserved.
+     LICENSE
+  }
+  s.author       = 'InMobi'
+  s.source       = { :http => "https://dl.inmobi.com/SDK/InMobi_iOS_SDK.zip" }
+  s.platform     = :ios
+  s.source_files = 'InMobi-iOS-SDK-4.1.0/Libs/*.h'
+  s.public_header_files = 'InMobi-iOS-SDK-4.1.0/Libs/*.h'
+  s.preserve_paths = 'InMobi-iOS-SDK-4.1.0/Libs/*.a'
+  s.libraries = 'InMobi-4.1.0', 'z', 'sqlite3.0'
+  s.frameworks  = %w{ AudioToolbox AVFoundation CoreTelephony MessageUI MediaPlayer Security SystemConfiguration StoreKit }
+  s.weak_frameworks = %w{ AdSupport }
+  s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC', 'LIBRARY_SEARCH_PATHS' => '${PODS_ROOT}/InMobiSDK/InMobi-iOS-SDK-4.1.0/Libs' }
+end


### PR DESCRIPTION
Hi !

I try to import InMob lib, commited by @ianlevesque

The PodSpec aim at a Zip file.

As usual, CocoaPods should download the zip then unzip it and delete the zip

I can see the zip file being downloaded in the good place, its content is unzipped, but at the end of the install, everything disappeared.

```
ld: warning: directory not found for option '-L/Users/damien/Dev/Projects/auchandrive-ios/Pods/InMobiSDK/InMobi-iOS-SDK-4.0.2/Libs'
ld: library not found for -lInMobi-4.0.2
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
