### PR TITLE
Spec update: Development target is removed

### DIFF
--- a/TLMotionEffect/0.0.1/TLMotionEffect.podspec
+++ b/TLMotionEffect/0.0.1/TLMotionEffect.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/jvenegas/TLMotionEffect.git', :tag => '0.0.1' }
   s.social_media_url = "http://twitter.com/javienegas"
   s.requires_arc = true
-  s.ios.deployment_target = '7.0'
+  s.platform     = :ios
   s.source_files  = 'UIView+TLMotionEffect*'
   s.framework = 'UIKit'
 end


### PR DESCRIPTION
The development target is removed to enable compatibility with
different iOS versions.
The category check the iOS version before add the motion effect.
