### PR TITLE
Added OCInject v0.3.0.

### DIFF
--- a/OCInject/0.3.0/OCInject.podspec
+++ b/OCInject/0.3.0/OCInject.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name         = "OCInject"
+  s.version      = "0.3.0"
+  s.summary      = "Objective-C dependency injection framework"
+  s.homepage     = "https://github.com/ivan-korobkov/OCInject"
+  s.license      = 'Apache License 2.0'
+
+  s.author       = { "Ivan Korobkov" => "ivan.korobkov@gmail.com" }
+  s.source       = { :git => "https://github.com/ivan-korobkov/OCInject.git", :tag => "v0.3.0" }
+  s.requires_arc = true
+
+  s.ios.deployment_target = '6.0'
+  s.osx.deployment_target = '10.8'
+
+  s.source_files  = 'Source/*.{h,m}'
+end
+


### PR DESCRIPTION
OCInject is a fast and simple dependency injection framework which does not steal constructors from  developers.
- Fast and small.
- Really easy to use.
- Does not steal `[[Class alloc]initWithSomeArgs]` from you.
- Does not manage your application object graph.
- Injects dependencies everywhere via `OCInject(Class)` and `OCInjectProtocol(protocol)` functions.
- Provides an optional category method `[NSObject inject]` equivalent to `OCInject(class)`.
- Requires almost zero configuration because of runtime bindings.
- Transparently integrates into tests/mocks.
