### PR TITLE
Updated EZAudio to master version 0.0.3 with new extensions, updates, and bug fixes.

### DIFF
--- a/EZAudio/0.0.3/EZAudio.podspec
+++ b/EZAudio/0.0.3/EZAudio.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name         = "EZAudio"
+  s.version      = "0.0.3"
+  s.summary      = "A simple, intuitive audio framework for iOS and OSX useful for anyone doing audio processing and/or audio-based visualizations."
+  s.homepage     = "http://syedharisali.com/projects/EZAudio/getting-started"
+  s.screenshots  = "https://s3-us-west-1.amazonaws.com/ezaudio-media/EZAudioSummary.png"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author       = { "Syed Haris Ali" => "syedhali07@gmail.com" }
+  s.ios.deployment_target = '6.0'
+  s.osx.deployment_target = '10.8'
+  s.source       = { :git => "https://github.com/syedhali/EZAudio.git", :tag => "0.0.3" }
+  s.source_files  = 'EZAudio/*.{h,m,c}'
+  s.exclude_files = 'EZAudio/VERSION'
+  s.ios.frameworks = 'AudioToolbox','GLKit'
+  s.osx.frameworks = 'AudioToolbox','AudioUnit','CoreAudio','QuartzCore','OpenGL','GLKit'
+  s.requires_arc = true;
+end


### PR DESCRIPTION
Changelog:
- Changing EZAudioPlot and EZAudioPlotGL to scroll for the EZPlotTypeRolling instead of wiping the screen clean when hitting the end
- Allowed EZMicrophone EZOutput to have custom AudioStreamBasicDescription setters
- Fixed bug in EZAudioFile's getWaveformData function where it was not exiting after sending back cached waveform data (rereading from the audio file)
- Added stereo support for EZMicrophone, EZAudioFile, EZRecorder, and EZOutput
- Added more memory cleanup for EZAudioFile
- Added adjustable rolling length for EZAudioPlot and EZAudioPlotGL so those rolling graphs can now range from 128 to 8192 whereas before it was fixed at 1024
- Added adjustable resolution for waveform data coming from the EZAudioFile so output from the getWaveformDataWithCompletionBlock: function can literally be of any size. Try 128 for a low resolution waveform or 8192 for a much higher resolution waveform.
- Added quick fix for EZOutput to properly route stereo data coming from a circular buffer datasource. Next version (0.0.4) needs to add EZConverter to allow quick conversions between non-interleaved and interleaved formats.
