### PR TITLE
Releasing AeroGear iOS Crypto

### DIFF
--- a/AeroGear-Crypto/0.2.0/AeroGear-Crypto.podspec
+++ b/AeroGear-Crypto/0.2.0/AeroGear-Crypto.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name         = "AeroGear-Crypto"
+  s.version      = "0.2.0"
+  s.summary      = "Provides encryption utilities."
+  s.homepage     = "https://github.com/aerogear/aerogear-crypto-ios"
+  s.license      = 'Apache License, Version 2.0'
+  s.author       = "Red Hat, Inc."
+  s.source       = { :git => 'https://github.com/aerogear/aerogear-crypto-ios.git', :tag => '0.2.0' }
+  s.platform     = :ios, 7.0
+  s.source_files = 'crypto-sdk/**/*.{h,m}'
+  s.public_header_files = 'crypto-sdk/AeroGearCrypto.h', 'crypto-sdk/AGPBKDF2.h', 'crypto-sdk/AGRandomGenerator.h', 'crypto-sdk/AGSecretBox.h', 'crypto-sdk/AGCryptoBox.h', 'crypto-sdk/AGHash.h', 'crypto-sdk/AGSigningKey.h', 'crypto-sdk/AGVerifyKey.h', 'crypto-sdk/AGVerifyKey.h'
+  s.requires_arc = true
+  s.dependency 'libsodium-ios', '~> 0.4.5'
+end


### PR DESCRIPTION
Good morning guys, I used to push the Specs repository but now looks like I don't have the rights anymore. Running _pod lint_ everything seems to be correct

```
~/h/o/S/A/0.2.0 git:master ❯❯❯ pod spec lint                                                                                                        ⬆

 -> AeroGear-Crypto (0.2.0)
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_stream/aes256estream/hongjun/aes256-ctr.c:199:57: warning: implicit conversion loses integer precision: 'unsigned long long' to 'u32' (aka 'unsigned int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_stream/aes256estream/hongjun/aes256-ctr.c:212:62: warning: implicit conversion loses integer precision: 'unsigned long long' to 'u32' (aka 'unsigned int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c:977:15: warning: implicit conversion loses integer precision: 'unsigned long long' to 'int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c:979:15: warning: implicit conversion loses integer precision: 'unsigned long long' to 'int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c:982:15: warning: implicit conversion loses integer precision: 'unsigned long long' to 'int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c:1022:15: warning: implicit conversion loses integer precision: 'unsigned long long' to 'int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c:1024:15: warning: implicit conversion loses integer precision: 'unsigned long long' to 'int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c:1025:15: warning: implicit conversion loses integer precision: 'unsigned long long' to 'int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c:1028:15: warning: implicit conversion loses integer precision: 'unsigned long long' to 'int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c:1076:15: warning: implicit conversion loses integer precision: 'unsigned long long' to 'int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c:1079:16: warning: implicit conversion loses integer precision: 'unsigned long long' to 'int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c:1080:16: warning: implicit conversion loses integer precision: 'unsigned long long' to 'int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c:1083:16: warning: implicit conversion loses integer precision: 'unsigned long long' to 'int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c:1129:16: warning: implicit conversion loses integer precision: 'unsigned long long' to 'int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c:1132:16: warning: implicit conversion loses integer precision: 'unsigned long long' to 'int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c:1136:16: warning: implicit conversion loses integer precision: 'unsigned long long' to 'int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/donna/auth_poly1305_donna.c:132:22: warning: implicit conversion loses integer precision: 'uint64_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/donna/auth_poly1305_donna.c:133:22: warning: implicit conversion loses integer precision: 'uint64_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/donna/auth_poly1305_donna.c:134:22: warning: implicit conversion loses integer precision: 'uint64_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_onetimeauth/poly1305/donna/auth_poly1305_donna.c:135:22: warning: implicit conversion loses integer precision: 'uint64_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_frombytes.c:63:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_frombytes.c:64:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_frombytes.c:65:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_frombytes.c:66:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_frombytes.c:67:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_frombytes.c:68:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_frombytes.c:69:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_frombytes.c:70:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_frombytes.c:71:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_frombytes.c:72:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_mul.c:243:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_mul.c:244:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_mul.c:245:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_mul.c:246:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_mul.c:247:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_mul.c:248:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_mul.c:249:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_mul.c:250:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_mul.c:251:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_mul.c:252:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq.c:139:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq.c:140:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq.c:141:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq.c:142:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq.c:143:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq.c:144:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq.c:145:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq.c:146:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq.c:147:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq.c:148:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq2.c:150:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq2.c:151:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq2.c:152:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq2.c:153:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq2.c:154:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq2.c:155:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq2.c:156:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq2.c:157:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq2.c:158:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/crypto_sign/ed25519/ref10/fe_sq2.c:159:10: warning: implicit conversion loses integer precision: 'crypto_int64' (aka 'long long') to 'crypto_int32' (aka 'int') [-Wshorten-64-to-32]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/randombytes/salsa20/randombytes_salsa20_random.c:271:17: warning: comparison of constant 18446744073709551615 with expression of type 'const size_t' (aka 'const unsigned long') is always true [-Wtautological-constant-out-of-range-compare]
    - NOTE  | [xcodebuild]  libsodium-ios/src/libsodium/randombytes/sysrandom/randombytes_sysrandom.c:162:17: warning: comparison of constant 18446744073709551615 with expression of type 'const size_t' (aka 'const unsigned long') is always true [-Wtautological-constant-out-of-range-compare]
    - NOTE  | [xcodebuild]  AeroGear-Crypto/crypto-sdk/AGCryptoBox.m:44:9: warning: unused variable 'status' [-Wunused-variable]
    - NOTE  | [xcodebuild]  AeroGear-Crypto/crypto-sdk/AGCryptoBox.m:65:9: warning: unused variable 'status' [-Wunused-variable]
    - NOTE  | [xcodebuild]  AeroGear-Crypto/crypto-sdk/AGSigningKey.m:37:13: warning: unused variable 'status' [-Wunused-variable]
    - NOTE  | [xcodebuild]  AeroGear-Crypto/crypto-sdk/AGSigningKey.m:54:9: warning: unused variable 'status' [-Wunused-variable]

Analyzed 1 podspec.

AeroGear-Crypto.podspec passed validation.
```
