### PR TITLE
Rename xingapi

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -90,6 +90,7 @@ PODS_ALLOWED_TO_FAIL = {
     'TouchDB',
     'unoffical-twitter-sdk',
     'XingSDK',
+    'XINGAPI'
   ],
 
   "The pre install hook of the specification DSL has been deprecated, use the `resource_bundles` or the `prepare_command` attributes." => [

--- a/Rakefile
+++ b/Rakefile
@@ -90,6 +90,7 @@ PODS_ALLOWED_TO_FAIL = {
     'TouchDB',
     'unoffical-twitter-sdk',
     'XingSDK',
+    'XNGAPIClient'
   ],
 
   "The pre install hook of the specification DSL has been deprecated, use the `resource_bundles` or the `prepare_command` attributes." => [

--- a/Rakefile
+++ b/Rakefile
@@ -90,7 +90,6 @@ PODS_ALLOWED_TO_FAIL = {
     'TouchDB',
     'unoffical-twitter-sdk',
     'XingSDK',
-    'XNGAPIClient'
   ],
 
   "The pre install hook of the specification DSL has been deprecated, use the `resource_bundles` or the `prepare_command` attributes." => [

--- a/XINGAPI/0.0.1/XINGAPI.podspec
+++ b/XINGAPI/0.0.1/XINGAPI.podspec
@@ -18,4 +18,7 @@ Pod::Spec.new do |s|
   s.dependency   'gtm-oauth', '= 0.0.1'
   s.dependency   'SFHFKeychainUtils', '= 0.0.1'
   s.frameworks = 'Security','SystemConfiguration'
+  s.post_install do
+    puts "[!] XINGAPI pod is deprecated please use the XNGAPIClient pod instead"
+  end
 end

--- a/XINGAPI/0.0.2/XINGAPI.podspec
+++ b/XINGAPI/0.0.2/XINGAPI.podspec
@@ -18,4 +18,7 @@ Pod::Spec.new do |s|
   s.dependency   'gtm-oauth', '= 0.0.1'
   s.dependency   'SFHFKeychainUtils', '= 0.0.1'
   s.frameworks = 'Security','SystemConfiguration'
+  s.post_install do
+    puts "[!] XINGAPI pod is deprecated please use the XNGAPIClient pod instead"
+  end
 end

--- a/XINGAPI/0.0.3/XINGAPI.podspec
+++ b/XINGAPI/0.0.3/XINGAPI.podspec
@@ -18,4 +18,7 @@ Pod::Spec.new do |s|
   s.dependency   'gtm-oauth', '= 0.0.1'
   s.dependency   'SFHFKeychainUtils', '= 0.0.1'
   s.frameworks = 'Security','SystemConfiguration'
+  s.post_install do
+    puts "[!] XINGAPI pod is deprecated please use the XNGAPIClient pod instead"
+  end
 end

--- a/XINGAPI/0.0.4/XINGAPI.podspec
+++ b/XINGAPI/0.0.4/XINGAPI.podspec
@@ -20,4 +20,7 @@ Pod::Spec.new do |s|
   s.dependency   'SSKeychain', '= 1.2.0'
   s.dependency   'AFOAuth1Client', '~> 0.3.1'
   s.frameworks = 'Security','SystemConfiguration'
+  s.post_install do
+    puts "[!] XINGAPI pod is deprecated please use the XNGAPIClient pod instead"
+  end
 end

--- a/XINGAPI/0.1.0/XINGAPI.podspec
+++ b/XINGAPI/0.1.0/XINGAPI.podspec
@@ -19,4 +19,7 @@ Pod::Spec.new do |s|
   s.dependency   'SSKeychain', '= 1.2.0'
   s.dependency   'AFOAuth1Client', '= 0.3.1'
   s.frameworks = 'Security','SystemConfiguration'
+  s.post_install do
+    puts "[!] XINGAPI pod is deprecated please use the XNGAPIClient pod instead"
+  end
 end

--- a/XNGAPIClient/0.1.0/XNGAPIClient.podspec
+++ b/XNGAPIClient/0.1.0/XNGAPIClient.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name = 'XNGAPIClient'
+  s.version = '0.1.0'
+  s.license = 'MIT'
+  s.ios.deployment_target = '6.0'
+  s.osx.deployment_target = '10.7'
+  s.summary = 'The official Objective-C client for the XING API'
+  s.author  = {
+    'XING iOS Team' => 'iphonedev@xing.com'
+  }
+  s.source = {
+    :git => 'https://github.com/xing/XNGAPIClient.git',
+    :tag => '0.1.0'
+  }
+  s.source_files = 'XNGAPIClient/*.{h,m}'
+  s.requires_arc = true
+  s.homepage = 'https://www.xing.com'
+  s.dependency   'AFNetworking','~> 1.3.0'
+  s.dependency   'SSKeychain', '= 1.2.0'
+  s.dependency   'AFOAuth1Client', '= 0.3.1'
+  s.frameworks = 'Security','SystemConfiguration'
+end


### PR DESCRIPTION
Hey *,

I deprecated the XINGAPI pods with a post install print (as suggested in CocoaPods/Specs/issues/4608 ).

I added the 'new' XNGAPIClient spec too.
