### PR TITLE
Added TASTaggedAttributedString 1.0.0

### DIFF
--- a/TASTaggedAttributedString/1.0.0/TASTaggedAttributedString.podspec
+++ b/TASTaggedAttributedString/1.0.0/TASTaggedAttributedString.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = "TASTaggedAttributedString"
+  s.version      = "1.0.0"
+
+  s.summary      = "A category on NSString for quickly generating attributed strings from HTML-style tags."
+  s.description  = "NSAttributedStrings are quite useful in UILabels and UITextViews, however they're not particularly user-friendly, especially with dynamic text. TaggedAttributedString is a simple way to generate NSAttributedStrings using lightweight HTML-style tags, and makes using NSAttributedStrings far less painful."
+  s.homepage     = "https://github.com/svwolfpack/TaggedAttributedString"
+
+  s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }
+  s.author       = { "Sam Voigt" => "sam@intrepid.io" }
+  
+  s.platform     = :ios, '5.0'
+  s.source       = { :git => "https://github.com/samvoigt/TASTaggedAttributedString.git", :tag => "1.0.0" }
+  s.source_files  = 'TASTaggedAttributedString/*.{h,m}'
+  s.requires_arc = true
+end


### PR DESCRIPTION
Added TASTaggedAttributedString 1.0.0, a category on NSString for quickly generating attributed strings from HTML-style tags.
