### PR TITLE
[Fixed] iCloudDocumentSync Podspec

### DIFF
--- a/iCloudDocumentSync/7.1/iCloudDocumentSync.podspec
+++ b/iCloudDocumentSync/7.1/iCloudDocumentSync.podspec
@@ -14,7 +14,6 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => 'https://github.com/iRareMedia/iCloudDocumentSync.git', :tag => 'v7.1' }
 
-  s.source_files = 'iCloud', 'iCloud/*.{h,m}'
   s.preserve_paths = 'iCloud.framework/*'
   s.frameworks   = 'UIKit', 'Foundation'
   s.vendored_frameworks = 'iCloud.framework'


### PR DESCRIPTION
There was an issue with the podspec that caused `duplicate symbols` errors. Fixed those errors. Now only the framework file is installed, not the source and framework. 

Same podspec version and file.
