### PR TITLE
Add UIImage+ImageWithColor-v1

### DIFF
--- a/UIImage+ImageWithColor/1/UIImage+ImageWithColor.podspec
+++ b/UIImage+ImageWithColor/1/UIImage+ImageWithColor.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name          = 'UIImage+ImageWithColor'
+  s.version       = '1'
+  s.summary       = 'Creates a 1x1 UIImage with its pixel set to the color you choose.'
+  s.license       = 'Public Domain'
+  s.author        = {'Max Howell' => 'mxcl@me.com'}
+  s.platform      = :ios
+  s.source        = {:git => 'https://github.com/mxcl/UIImageWithColor.git', :tag => "1"}
+  s.source_files  = '*.{h,m}'
+  s.requires_arc  = false
+  s.frameworks    = 'UIKit'
+  s.homepage      = 'https://github.com/mxcl/UIImageWithColor'
+end


### PR DESCRIPTION
Generates a 1x1 UIImage with a single pixel color.

Useful for stub images for custom barButtons or toolbarButtons or for when you need a single colored UIButton and of course, buttons only allow you to set the backgroundImage.
