### PR TITLE
ADFullScreenDetailView changed platform requirement form ios 6.1 to ios ...

### DIFF
--- a/ADFullScreenDetailView/0.0.1/ADFullScreenDetailView.podspec
+++ b/ADFullScreenDetailView/0.0.1/ADFullScreenDetailView.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
 	s.license = 'MIT'
 	s.author = { "Zack Liston" => "zackmliston@gmail.com" }
 	s.source = { :git => "https://github.com/agilemd/ADFullScreenDetailView.git", :tag => "0.0.1" }
-	s.platform = :ios, '6.1'
+	s.platform = :ios, '6.0'
 	s.source_files = 'ADFullScreenDetailView'
 	s.exclude_files = 'ADFullScreenDetailViewDemo', 'ADFullScreenDetailViewTests'
 	s.framework = 'QuartzCore'


### PR DESCRIPTION
...6.0 
When I initially created this I did so with the intention of targeting it to ios 6.0 but failed to reflect this in the podspecs file. It was 6.1, now it is 6.0
