### PR TITLE
Updated all CorePlot specs

### DIFF
--- a/CorePlot/1.0/CorePlot.podspec
+++ b/CorePlot/1.0/CorePlot.podspec
@@ -3,21 +3,27 @@ Pod::Spec.new do |s|
   s.version  = '1.0'
   s.license  = 'BSD'
   s.summary  = 'Cocoa plotting framework for Mac OS X and iOS.'
-  s.homepage = 'http://code.google.com/p/core-plot/'
+  s.homepage = 'https://github.com/core-plot'
   s.authors  = { 'Drew McCormack' => 'drewmccormack@mac.com',
                  'Brad Larson'    => 'larson@sunsetlakesoftware.com',
                  'Eric Skroch'    => 'eskroch@mac.com',
                  'Barry Wark'     => 'barrywark@gmail.com' }
-  s.source   = { :hg  => 'https://code.google.com/p/core-plot', :revision => 'release_1.0' }
+  s.source   = { :http => 'https://github.com/core-plot/core-plot/releases/download/release_1.0/CorePlot_1.0.zip' }
 
   s.description = 'Core Plot is a plotting framework for OS X and iOS. It provides 2D visualization ' \
                   'of data, and is tightly integrated with Apple technologies like Core Animation, ' \
                   'Core Data, and Cocoa Bindings.'
 
-  s.source_files = 'framework/TestResources/CorePlotProbes.d', 'framework/Source/*.{h,m}'
+  s.source_files = 'framework/Source/*.{h,m}'
   s.exclude_files = '**/*{TestCase,Tests}.{h,m}'
   s.ios.source_files = 'framework/CorePlot-CocoaTouch.h', 'framework/iPhoneOnly/*.{h,m}'
   s.osx.source_files = 'framework/CorePlot.h', 'framework/MacOnly/*.{h,m}'
 
   s.framework   = 'QuartzCore'
+
+  s.prepare_command = <<-CMD
+    mv -v CorePlot_1.0/Source/framework .
+    mv -v CorePlot_1.0/Source/License.txt .
+    dtrace -h -s framework/TestResources/CorePlotProbes.d -o framework/Source/CorePlotProbes.h
+  CMD
 end

--- a/CorePlot/1.1/CorePlot.podspec
+++ b/CorePlot/1.1/CorePlot.podspec
@@ -3,21 +3,27 @@ Pod::Spec.new do |s|
   s.version  = '1.1'
   s.license  = 'BSD'
   s.summary  = 'Cocoa plotting framework for Mac OS X and iOS.'
-  s.homepage = 'http://code.google.com/p/core-plot/'
+  s.homepage = 'https://github.com/core-plot'
   s.authors  = { 'Drew McCormack' => 'drewmccormack@mac.com',
                  'Brad Larson'    => 'larson@sunsetlakesoftware.com',
                  'Eric Skroch'    => 'eskroch@mac.com',
                  'Barry Wark'     => 'barrywark@gmail.com' }
-  s.source   = { :hg  => 'http://code.google.com/p/core-plot', :revision => 'release_1.1' }
+  s.source   = { :http => 'https://github.com/core-plot/core-plot/releases/download/release_1.1/CorePlot_1.1.zip' }
 
   s.description = 'Core Plot is a plotting framework for OS X and iOS. It provides 2D visualization ' \
                   'of data, and is tightly integrated with Apple technologies like Core Animation, ' \
                   'Core Data, and Cocoa Bindings.'
 
-  s.source_files = 'framework/TestResources/CorePlotProbes.d', 'framework/Source/*.{h,m}'
+  s.source_files = 'framework/Source/*.{h,m}'
   s.exclude_files = '**/*{TestCase,Tests}.{h,m}'
   s.ios.source_files = 'framework/CorePlot-CocoaTouch.h', 'framework/iPhoneOnly/*.{h,m}'
   s.osx.source_files = 'framework/CorePlot.h', 'framework/MacOnly/*.{h,m}'
 
   s.framework   = 'QuartzCore'
+
+  s.prepare_command = <<-CMD
+    mv -v CorePlot_1.1/Source/framework .
+    mv -v CorePlot_1.1/Source/License.txt .
+    dtrace -h -s framework/TestResources/CorePlotProbes.d -o framework/Source/CorePlotProbes.h
+  CMD
 end

--- a/CorePlot/1.2/CorePlot.podspec
+++ b/CorePlot/1.2/CorePlot.podspec
@@ -3,12 +3,12 @@ Pod::Spec.new do |s|
   s.version  = '1.2'
   s.license  = 'BSD'
   s.summary  = 'Cocoa plotting framework for Mac OS X and iOS.'
-  s.homepage = 'http://code.google.com/p/core-plot/'
+  s.homepage = 'https://github.com/core-plot'
   s.authors  = { 'Drew McCormack' => 'drewmccormack@mac.com',
                  'Brad Larson'    => 'larson@sunsetlakesoftware.com',
                  'Eric Skroch'    => 'eskroch@mac.com',
                  'Barry Wark'     => 'barrywark@gmail.com' }
-  s.source   = { :hg  => 'http://code.google.com/p/core-plot', :revision => 'release_1.2' }
+  s.source   = { :http => 'https://github.com/core-plot/core-plot/releases/download/release_1.2/CorePlot_1.2.zip' }
 
   s.description = 'Core Plot is a plotting framework for OS X and iOS. It provides 2D visualization ' \
                   'of data, and is tightly integrated with Apple technologies like Core Animation, ' \
@@ -21,7 +21,9 @@ Pod::Spec.new do |s|
 
   s.framework   = 'QuartzCore'
 
-  s.pre_install do |pod, target_definition|
-    Dir.chdir(pod.root) {`/usr/sbin/dtrace -h -s framework/TestResources/CorePlotProbes.d -o framework/Source/CorePlotProbes.h`}
-  end
+  s.prepare_command = <<-CMD
+    mv -v CorePlot_1.2/Source/framework .
+    mv -v CorePlot_1.2/Source/License.txt .
+    dtrace -h -s framework/TestResources/CorePlotProbes.d -o framework/Source/CorePlotProbes.h
+  CMD
 end

--- a/CorePlot/1.3/CorePlot.podspec
+++ b/CorePlot/1.3/CorePlot.podspec
@@ -3,12 +3,12 @@ Pod::Spec.new do |s|
   s.version  = '1.3'
   s.license  = 'BSD'
   s.summary  = 'Cocoa plotting framework for Mac OS X and iOS.'
-  s.homepage = 'http://code.google.com/p/core-plot/'
+  s.homepage = 'https://github.com/core-plot'
   s.authors  = { 'Drew McCormack' => 'drewmccormack@mac.com',
                  'Brad Larson'    => 'larson@sunsetlakesoftware.com',
                  'Eric Skroch'    => 'eskroch@mac.com',
                  'Barry Wark'     => 'barrywark@gmail.com' }
-  s.source   = { :http => 'https://core-plot.googlecode.com/files/CorePlot_1.3.zip' }
+  s.source   = { :http => 'https://github.com/core-plot/core-plot/releases/download/release_1.3/CorePlot_1.3.zip' }
 
   s.description = 'Core Plot is a plotting framework for OS X and iOS. It provides 2D visualization ' \
                   'of data, and is tightly integrated with Apple technologies like Core Animation, ' \
@@ -18,15 +18,12 @@ Pod::Spec.new do |s|
   s.exclude_files = '**/*{TestCase,Tests}.{h,m}'
   s.ios.source_files = 'framework/CorePlot-CocoaTouch.h', 'framework/iPhoneOnly/*.{h,m}'
   s.osx.source_files = 'framework/CorePlot.h', 'framework/MacOnly/*.{h,m}'
+
   s.framework   = 'QuartzCore'
 
-  s.pre_install do |pod, target_definition|
-    Dir.chdir(pod.root) {
-      unless File.exists?('framework')
-        FileUtils.mv Dir.glob('**/framework'), '.'
-        FileUtils.mv Dir.glob('**/License.txt'), '.'
-        `dtrace -h -s framework/TestResources/CorePlotProbes.d -o framework/Source/CorePlotProbes.h`
-      end
-    }
-  end
+  s.prepare_command = <<-CMD
+    mv -v CorePlot_1.3/Source/framework .
+    mv -v CorePlot_1.3/Source/License.txt .
+    dtrace -h -s framework/TestResources/CorePlotProbes.d -o framework/Source/CorePlotProbes.h
+  CMD
 end

--- a/CorePlot/1.4/CorePlot.podspec
+++ b/CorePlot/1.4/CorePlot.podspec
@@ -3,12 +3,12 @@ Pod::Spec.new do |s|
   s.version  = '1.4'
   s.license  = 'BSD'
   s.summary  = 'Cocoa plotting framework for Mac OS X and iOS.'
-  s.homepage = 'http://code.google.com/p/core-plot/'
+  s.homepage = 'https://github.com/core-plot'
   s.authors  = { 'Drew McCormack' => 'drewmccormack@mac.com',
                  'Brad Larson'    => 'larson@sunsetlakesoftware.com',
                  'Eric Skroch'    => 'eskroch@mac.com',
                  'Barry Wark'     => 'barrywark@gmail.com' }
-  s.source   = { :http => 'https://core-plot.googlecode.com/files/CorePlot_1.4.zip' }
+  s.source   = { :http => 'https://github.com/core-plot/core-plot/releases/download/release_1.4/CorePlot_1.4.zip' }
 
   s.description = 'Core Plot is a plotting framework for OS X and iOS. It provides 2D visualization ' \
                   'of data, and is tightly integrated with Apple technologies like Core Animation, ' \
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
   s.exclude_files = '**/*{TestCase,Tests}.{h,m}'
   s.ios.source_files = 'framework/CorePlot-CocoaTouch.h', 'framework/iPhoneOnly/*.{h,m}'
   s.osx.source_files = 'framework/CorePlot.h', 'framework/MacOnly/*.{h,m}'
+
   s.framework   = 'QuartzCore'
 
   s.prepare_command = <<-CMD


### PR DESCRIPTION
This is follow-up from CocoaPods/Specs#7383
- Changed URLs to reflect project's move to GitHub.
- Replace pre_install hook with prepare_command where appropriate (avoid deprecation warnings).
- Generally made spec file consistent among versions.

I tested these with a dummy project with a one line Podfile, they all installed correctly and the installed source files looked in order.
