### PR TITLE
Improved Objective-LevelDB podspec

### DIFF
--- a/Objective-LevelDB/2.0.5/Objective-LevelDB.podspec
+++ b/Objective-LevelDB/2.0.5/Objective-LevelDB.podspec
@@ -21,7 +21,8 @@ Pod::Spec.new do |s|
       'CC'  => 'clang',
       'CXX' => 'clang++',
       'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/Objective-LevelDB/leveldb-library"',
-      'GCC_PREPROCESSOR_DEFINITIONS' => 'LEVELDB_PLATFORM_POSIX=1 OS_MACOSX=1'
+      'GCC_PREPROCESSOR_DEFINITIONS' => 'LEVELDB_PLATFORM_POSIX=1 OS_MACOSX=1',
+      'OTHER_LDFLAGS' => '-lc++'
     }
   end
   


### PR DESCRIPTION
OTHER_LDFLAGS was set to `-lc++` so users of this library don't have to manually link against libc++.
