### PR TITLE
Activate SBJson for OS X as well as iOS + limit public headers

### DIFF
--- a/SBJson/4.0.0/SBJson.podspec
+++ b/SBJson/4.0.0/SBJson.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name     = 'SBJson'
   s.version  = '4.0.0'
   s.license = { :type => 'BSD', :text => <<-LICENSE
-    Copyright (C) 2007-2013 Stig Brautaset. All rights reserved.
+    Copyright (C) 2007-2014 Stig Brautaset. All rights reserved.
 
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
@@ -50,5 +50,8 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.7'
+
   s.source_files = 'src/main/objc'
+  s.public_header_files = 'src/main/objc/SBJson4{,Parser,StreamParser,StreamWriter,Writer}.h'
 end

--- a/SBJson4/4.0.0/SBJson4.podspec
+++ b/SBJson4/4.0.0/SBJson4.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name     = 'SBJson4'
   s.version  = '4.0.0'
   s.license = { :type => 'BSD', :text => <<-LICENSE
-    Copyright (C) 2007-2013 Stig Brautaset. All rights reserved.
+    Copyright (C) 2007-2014 Stig Brautaset. All rights reserved.
 
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
@@ -45,10 +45,13 @@ Pod::Spec.new do |s|
   DESC
 
   s.homepage = 'http://sbjson.org'
-  s.authors  = { 'Stig Brautaset' => 'stig@brautaset.org' }
+  s.author   = { 'Stig Brautaset' => 'stig@brautaset.org' }
   s.source   = { :git => 'https://github.com/stig/json-framework.git', :tag => 'v4.0.0' }
 
   s.requires_arc = true
   s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.7'
+
   s.source_files = 'src/main/objc'
+  s.public_header_files = 'src/main/objc/SBJson4{,Parser,StreamParser,StreamWriter,Writer}.h'
 end


### PR DESCRIPTION
I finally figured out why it was not listed as available for OS X :-)

If limiting the public headers for an existing spec is not acceptable I can drop that and introduce it in a later patch version.
