### PR TITLE
Bump YOLOKit to v5

### DIFF
--- a/YOLOKit/5/YOLOKit.podspec
+++ b/YOLOKit/5/YOLOKit.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name         = "YOLOKit"
+  s.version      = "5"
+  s.source       = { :git => 'https://github.com/mxcl/YOLOKit.git', :tag => "5" }
+  s.requires_arc = true
+  s.source_files = '*.m', 'YOLO.h'
+  s.summary      = 'A delightful library for enumerating Foundation objects.'
+  s.description  = <<-DESC
+                   You only live once: enumerating arrays, dictionaries and
+                   strings should be easy, powerful and delightful.
+                   
+                   Friends don’t let friends use 1983 design patterns.
+                   
+                   From the creator of Homebrew.
+                   DESC
+  s.homepage     = 'https://github.com/mxcl/YOLOKit'
+  s.frameworks   = 'Foundation'
+  s.author       = { 'Max Howell' => 'mxcl@me.com' }
+  s.license      = { :type => 'Public Domain', :file => 'README.markdown' }
+end


### PR DESCRIPTION
Replaces underscore style methods with CamelCase.

Everything else is CamelCase on this platform. I’m not sure what I was thinking.

Apologies for the rapid pull requests.
