### PR TITLE
[Update] Braintree (2.2.6)

### DIFF
--- a/Braintree/2.2.6/Braintree.podspec
+++ b/Braintree/2.2.6/Braintree.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name                = 'Braintree'
+  s.summary             = 'The Braintree API helps businesses accept payments online.'
+  s.version             = '2.2.6'
+  s.license             = 'LICENSES'
+  s.author              = { 'Braintree' => 'code@getbraintree.com' }
+  s.homepage            = 'https://braintreepayments.com/'
+  s.source              = { :git => 'https://github.com/braintree/braintree_ios.git', :tag => s.version.to_s }
+  s.platform            = :ios, '5.0'
+  s.requires_arc        = true
+
+  s.source_files        = 'venmo-touch/VenmoTouch.framework/Headers/*.h', 'braintree/BTEncryption/*.{h,m}', 'braintree/BTPayment/*.{h,m}'
+  s.preserve_paths      = 'venmo-touch/VenmoTouch.framework/*'
+  s.frameworks          = 'Foundation', 'UIKit', 'QuartzCore', 'CoreGraphics', 'Security', 'VenmoTouch', 'CoreTelephony', 'AdSupport', 'CoreText'
+  s.xcconfig            = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/Braintree/venmo-touch"' }
+  s.public_header_files = 'venmo-touch/VenmoTouch.framework/Headers/*.h', 'braintree/BTEncryption/*.h', 'braintree/BTPayment/*.h'
+
+  s.resources           = 'braintree/BraintreeResources.bundle', 'venmo-touch/VenmoTouchResources.bundle'
+end


### PR DESCRIPTION
CHANGELOG:                                                                                                
- adds 64-bit support (Thanks @macdrevx, @chrismanderson!)
- bumps iOS Deployment Target from 5.0 to 5.1.1
- use nice constants instead of version numbers. (Thanks @blommegard!)
- internal bug fixes

Includes fixes for:
- https://github.com/braintree/braintree_ios/issues/15
- https://github.com/braintree/braintree_ios/pull/18
- https://github.com/braintree/braintree_ios/pull/21
- https://github.com/braintree/braintree_ios/issues/22

Thanks!
