### PR TITLE
[Update] REFormattedNumberField (1.1.2)

### DIFF
--- a/REFormattedNumberField/1.1.2/REFormattedNumberField.podspec
+++ b/REFormattedNumberField/1.1.2/REFormattedNumberField.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name        = 'REFormattedNumberField'
+  s.version     = '1.1.2'
+  s.authors     = { 'Roman Efimov' => 'romefimov@gmail.com' }
+  s.homepage    = 'https://github.com/romaonthego/REFormattedNumberField'
+  s.summary     = 'UITextField subclass that allows number input in a predefined format.'
+  s.source      = { :git => 'https://github.com/romaonthego/REFormattedNumberField.git',
+                    :tag => '1.1.2' }
+  s.license     = { :type => "MIT", :file => "LICENSE" }
+
+  s.platform = :ios, '5.0'
+  s.requires_arc = true
+  s.source_files = 'REFormattedNumberField'
+  s.public_header_files = 'REFormattedNumberField/*.h'
+
+  s.ios.deployment_target = '5.0'
+end


### PR DESCRIPTION
Could you please give me the write access again? It's been gone since the corruption of the Specs repo. It was so convenient to push specs with `$ pod push master`. Thanks!
