### PR TITLE
Update Mailcheck-ObjectiveC to Version 0.2

### DIFF
--- a/Mailcheck-ObjectiveC/0.2/Mailcheck-ObjectiveC.podspec
+++ b/Mailcheck-ObjectiveC/0.2/Mailcheck-ObjectiveC.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name         = "Mailcheck-ObjectiveC"
+  s.version      = "0.2"
+  s.summary      = "An Objective-C port of Kicksend's Mailcheck. Suggest corrections for misspelled email addresses."
+  s.homepage     = "https://github.com/dkasper/Mailcheck-ObjectiveC"
+
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+
+  s.author       = { "David Kasper" => "dkasper@gmail.com" }
+  s.source       = { :git => "https://github.com/dkasper/Mailcheck-ObjectiveC.git", :tag => "0.2" }
+
+  s.platform     = :ios, '6.0'
+
+  s.source_files = 'Mailcheck/*.{h,m}'
+
+  s.requires_arc = true
+
+  s.dependency     'NSString-Email'
+end


### PR DESCRIPTION
Adds dependency on NSString-Email
