### PR TITLE
Add QBImagePickerController 2.1

### DIFF
--- a/QBImagePickerController/2.1/QBImagePickerController.podspec
+++ b/QBImagePickerController/2.1/QBImagePickerController.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name         = "QBImagePickerController"
+  s.version      = "2.1"
+  s.summary      = "A clone of UIImagePickerController with multiple selection support."
+  s.homepage     = "https://github.com/questbeat/QBImagePickerController"
+  s.license      = 'MIT'
+  s.author       = { "questbeat" => "questbeat@gmail.com" }
+  s.platform     = :ios, '6.1'
+  s.frameworks   = 'AssetsLibrary'
+  s.source       = { :git => "https://github.com/questbeat/QBImagePickerController.git", :tag => "v2.1" }
+  s.source_files = 'QBImagePickerController', 'QBImagePickerController/**/*.{h,m}'
+  s.resources    = "QBImagePickerController/Resources/*.lproj"
+  s.requires_arc = true
+end
+


### PR DESCRIPTION
This commit updates the podspec for QBImagePickerController to v2.1 to include iOS 6 support.
