### PR TITLE
Updated JKSegueActionViewController 1.0.2

### DIFF
--- a/JKSegueActionViewController/1.0.2/JKSegueActionViewController.podspec
+++ b/JKSegueActionViewController/1.0.2/JKSegueActionViewController.podspec
@@ -16,5 +16,4 @@ Pod::Spec.new do |s|
   }
   s.platform     = :ios
   s.source_files = 'JKSegueActionViewController/*.{h,m}'
-  s.documentation = { :appledoc => ['--no-repeat-first-par'] }
 end


### PR DESCRIPTION
Removed deprecated documentation from the JKSegueActionViewController spec.
