### PR TITLE
Remove 7.0 version requirement for ProximityKit

### DIFF
--- a/ProximityKit/0.2.3/ProximityKit.podspec
+++ b/ProximityKit/0.2.3/ProximityKit.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.homepage            = "http://proximitykit.com/"
   s.license             = { :type => 'Commercial', :text => 'See http://radiusnetworks.com/terms_of_service.html' }
   s.author              = { "Radius Networks" => "support@radiusnetworks.com" }
-  s.platform            = :ios, '7.0'
+  s.platform            = :ios
   s.source              = { :http => "http://s3.proximitykit.com/ProximityKit-v0.2.3.zip" }
   s.preserve_paths      = 'ProximityKit.framework'
   s.source_files        = 'ProximityKit.framework/**/*.h'

--- a/ProximityKit/0.2.6/ProximityKit.podspec
+++ b/ProximityKit/0.2.6/ProximityKit.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.homepage            = "http://proximitykit.com/"
   s.license             = { :type => 'Commercial', :text => 'See http://radiusnetworks.com/terms_of_service.html' }
   s.author              = { "Radius Networks" => "support@radiusnetworks.com" }
-  s.platform            = :ios, '7.0'
+  s.platform            = :ios
   s.source              = { :http => "http://s3.proximitykit.com/ProximityKit-v0.2.6.zip" }
   s.preserve_paths      = 'ProximityKit.framework'
   s.source_files        = 'ProximityKit.framework/**/*.h'


### PR DESCRIPTION
Not all the features are available pre-iOS 7, but there is no need to
restrict the target platform in the podspec.
