### PR TITLE
Adding MMRecord 1.2.0 with updated dependencies

### DIFF
--- a/MMRecord/1.2.0/MMRecord.podspec
+++ b/MMRecord/1.2.0/MMRecord.podspec
@@ -5,10 +5,10 @@ Pod::Spec.new do |s|
   s.summary  = 'A simple block based web service integration library.'
   s.homepage = 'https://github.com/MutualMobile/MMRecord'
   s.authors  = { 'Conrad Stoll' => 'conrad.stoll@mutualmobile.com' }
-  s.source   = { :git => 'https://github.com/mutualmobile/MMRecord.git', :tag => '1.2.0' }
+  s.source   = { :git => 'https://github.com/mutualmobile/MMRecord.git', :tag => s.version.to_s }
   s.requires_arc = true
   
-  s.preferred_dependency = 'Core'
+  s.default_subspec = 'Core'
 
   s.ios.deployment_target = '5.0'
   s.ios.frameworks = 'CoreData'
@@ -22,26 +22,26 @@ Pod::Spec.new do |s|
   
   s.subspec 'AFServer' do |af|
     af.source_files = 'Source/MMRecordAFServer/*.{h,m}'
-  af.dependency 'AFNetworking', '~>1.0'
-  af.dependency 'MMRecord/Core'
+    af.dependency 'AFNetworking', '~> 1.0'
+    af.dependency 'MMRecord/Core'
   end
   
   s.subspec 'DynamicModel' do |dyn|
     dyn.source_files = 'Source/MMRecordDynamicModel/*.{h,m}'
-  dyn.dependency 'MMRecord/Core'
+    dyn.dependency 'MMRecord/Core'
   end
   
   s.subspec 'JSONServer' do |json|
     json.source_files = 'Source/MMRecordJSONServer/*.{h,m}'
-  json.dependency 'MMRecord/Core'
+    json.dependency 'MMRecord/Core'
   end
 
   s.subspec 'ResponseSerializer' do |ser|
     ser.source_files = 'Source/AFMMRecordResponseSerializer/*.{h,m}'
-  ser.dependency 'AFNetworking', '~>2.0'
-  ser.dependency 'MMRecord/Core'
-  ser.ios.deployment_target = '6.0'
-  ser.osx.deployment_target = '10.8'
+    ser.dependency 'AFNetworking', '>= 2.0'
+    ser.dependency 'MMRecord/Core'
+    ser.ios.deployment_target = '6.0'
+    ser.osx.deployment_target = '10.8'
   end
   
 end

--- a/MMRecord/1.2.0/MMRecord.podspec
+++ b/MMRecord/1.2.0/MMRecord.podspec
@@ -1,0 +1,44 @@
+Pod::Spec.new do |s|
+  s.name     = 'MMRecord'
+  s.version  = '1.2.0'
+  s.license  = 'MIT'
+  s.summary  = 'A simple block based web service integration library.'
+  s.homepage = 'https://github.com/MutualMobile/MMRecord'
+  s.authors  = { 'Conrad Stoll' => 'conrad.stoll@mutualmobile.com' }
+  s.source   = { :git => 'https://github.com/mutualmobile/MMRecord.git', :tag => '1.2.0' }
+  s.requires_arc = true
+  
+  s.preferred_dependency = 'Core'
+
+  s.ios.deployment_target = '5.0'
+  s.ios.frameworks = 'CoreData'
+
+  s.osx.deployment_target = '10.7'
+  s.osx.frameworks = 'CoreData'
+  
+  s.subspec 'Core' do |core|
+    core.source_files = 'Source/MMRecord/*.{h,m}'
+  end
+  
+  s.subspec 'AFServer' do |af|
+    af.source_files = 'Source/MMRecordAFServer/*.{h,m}'
+  af.dependency 'AFNetworking', '~>1.0'
+  af.dependency 'MMRecord/Core'
+  end
+  
+  s.subspec 'DynamicModel' do |dyn|
+    dyn.source_files = 'Source/MMRecordDynamicModel/*.{h,m}'
+  dyn.dependency 'MMRecord/Core'
+  end
+  
+  s.subspec 'JSONServer' do |json|
+    json.source_files = 'Source/MMRecordJSONServer/*.{h,m}'
+  json.dependency 'MMRecord/Core'
+  end
+
+  s.subspec 'ResponseSerializer' do |ser|
+    ser.source_files = 'Source/AFMMRecordResponseSerializer/*.{h,m}'
+  ser.dependency 'MMRecord/Core'
+  end
+  
+end

--- a/MMRecord/1.2.0/MMRecord.podspec
+++ b/MMRecord/1.2.0/MMRecord.podspec
@@ -10,10 +10,10 @@ Pod::Spec.new do |s|
   
   s.default_subspec = 'Core'
 
-  s.ios.deployment_target = '5.0'
+  s.ios.deployment_target = '6.0'
   s.ios.frameworks = 'CoreData'
 
-  s.osx.deployment_target = '10.7'
+  s.osx.deployment_target = '10.8'
   s.osx.frameworks = 'CoreData'
   
   s.subspec 'Core' do |core|
@@ -40,8 +40,6 @@ Pod::Spec.new do |s|
     ser.source_files = 'Source/AFMMRecordResponseSerializer/*.{h,m}'
     ser.dependency 'AFNetworking', '>= 2.0'
     ser.dependency 'MMRecord/Core'
-    ser.ios.deployment_target = '6.0'
-    ser.osx.deployment_target = '10.8'
   end
   
 end

--- a/MMRecord/1.2.0/MMRecord.podspec
+++ b/MMRecord/1.2.0/MMRecord.podspec
@@ -40,6 +40,8 @@ Pod::Spec.new do |s|
     ser.source_files = 'Source/AFMMRecordResponseSerializer/*.{h,m}'
   ser.dependency 'AFNetworking', '~>2.0'
   ser.dependency 'MMRecord/Core'
+  ser.ios.deployment_target = '6.0'
+  ser.osx.deployment_target = '10.8'
   end
   
 end

--- a/MMRecord/1.2.0/MMRecord.podspec
+++ b/MMRecord/1.2.0/MMRecord.podspec
@@ -38,6 +38,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'ResponseSerializer' do |ser|
     ser.source_files = 'Source/AFMMRecordResponseSerializer/*.{h,m}'
+  ser.dependency 'AFNetworking', '~>2.0'
   ser.dependency 'MMRecord/Core'
   end
   


### PR DESCRIPTION
This pod spec does pass lint, so if it fails again I'm not sure what else to do
