### PR TITLE
Add podspecs for ETA-SDK, including historical versions.

### DIFF
--- a/ETA-SDK/2.1.0/ETA-SDK.podspec
+++ b/ETA-SDK/2.1.0/ETA-SDK.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |s|
+  s.name         = "ETA-SDK"
+  s.version      = "2.1.0"
+  s.summary      = "eTilbudsavis iOS SDK."
+  s.description  = <<-DESC
+                     An SDK that makes it easy to talk to the eTilbudsavis API.
+                     Also allows you to easily embed catalogs and shopping lists in your own iOS app.
+                    DESC
+
+  s.homepage     = "http://engineering.etilbudsavis.dk/native-ios-eta-sdk/"
+  s.license      = 'MIT'
+  s.author       = { "Laurie Hufford" => "lh@etilbudsavis.dk" }
+
+  s.platform     = :ios, '5.0'
+  s.requires_arc = true
+
+  s.source       = { :git => "https://github.com/eTilbudsavis/native-ios-eta-sdk.git", :tag => "v2.1.0" }
+  s.source_files = 'ETA-SDK/**/*.{h,m}'
+  s.frameworks   = 'CoreLocation', 'Foundation', 'UIKit'
+
+  s.dependency 'AFNetworking', '~> 1.3.1'
+  s.dependency 'Mantle', '~> 1.2'
+  s.dependency 'FMDB', '~> 2.1'
+  s.dependency 'MAKVONotificationCenter', '~> 0.0.2'
+
+end

--- a/ETA-SDK/2.1.1/ETA-SDK.podspec
+++ b/ETA-SDK/2.1.1/ETA-SDK.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |s|
+  s.name         = "ETA-SDK"
+  s.version      = "2.1.1"
+  s.summary      = "eTilbudsavis iOS SDK."
+  s.description  = <<-DESC
+                     An SDK that makes it easy to talk to the eTilbudsavis API.
+                     Also allows you to easily embed catalogs and shopping lists in your own iOS app.
+                    DESC
+
+  s.homepage     = "http://engineering.etilbudsavis.dk/native-ios-eta-sdk/"
+  s.license      = 'MIT'
+  s.author       = { "Laurie Hufford" => "lh@etilbudsavis.dk" }
+
+  s.platform     = :ios, '5.0'
+  s.requires_arc = true
+
+  s.source       = { :git => "https://github.com/eTilbudsavis/native-ios-eta-sdk.git", :tag => "v2.1.1" }
+  s.source_files = 'ETA-SDK/**/*.{h,m}'
+  s.frameworks   = 'CoreLocation', 'Foundation', 'UIKit'
+
+  s.dependency 'AFNetworking', '~> 1.3.1'
+  s.dependency 'Mantle', '~> 1.2'
+  s.dependency 'FMDB', '~> 2.1'
+  s.dependency 'MAKVONotificationCenter', '~> 0.0.2'
+
+end

--- a/ETA-SDK/2.2.0/ETA-SDK.podspec
+++ b/ETA-SDK/2.2.0/ETA-SDK.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |s|
+  s.name         = "ETA-SDK"
+  s.version      = "2.2.0"
+  s.summary      = "eTilbudsavis iOS SDK."
+  s.description  = <<-DESC
+                     An SDK that makes it easy to talk to the eTilbudsavis API.
+                     Also allows you to easily embed catalogs and shopping lists in your own iOS app.
+                    DESC
+
+  s.homepage     = "http://engineering.etilbudsavis.dk/native-ios-eta-sdk/"
+  s.license      = 'MIT'
+  s.author       = { "Laurie Hufford" => "lh@etilbudsavis.dk" }
+
+  s.platform     = :ios, '6.0'
+  s.requires_arc = true
+
+  s.source       = { :git => "https://github.com/eTilbudsavis/native-ios-eta-sdk.git", :tag => "v2.2.0" }
+  s.source_files = 'ETA-SDK/**/*.{h,m}'
+  s.frameworks   = 'CoreLocation', 'Foundation', 'UIKit'
+
+  s.dependency 'AFNetworking', '~> 2.1.0'
+  s.dependency 'Mantle', '~> 1.3.1'
+  s.dependency 'FMDB', '~> 2.2.0'
+  s.dependency 'MAKVONotificationCenter', '~> 0.0.2'
+
+end


### PR DESCRIPTION
I have included multiple podspec files in this pull request as the latest version changes the ios version requirements, and I wish to give users a fallback.
