### PR TITLE
Add Google AdMob SDK 6.8.0

### DIFF
--- a/Google-AdMob-Ads-SDK/6.8.0/Google-AdMob-Ads-SDK.podspec
+++ b/Google-AdMob-Ads-SDK/6.8.0/Google-AdMob-Ads-SDK.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+  s.name = "Google-AdMob-Ads-SDK"
+  s.version = "6.8.0"
+  s.summary = "Google AdMob Ads SDK."
+  s.description = "The Google AdMob Ads SDK allows developers to easily incorporate mobile-friendly text and image banners as well as rich, full-screen web apps known as interstitials."
+  s.homepage = "https://developers.google.com/mobile-ads-sdk/docs/"
+
+  s.license = {
+    :type => 'Copyright',
+    :text => <<-LICENSE
+Copyright 2009 - 2012 Google, Inc. All rights reserved.
+LICENSE
+  }
+  s.author = 'Google Inc.'
+  s.source = { :http => "http://dl.google.com/googleadmobadssdk/googlemobileadssdkios.zip" }
+  s.platform = :ios
+
+  s.source_files = 'GoogleAdMobAdsSdkiOS-6.8.0/*.h'
+  s.preserve_paths = 'GoogleAdMobAdsSdkiOS-6.8.0'
+
+  s.framework = %w{AVFoundation AudioToolbox CoreTelephony MessageUI SystemConfiguration CoreGraphics AdSupport}
+  s.library = 'GoogleAdMobAds'
+  s.xcconfig = { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Google-AdMob-Ads-SDK/GoogleAdMobAdsSdkiOS-6.8.0"' }
+end


### PR DESCRIPTION
The iOS SDK utilizes Apple's advertising identifier (IDFA). The SDK uses
IDFA under the guidelines laid out in the iOS developer program license
agreement. You must ensure you are in compliance with the iOS developer
program license agreement policies governing the use of this identifier.

This version of the SDK allows you to specify if you would like your app
to be treated as child-directed for purposes of the Children's Online
Privacy Protection Act (COPPA).
