### PR TITLE
Added Courier version 0.0.3 to spec

### DIFF
--- a/Courier/0.0.3/Courier.podspec
+++ b/Courier/0.0.3/Courier.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name         = "Courier"
+  s.version      = "0.0.3"
+  s.summary      = "A lightweight network layer built on NSURLSession."
+  s.license      = 'MIT'
+  s.author       = { 
+    "Andrew Smith" => "drewsmits@gmail.com"
+  }
+  s.social_media_url = "http://twitter.com/drewsmits"
+  s.requires_arc = true
+  s.platform     = :ios, '7.0'
+  s.source       = { 
+    :git => "https://github.com/Drewsmits/Courier.git", 
+    :tag => s.version.to_s 
+  }
+  s.homepage = "http://github.com/Drewsmits/Courier"
+  s.source_files  = 'Courier/*.{h,m}'
+  s.public_header_files = 'Courier/*.h'
+  s.frameworks = 'UIKit', 'SystemConfiguration', 'Foundation'
+end


### PR DESCRIPTION
Adds Courier v 0.0.3 to Specs. Courier is a lightweight network layer intended to exist somewhere in between a vanilla NSURLSession and the much larger AFNetworking library.
