### PR TITLE
Add NUI 0.5.2

### DIFF
--- a/NUI/0.5.2/NUI.podspec
+++ b/NUI/0.5.2/NUI.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name         = "NUI"
+  s.version      = "0.5.2"
+  s.summary      = "Style iOS apps with a stylesheet, similar to CSS."
+  s.description  = "NUI is a drop-in UI kit for iOS that lets you style UI elements using a stylesheet, similar to CSS. It lets you style an entire app in minutes."
+  s.homepage     = "https://github.com/tombenner/nui"
+  s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }
+  s.author       = { "Tom Benner" => "tombenner@gmail.com" }
+  s.source       = { :git => "https://github.com/tombenner/nui.git", :tag => "v0.5.2" }
+  s.platform     = :ios, '5.1'
+
+  s.source_files = 'NUI', 'NUI/**/*.{h,m}'
+  s.resources    = "NUI/Resources/*.png", "NUI/**/*.nss"
+  s.requires_arc = true
+  s.frameworks   = [ "UIKit", "CoreGraphics","QuartzCore", "CoreImage" ]
+  
+  s.dependency 'CoreParse'
+end


### PR DESCRIPTION
Also, unless I'm missing something, I'm not able to push to CocoaPods/Specs like I use to be able to. I used to do a `git push`, but that fails now, and I see that the `Specs` Github team (which I belong to) only has read access.

When I try `pod push master NUI.podspec` and enter my credentials, I get the following:

```
error: The requested URL returned error: 403 while accessing https://github.com/CocoaPods/Specs.git/info/refs?service=git-receive-pack
fatal: HTTP request failed
```

Can someone help me with this? Thanks!
