### PR TITLE
[Update] ALAssetsLibrary-CustomPhotoAlbum (1.1.5)

### DIFF
--- a/ALAssetsLibrary-CustomPhotoAlbum/1.1.5/ALAssetsLibrary-CustomPhotoAlbum.podspec
+++ b/ALAssetsLibrary-CustomPhotoAlbum/1.1.5/ALAssetsLibrary-CustomPhotoAlbum.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "ALAssetsLibrary-CustomPhotoAlbum"
+  s.version      = "1.1.5"
+  s.summary      = "A nice ALAssetsLibrary category for saving images & videos into custom photo album."
+  s.homepage     = "https://github.com/Kjuly/ALAssetsLibrary-CustomPhotoAlbum"
+  s.license      = 'MIT'
+  s.authors      = { "Marin Todorov" => "touch-code-magazine@underplot.com", "Kjuly" => "dev@kjuly.com" }
+  s.source       = { :git => "https://github.com/Kjuly/ALAssetsLibrary-CustomPhotoAlbum.git", :tag => "1.1.5" }
+  s.platform     = :ios, '5.0'
+  s.source_files = 'ALAssetsLibrary-CustomPhotoAlbum/*.{h,m}'
+  s.frameworks   = 'AssetsLibrary'
+  s.requires_arc = true
+end


### PR DESCRIPTION
  Rename |-loadPhotosFromAlbum:| to |-loadImagesFromAlbum:completion:|
    with a completion block to use the |images| array.
