### PR TITLE
libextobjc 0.3.1-beta20140207 - remove experimental / broken features (just like post 0.3 upstream already did)

### DIFF
--- a/libextobjc/0.3.1-beta20140207/libextobjc.podspec
+++ b/libextobjc/0.3.1-beta20140207/libextobjc.podspec
@@ -1,0 +1,80 @@
+#### Note to future updaters of this podspec
+# 20140207
+# ---
+# * If you use this as the base for the next version, then return the git source to
+#   jspahrsummers canonical repo.
+# * This version is a snapshot after jspahrsummers removed experimental features in
+# * If someone requires broken or experimental featurse, there is a 'experimental'
+#   branch, which can be (somewhat manually) switched to
+#
+# General
+# ---
+# * Always refer to extobjc/extobjc.h and add (or remove!) items from subspecs_names
+#   below -- this is the list of "supported features"
+
+Pod::Spec.new do |s|
+  s.name         = "libextobjc"
+  s.version      = "0.3.1-beta20140207"
+  s.summary      = "A Cocoa library to extend the Objective-C programming language."
+  s.homepage     = "https://github.com/jspahrsummers/libextobjc"
+  s.author       = { "Justin Spahr-Summers" => "jspahrsummers@github.com" }
+  #s.source       = { :git => "https://github.com/jspahrsummers/libextobjc.git", :tag => s.version }
+  s.source       = { :git => "https://github.com/greymouser/libextobjc.git", :tag => "#{s.version}" }
+  s.requires_arc = true
+
+  # Provided as a convenience but not requiring all the subspecs because it would be redundant
+  s.subspec 'UmbrellaHeader' do |sp|
+    sp.source_files = "extobjc/extobjc.h"
+  end
+
+  s.subspec 'RuntimeExtensions' do |sp|
+    sp.source_files = "extobjc/metamacros.h", "extobjc/EXTRuntimeExtensions.{h,m}"
+  end
+
+  # List obtained from extobjc/extobjc.h
+  subspecs_names = %w[
+    EXTADT
+    EXTConcreteProtocol
+    EXTKeyPathCoding
+    EXTNil
+    EXTSafeCategory
+    EXTScope
+    EXTSelectorChecking
+    EXTSynthesize
+    NSInvocation+EXT
+    NSMethodSignature+EXT ]
+
+  # Example inclusion of pod dependencies on a specific subspec / feature
+  subspec_dependencies = {
+  #    'exampleFeatureFromSubspecsNames' => ['libexample']
+  }
+
+  subspecs_names.each do |name|
+    s.subspec name do |sp|
+      sp.source_files = "extobjc/#{name}.{h,m}"
+      sp.dependency 'libextobjc/RuntimeExtensions'
+      deps = subspec_dependencies[name] || []
+      deps.each do |dep|
+        sp.dependency dep
+      end
+    end
+  end
+
+  s.description  = <<-DESC
+                    The Extended Objective-C library extends the dynamism of the Objective-C programming language to support additional patterns present in other dynamic programming languages (including those that are not necessarily object-oriented).
+
+                    libextobjc is meant to be very modular – most of its classes and modules can be used with no more than one or two dependencies.
+                    
+                    NOTE: This tagged 'beta' spec is from a known good version of the upstream repo which has removed all experimental functionality (some of which is known not to work on iOS7 / 64-bit).
+                   DESC
+  s.license      = { :type => 'MIT', :text => <<-LICENSE
+                      Copyright (c) 2012 Justin Spahr-Summers
+
+                      Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+                      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+                      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+                    LICENSE
+                    }
+end

--- a/libextobjc/0.3.1-beta20140207/libextobjc.podspec
+++ b/libextobjc/0.3.1-beta20140207/libextobjc.podspec
@@ -4,8 +4,8 @@
 # * If you use this as the base for the next version, then return the git source to
 #   jspahrsummers canonical repo.
 # * This version is a snapshot after jspahrsummers removed experimental features in
-# * If someone requires broken or experimental featurse, there is a 'experimental'
-#   branch, which can be (somewhat manually) switched to
+# * If someone requires broken or experimental features, there is an 'experimental'
+#   branch, which can be switched to manually in the normal podfile specific way
 #
 # General
 # ---
@@ -18,8 +18,8 @@ Pod::Spec.new do |s|
   s.summary      = "A Cocoa library to extend the Objective-C programming language."
   s.homepage     = "https://github.com/jspahrsummers/libextobjc"
   s.author       = { "Justin Spahr-Summers" => "jspahrsummers@github.com" }
-  #s.source       = { :git => "https://github.com/jspahrsummers/libextobjc.git", :tag => s.version }
-  s.source       = { :git => "https://github.com/greymouser/libextobjc.git", :tag => "#{s.version}" }
+  #s.source       = { :git => "https://github.com/jspahrsummers/libextobjc.git", :tag => s.version.to_s }
+  s.source       = { :git => "https://github.com/greymouser/libextobjc.git", :tag => s.version.to_s }
   s.requires_arc = true
 
   # Provided as a convenience but not requiring all the subspecs because it would be redundant


### PR DESCRIPTION
- Tagged version of upstream repo
- Upstream dev removed experimental and broken features from post 0.3 that do not work in various configurations (e.g. arm64).
- Basically, the previous podspec is a non-starter on any modern iOS7 dev that tries to compile with 64 bit support, and mainly because of the dependency on libffi ... which was only needed for an experimental feature, which upstream removed from master, and moved all experiments to another branch. This new spec simply acts as a holdover until upstream decides to tag another version.
