### PR TITLE
[Fix] AdMobHelper (6.4.0)

### DIFF
--- a/AdMobHelper/6.4.0/AdMobHelper.podspec
+++ b/AdMobHelper/6.4.0/AdMobHelper.podspec
@@ -8,5 +8,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/youknowone/AdMobHelper.git", :tag => "6.4.0" }
   s.platform     = :ios
   s.source_files = '*.{h,m}'
-  s.dependency 'AdMob'
+  s.dependency 'Google-Mobile-Ads-SDK'
 end


### PR DESCRIPTION
Rename AdMob -> Google-Mobile-Ads-SDK

And I hope names of existing pods will not be changed :)
