### PR TITLE
Upgraded MapBox's GRMustache to 6.8.3 to match the repository

### DIFF
--- a/MapBox/1.1.0/MapBox.podspec
+++ b/MapBox/1.1.0/MapBox.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |m|
   m.preserve_paths = 'Proj4/libProj4.a', 'MapView/MapView.xcodeproj', 'MapView/Map/Resources'
 
   m.dependency 'FMDB', '2.0'
-  m.dependency 'GRMustache', '5.4.3'
+  m.dependency 'GRMustache', '6.8.3'
   m.dependency 'SMCalloutView', '1.1'
 
 end


### PR DESCRIPTION
https://github.com/mapbox/mapbox-ios-sdk/blob/release/Mapbox.podspec

The Mapbox SDK had an outdated version of GRMustache. The version bump is in the main repository but not the spec repository.
