### PR TITLE
[Update] Add "MagicalRecord/Core" and "MagicalRecord/Shorthand" subspecs

### DIFF
--- a/MagicalRecord/1.7.1/MagicalRecord.podspec
+++ b/MagicalRecord/1.7.1/MagicalRecord.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |s|
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'Source/**/*.{h,m}'
   s.framework = 'CoreData'
-  s.requires_arc = true
+  s.requires_arc = false
   s.prefix_header_contents = '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
 end

--- a/MagicalRecord/1.7.1/MagicalRecord.podspec
+++ b/MagicalRecord/1.7.1/MagicalRecord.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'Source/**/*.{h,m}'
-  s.framework    = 'CoreData'
+  s.framework = 'CoreData'
   s.requires_arc = true
   s.prefix_header_contents = '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
 end

--- a/MagicalRecord/1.8.3/MagicalRecord.podspec
+++ b/MagicalRecord/1.8.3/MagicalRecord.podspec
@@ -8,7 +8,8 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'Source/**/*.{h,m}'
-  s.framework    = 'CoreData'
+  s.framework = 'CoreData'
+  s.requires_arc = true
   s.prefix_header_contents = '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
 end
 

--- a/MagicalRecord/1.8.3/MagicalRecord.podspec
+++ b/MagicalRecord/1.8.3/MagicalRecord.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
   s.source_files = 'Source/**/*.{h,m}'
   s.framework = 'CoreData'
-  s.requires_arc = true
+  s.requires_arc = false
   s.prefix_header_contents = '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
 end
 

--- a/MagicalRecord/2.0.3/MagicalRecord.podspec
+++ b/MagicalRecord/2.0.3/MagicalRecord.podspec
@@ -7,8 +7,17 @@ Pod::Spec.new do |s|
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
   s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
-  s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'
   s.requires_arc = true
-  s.prefix_header_contents = '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  s.default_subspec = 'Core'
+
+  s.subspec "Core" do |sp|
+    sp.source_files = 'MagicalRecord/**/*.{h,m}'
+    sp.prefix_header_contents = '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  end
+
+  s.subspec "Shorthand" do |sp|
+    sp.source_files = 'MagicalRecord/**/*.{h,m}'
+    sp.prefix_header_contents = '#define MR_SHORTHAND 0', '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  end
 end

--- a/MagicalRecord/2.0.4/MagicalRecord.podspec
+++ b/MagicalRecord/2.0.4/MagicalRecord.podspec
@@ -7,7 +7,17 @@ Pod::Spec.new do |s|
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
   s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
-  s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'
-  s.prefix_header_contents = '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  s.requires_arc = true
+  s.default_subspec = 'Core'
+
+  s.subspec "Core" do |sp|
+    sp.source_files = 'MagicalRecord/**/*.{h,m}'
+    sp.prefix_header_contents = '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  end
+
+  s.subspec "Shorthand" do |sp|
+    sp.source_files = 'MagicalRecord/**/*.{h,m}'
+    sp.prefix_header_contents = '#define MR_SHORTHAND 0', '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  end
 end

--- a/MagicalRecord/2.0.7/MagicalRecord.podspec
+++ b/MagicalRecord/2.0.7/MagicalRecord.podspec
@@ -7,8 +7,17 @@ Pod::Spec.new do |s|
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
   s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
-  s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'
   s.requires_arc = true
-  s.prefix_header_contents = '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  s.default_subspec = 'Core'
+
+  s.subspec "Core" do |sp|
+    sp.source_files = 'MagicalRecord/**/*.{h,m}'
+    sp.prefix_header_contents = '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  end
+
+  s.subspec "Shorthand" do |sp|
+    sp.source_files = 'MagicalRecord/**/*.{h,m}'
+    sp.prefix_header_contents = '#define MR_SHORTHAND 0', '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  end
 end

--- a/MagicalRecord/2.0.8/MagicalRecord.podspec
+++ b/MagicalRecord/2.0.8/MagicalRecord.podspec
@@ -7,8 +7,17 @@ Pod::Spec.new do |s|
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
   s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
-  s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'
   s.requires_arc = true
-  s.prefix_header_contents = '#import "CoreData+MagicalRecord.h"'
+  s.default_subspec = 'Core'
+
+  s.subspec "Core" do |sp|
+    sp.source_files = 'MagicalRecord/**/*.{h,m}'
+    sp.prefix_header_contents = '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  end
+
+  s.subspec "Shorthand" do |sp|
+    sp.source_files = 'MagicalRecord/**/*.{h,m}'
+    sp.prefix_header_contents = '#define MR_SHORTHAND 0', '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  end
 end

--- a/MagicalRecord/2.0/MagicalRecord.podspec
+++ b/MagicalRecord/2.0/MagicalRecord.podspec
@@ -7,8 +7,17 @@ Pod::Spec.new do |s|
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
   s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
-  s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'
   s.requires_arc = true
-  s.prefix_header_contents = '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  s.default_subspec = 'Core'
+
+  s.subspec "Core" do |sp|
+    sp.source_files = 'MagicalRecord/**/*.{h,m}'
+    sp.prefix_header_contents = '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  end
+
+  s.subspec "Shorthand" do |sp|
+    sp.source_files = 'MagicalRecord/**/*.{h,m}'
+    sp.prefix_header_contents = '#define MR_SHORTHAND 0', '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  end
 end

--- a/MagicalRecord/2.1/MagicalRecord.podspec
+++ b/MagicalRecord/2.1/MagicalRecord.podspec
@@ -7,8 +7,17 @@ Pod::Spec.new do |s|
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
   s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
-  s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'
   s.requires_arc = true
-  s.prefix_header_contents = '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  s.default_subspec = 'Core'
+
+  s.subspec "Core" do |sp|
+    sp.source_files = 'MagicalRecord/**/*.{h,m}'
+    sp.prefix_header_contents = '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  end
+
+  s.subspec "Shorthand" do |sp|
+    sp.source_files = 'MagicalRecord/**/*.{h,m}'
+    sp.prefix_header_contents = '#define MR_SHORTHAND 0', '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  end
 end

--- a/MagicalRecord/2.2/MagicalRecord.podspec
+++ b/MagicalRecord/2.2/MagicalRecord.podspec
@@ -7,8 +7,17 @@ Pod::Spec.new do |s|
   s.author   = { 'Saul Mora' => 'saul@magicalpanda.com' }
   s.source   = { :git => 'https://github.com/magicalpanda/MagicalRecord.git', :tag => "#{s.version}" }
   s.description  = 'Handy fetching, threading and data import helpers to make Core Data a little easier to use.'
-  s.source_files = 'MagicalRecord/**/*.{h,m}'
   s.framework    = 'CoreData'
   s.requires_arc = true
-  s.prefix_header_contents = '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  s.default_subspec = 'Core'
+
+  s.subspec "Core" do |sp|
+    sp.source_files = 'MagicalRecord/**/*.{h,m}'
+    sp.prefix_header_contents = '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  end
+
+  s.subspec "Shorthand" do |sp|
+    sp.source_files = 'MagicalRecord/**/*.{h,m}'
+    sp.prefix_header_contents = '#define MR_SHORTHAND 0', '#import <CoreData/CoreData.h>', '#import "CoreData+MagicalRecord.h"'
+  end
 end


### PR DESCRIPTION
User needed MR_SHORTHAND enabled should use "MagicalRecord/Shorthand" instead.

Discussion: https://github.com/CocoaPods/Specs/commit/9e7d7aa808ed19c4e6ea1e9647cd2a7668560886#commitcomment-5290889
