### PR TITLE
Alias syntax error for Geos podspec

### DIFF
--- a/geos/3.4.2/geos.podspec
+++ b/geos/3.4.2/geos.podspec
@@ -17,12 +17,12 @@ Pod::Spec.new do |s|
 
   s.prepare_command = <<-CMD
 
-    type -P autoconf &>/dev/null || alias autoconf 'xcrun autoconf'
-    type -P autoheader &>/dev/null || alias autoheader 'xcrun autoheader'
-    type -P aclocal &>/dev/null || alias aclocal 'xcrun aclocal'
-    type -P automake &>/dev/null || alias automake 'xcrun automake'
-    type -P glibtool &>/dev/null || alias glibtool 'xcrun glibtool'
-    type -P glibtoolize &>/dev/null || alias glibtoolize 'xcrun glibtoolize'
+    type -P autoconf &>/dev/null || alias autoconf='xcrun autoconf'
+    type -P autoheader &>/dev/null || alias autoheader='xcrun autoheader'
+    type -P aclocal &>/dev/null || alias aclocal='xcrun aclocal'
+    type -P automake &>/dev/null || alias automake='xcrun automake'
+    type -P glibtool &>/dev/null || alias glibtool='xcrun glibtool'
+    type -P glibtoolize &>/dev/null || alias glibtoolize='xcrun glibtoolize'
 
     sh autogen.sh
     ./configure


### PR DESCRIPTION
Small syntax error for "alias" command, used a space instead of an equals sign.
See also https://github.com/andreacremaschi/SpatialDBKit/issues/9
