### PR TITLE
Bump TransformerKit to upstream version 0.3.1

### DIFF
--- a/TransformerKit/0.3.1/TransformerKit.podspec
+++ b/TransformerKit/0.3.1/TransformerKit.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name     = 'TransformerKit'
+  s.version  = '0.3.1'
+  s.license  = 'MIT'
+  s.summary  = 'A block-based API for NSValueTransformer, with a growing collection of useful examples.'
+  s.homepage = 'https://github.com/mattt/TransformerKit'
+  s.authors  = { 'Mattt Thompson' => 'm@mattt.me' }
+  s.source   = { :git => 'https://github.com/mattt/TransformerKit.git', :tag => s.version.to_s }
+  s.source_files = 'TransformerKit'
+  s.requires_arc = true
+end


### PR DESCRIPTION
# Bump TransformerKit to upstream version 0.3.1.
- Fixed a minor redundancy in the version to tag line so that the current version only needs to be set in one spot.
