### PR TITLE
Fix MagicalRecord podspecs

### DIFF
--- a/MagicalRecord/1.7.1/MagicalRecord.podspec
+++ b/MagicalRecord/1.7.1/MagicalRecord.podspec
@@ -5,16 +5,9 @@ Pod::Spec.new do |s|
   s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1!.'
   s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
-  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => '1.7.1' }
+  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'Source/**/*.{h,m}'
   s.framework    = 'CoreData'
   s.requires_arc = true
-
-  def s.post_install(target)
-    prefix_header = config.project_pods_root + target.prefix_header_filename
-    prefix_header.open('a') do |file|
-      file.puts(%{#ifdef __OBJC__\n#define MR_SHORTHAND 1\n#import "CoreData+MagicalRecord.h"\n#endif})
-    end
-  end
 end

--- a/MagicalRecord/1.8.3/MagicalRecord.podspec
+++ b/MagicalRecord/1.8.3/MagicalRecord.podspec
@@ -5,16 +5,9 @@ Pod::Spec.new do |s|
   s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1!.'
   s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
-  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => '1.8.3' }
+  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'Source/**/*.{h,m}'
   s.framework    = 'CoreData'
-
-  def s.post_install(target)
-    prefix_header = config.project_pods_root + target.prefix_header_filename
-    prefix_header.open('a') do |file|
-      file.puts(%{#ifdef __OBJC__\n#define MR_SHORTHAND 1\n#import "CoreData+MagicalRecord.h"\n#endif})
-    end
-  end
 end
 

--- a/MagicalRecord/2.0.3/MagicalRecord.podspec
+++ b/MagicalRecord/2.0.3/MagicalRecord.podspec
@@ -5,16 +5,9 @@ Pod::Spec.new do |s|
   s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1!.'
   s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
-  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => '2.0.3' }
+  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'
   s.requires_arc = true
-
-  def s.post_install(target)
-    prefix_header = config.project_pods_root + target.prefix_header_filename
-    prefix_header.open('a') do |file|
-      file.puts(%{#ifdef __OBJC__\n#define MR_SHORTHAND\n#import "CoreData+MagicalRecord.h"\n#endif})
-    end
-  end
 end

--- a/MagicalRecord/2.0.4/MagicalRecord.podspec
+++ b/MagicalRecord/2.0.4/MagicalRecord.podspec
@@ -5,15 +5,8 @@ Pod::Spec.new do |s|
   s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1!.'
   s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
-  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => '2.0.4' }
+  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'
-
-  def s.post_install(target)
-    prefix_header = config.project_pods_root + target.prefix_header_filename
-    prefix_header.open('a') do |file|
-      file.puts(%{#ifdef __OBJC__\n#define MR_SHORTHAND\n#import "CoreData+MagicalRecord.h"\n#endif})
-    end
-  end
 end

--- a/MagicalRecord/2.0.7/MagicalRecord.podspec
+++ b/MagicalRecord/2.0.7/MagicalRecord.podspec
@@ -5,16 +5,9 @@ Pod::Spec.new do |s|
   s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1!.'
   s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
-  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => '2.0.7' }
+  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'
   s.requires_arc = true
-
-  def s.post_install(target)
-    prefix_header = config.project_pods_root + target.prefix_header_filename
-    prefix_header.open('a') do |file|
-      file.puts(%{#ifdef __OBJC__\n#define MR_SHORTHAND\n#import "CoreData+MagicalRecord.h"\n#endif})
-    end
-  end
 end

--- a/MagicalRecord/2.0.8/MagicalRecord.podspec
+++ b/MagicalRecord/2.0.8/MagicalRecord.podspec
@@ -5,15 +5,9 @@ Pod::Spec.new do |s|
   s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1!.'
   s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
-  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => '2.0.8' }
+  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'
   s.requires_arc = true
-  s.prefix_header_contents = <<-EOS
-#ifdef __OBJC__
-#define MR_SHORTHAND
-#import "CoreData+MagicalRecord.h"
-#endif
-EOS
 end

--- a/MagicalRecord/2.0/MagicalRecord.podspec
+++ b/MagicalRecord/2.0/MagicalRecord.podspec
@@ -5,16 +5,9 @@ Pod::Spec.new do |s|
   s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1!.'
   s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
-  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => '2.0' }
+  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'
   s.requires_arc = true
-
-  def s.post_install(target)
-    prefix_header = config.project_pods_root + target.prefix_header_filename
-    prefix_header.open('a') do |file|
-      file.puts(%{#ifdef __OBJC__\n#define MR_SHORTHAND\n#import "CoreData+MagicalRecord.h"\n#endif})
-    end
-  end
 end

--- a/MagicalRecord/2.1/MagicalRecord.podspec
+++ b/MagicalRecord/2.1/MagicalRecord.podspec
@@ -5,15 +5,9 @@ Pod::Spec.new do |s|
   s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1!.'
   s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
-  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git',:branch=>'develop', :tag => '2.1' }
+  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'
   s.requires_arc = true
-  s.prefix_header_contents = <<-EOS
-#ifdef __OBJC__
-#define MR_SHORTHAND
-#import "CoreData+MagicalRecord.h"
-#endif
-EOS
 end

--- a/MagicalRecord/2.2/MagicalRecord.podspec
+++ b/MagicalRecord/2.2/MagicalRecord.podspec
@@ -5,15 +5,9 @@ Pod::Spec.new do |s|
   s.summary  = 'Super Awesome Easy Fetching for Core Data 1!!!11!!!!1!.'
   s.homepage = 'http://github.com/magicalpanda/MagicalRecord'
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
-  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git',:branch=>'develop', :tag => '2.2' }
+  s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'
   s.requires_arc = true
-  s.prefix_header_contents = <<-EOS
-#ifdef __OBJC__
-#define MR_SHORTHAND
-#import "CoreData+MagicalRecord.h"
-#endif
-EOS
 end


### PR DESCRIPTION
Update MagicalRecord pod specs to dynamically determine the version. Also remove additions to prefix header — importing the header this way is not what the MagicalRecord team recommends, and `MR_SHORTHAND` shouldn't be enabled by default.
