### PR TITLE
CorePlot: s/pre_install/prepare_command/

### DIFF
--- a/CorePlot/1.4/CorePlot.podspec
+++ b/CorePlot/1.4/CorePlot.podspec
@@ -20,13 +20,9 @@ Pod::Spec.new do |s|
   s.osx.source_files = 'framework/CorePlot.h', 'framework/MacOnly/*.{h,m}'
   s.framework   = 'QuartzCore'
 
-  s.pre_install do |pod, target_definition|
-    Dir.chdir(pod.root) {
-      unless File.exists?('framework')
-        FileUtils.mv Dir.glob('**/framework'), '.'
-        FileUtils.mv Dir.glob('**/License.txt'), '.'
-        `dtrace -h -s framework/TestResources/CorePlotProbes.d -o framework/Source/CorePlotProbes.h`
-      end
-    }
-  end
+  s.prepare_command = <<-CMD
+    mv -v CorePlot_1.4/Source/framework .
+    mv -v CorePlot_1.4/Source/License.txt .
+    dtrace -h -s framework/TestResources/CorePlotProbes.d -o framework/Source/CorePlotProbes.h
+  CMD
 end


### PR DESCRIPTION
Replaced the pre_install hook with a prepare_command script, to avoid deprecation warnings.
