### PR TITLE
Updated spec for UITableViewHelper v0.0.5

### DIFF
--- a/UITableViewHelper/0.0.5/UITableViewHelper.podspec
+++ b/UITableViewHelper/0.0.5/UITableViewHelper.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name         = "UITableViewHelper"
+  s.version      = "0.0.5"
+  s.summary      = "Easier integration of UITableViews with custom cells built from nib files or storyboards."
+  s.homepage     = "https://github.com/fer662/UITableViewHelper"
+  s.license      = 'MIT'
+  s.author       = { "Fernando Mazzon" => "fer662@gmail.com" }
+  s.source       = { :git => "https://github.com/fer662/UITableViewHelper.git", :tag => "0.0.5" }
+  s.platform     = :ios
+  s.source_files = 'Classes', 'Classes/**/*.{h,m}'
+  s.public_header_files = 'Classes/**/*.h'
+  s.frameworks = 'UIKit', 'Foundation'
+  s.requires_arc = true
+  s.dependency 'RuntimeHelpers'
+end


### PR DESCRIPTION
Updated spec for UITableViewHelper v0.0.5. Now supports cells from storyboards as well.
