### PR TITLE
Add UIColor+PerceivedLuminance-v1

### DIFF
--- a/UIColor+PerceivedLuminance/1/UIColor+PerceivedLuminance.podspec
+++ b/UIColor+PerceivedLuminance/1/UIColor+PerceivedLuminance.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name          = 'UIColor+PerceivedLuminance'
+  s.version       = '1'
+  s.summary       = 'Obtain the luminance value of a `UIColor` as interperated by a human eye.'
+  s.license       = {:type => 'MIT', :file => 'UIColor+PerceivedLuminance.m'}
+  s.author        = {'Max Howell' => 'mxcl@me.com'}
+  s.platform      = :ios
+  s.source        = {:git => 'https://github.com/mxcl/UIColorPerceivedLuminance.git', :tag => "1"}
+  s.source_files  = '*.{h,m}'
+  s.requires_arc  = false
+  s.frameworks    = 'UIKit'
+  s.homepage      = 'https://github.com/mxcl/UIColorPerceivedLuminance'
+end


### PR DESCRIPTION
The point of my last two pods because now you can do:

``` objc
- (UIStatusBarStyle)preferredStatusBarStyle {
    return self.topImageView.image.averageColor.perceivedLuminance > 0.5
        ? UIStatusBarStyleLightContent
        : UIStatusBarStyleDefault;
}
```

Though I have discovered it is better to get the statusBarFrame amount of your image, so I'm deciding how I should go about submitting that pod.
