### PR TITLE
Adding podspec for AdBrixSDK 3.1.1

### DIFF
--- a/AdBrixSDK/3.1.1/AdBrixSDK.podspec
+++ b/AdBrixSDK/3.1.1/AdBrixSDK.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+  s.name         = "AdBrixSDK"
+  s.version      = "3.1.1"
+  s.summary      = "AdBrix SDK"
+  s.homepage     = "https://github.com/igaworks/AdBrixSDK-iOS"
+
+  s.license      = {
+    :type => 'Commercial',
+    :text => <<-LICENSE
+              All text and design is copyright 2006-2014 igaworks, Inc.
+
+              All rights reserved.
+
+              https://github.com/igaworks/AdBrixSDK-iOS
+    LICENSE
+  }
+
+  s.platform = :ios, '5.1.1'
+  s.author       = { "wonje,song" => "wonje@igaworks.com" }
+  s.source       = { :git => "https://github.com/igaworks/AdBrixSDK-iOS.git", :tag => "v#{s.version}" }
+  s.resources = "SDKResources.bundle"
+  s.ios.vendored_frameworks = 'AdBrixSDK.framework'
+  s.frameworks = 'UIKit', 'SystemConfiguration', 'CoreData', 'CoreTelephony'
+end

--- a/AdBrixSDK/3.1.1/AdBrixSDK.podspec
+++ b/AdBrixSDK/3.1.1/AdBrixSDK.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.platform = :ios, '5.1.1'
   s.author       = { "wonje,song" => "wonje@igaworks.com" }
-  s.source       = { :git => "https://github.com/igaworks/AdBrixSDK-iOS.git", :tag => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/igaworks/AdBrixSDK-iOS.git", :tag => "#{s.version}" }
   s.resources = "SDKResources.bundle"
   s.ios.vendored_frameworks = 'AdBrixSDK.framework'
   s.frameworks = 'UIKit', 'SystemConfiguration', 'CoreData', 'CoreTelephony'


### PR DESCRIPTION
(void)setAppleAdvertisingIdentifier:isAppleAdvertisingTrackingEnabled: 추가
광고 목적이 아닌 경우, Apple AdvertisingIdentifier를 사용하면, app reject 사유가 되기 때문에, iAd(AdSupport.framework)를 사용하지 않는다면 값을 전송하지 않는다.
AdBrix에서는 전달받은 Apple AdvertisingIdentifier 값이 없는경우, identifierForVendor 값을 identifier로 사용한다.
