### PR TITLE
add framework dependency to podspec

### DIFF
--- a/MagicPie/1.0.0/MagicPie.podspec
+++ b/MagicPie/1.0.0/MagicPie.podspec
@@ -9,4 +9,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/Sk0rpion/MagicPie.git", :tag => "1.0.0" }
   s.source_files  = 'MagicPieLayer', 'MagicPieLayer/**/*.{h,m}'
   s.requires_arc = true
+  s.framework   = 'QuartzCore', 'CoreGraphics'
 end


### PR DESCRIPTION
add framework dependency to MagicPie's podspec so that it won't report compile error when linking objects
