### PR TITLE
fixed issue with podspec RestForIOS - missing license

### DIFF
--- a/RestForIOS/1.0.0/RestForIOS.podspec
+++ b/RestForIOS/1.0.0/RestForIOS.podspec
@@ -24,5 +24,5 @@ Pod::Spec.new do |s|
 
   s.source_files  = 'RestForIOS/*.{h,m}'
   s.exclude_files = 'Classes/Exclude'
-  s.framework  = 'CommonCrypto'
+  s.ios.library  = 'commonCrypto'
 end

--- a/RestForIOS/1.0.0/RestForIOS.podspec
+++ b/RestForIOS/1.0.0/RestForIOS.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.homepage     = "http://github.com/adeeshaek/RestForIOS"
 
-  s.license      = { :type => 'MIT', :file => '../LICENSE' }
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Adeesha Ekanayake" => "adeeshaekanayake@gmail.com" }
 
   s.platform     = :ios


### PR DESCRIPTION
Fixed issue in my pod spec, where cocoapods issued a warning regarding a missing license. It works correctly now.

I also changed the dependency commonCrypto from a framework dependency to a library dependency.
