### PR TITLE
[Fix] LetsMove 1.9 to ignore main.m file

### DIFF
--- a/LetsMove/1.9/LetsMove.podspec
+++ b/LetsMove/1.9/LetsMove.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   }
 
   s.source_files  = '*.{h,m}'
-  s.exclude_files = 'LetsMoveAppDelegate.{h,m}'
+  s.exclude_files = 'main.m', 'LetsMoveAppDelegate.{h,m}'
   s.public_header_files = 'PFMoveApplication.h'
 
   s.resources = '*.lproj'


### PR DESCRIPTION
[Fix] LetsMove 1.9 to ignore main.m file. Otherwise this causes a linker error for any projects that already contain a main.m (which is _most_ projects)
