### PR TITLE
Update DBChooser.podspec

### DIFF
--- a/DBChooser/1.1/DBChooser.podspec
+++ b/DBChooser/1.1/DBChooser.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.homepage = "https://www.dropbox.com/developers/dropins"
 	s.platform = :ios
   s.requires_arc = true
-  s.ios.deployment_target = '7.0'
+  s.ios.deployment_target = '6.0'
 	s.frameworks = 'CoreFoundation', 'Foundation', 'UIKit'
   s.resource = "DBChooser.bundle"
   s.source_files = 'DBChooser/*.{h,m}', 'DBChooser/UI/*.{h,m}'


### PR DESCRIPTION
DBChooser is compatible with iOS 6
