### PR TITLE
[Update] Lookback (0.6.0)

### DIFF
--- a/Lookback/0.6.0/Lookback.podspec
+++ b/Lookback/0.6.0/Lookback.podspec
@@ -1,0 +1,51 @@
+Pod::Spec.new do |s|
+
+  s.name         = "Lookback"
+  s.version      = "0.6.0"
+  s.summary      = "Lookback records screen, camera, touches etc and uploads it to http://lookback.io. Useful for UX research, QA bug reporting, etc."
+
+  s.description  = <<-DESC
+                    Lookback is a tool and library for user experience testing
+                    that you can integrate into your app. Lookback records the
+                    iOS screen, the front-facing camera, microphone, metadata,
+                    touches and active views, and uploads it all in
+                    near-realtime to lookback.io where you can study and dive
+                    into the data. Example use cases:
+
+                  * User testing sessions. Instead of mounting web cams in your
+                    testing lab to record both the screen and your tester's
+                    reactions, let Lookback do the hard work for you.
+                  * Long-term usability study. Let a user record a week of
+                    using your app, and study trends, reactions and recurring
+                    problems.
+                  * Quality assurance. Record videos of found bugs, complete
+                    with a trace of how the tester reached it.
+
+                  See some more examples over at http://lookback.io/examples.
+
+                   DESC
+
+  s.homepage     = "http://lookback.io/"
+  s.license      = {
+    :type => 'Commercial',
+    :text => <<-LICENSE
+              All text and design is copyright © 2013 Lookback AB
+
+              All rights reserved. Terms of use as defined at http://lookback.io applies.
+    LICENSE
+  } 
+
+  s.author       = { "Joachim Bengtsson" => "nevyn@lookback.io" }
+  s.social_media_url = "http://twitter.com/lookback"
+
+  s.platform     = :ios, '6.0'
+
+  s.source       = { :http => "https://s3-eu-west-1.amazonaws.com/lookback-public/sdk/lookback-sdk-0.6.0.zip" }
+  s.source_files  = "lookback-#{s.version}/Lookback.framework/Versions/A/Headers/*.h"
+  s.resources = "lookback-#{s.version}/Lookback.framework/Versions/A/Resources/*"
+  s.preserve_paths = "lookback-#{s.version}/LookBack.framework"
+
+  s.frameworks = 'AVFoundation', 'AudioToolbox', 'CoreVideo', 'CoreMedia', 'SystemConfiguration', 'MediaPlayer', 'QuartzCore', 'LookBack'
+
+  s.xcconfig  =  { 'FRAMEWORK_SEARCH_PATHS' => "\"$(PODS_ROOT)/Lookback/lookback-#{s.version}\"" }
+end


### PR DESCRIPTION
- New UI to start recording. This new UI (in the form of
  LookbackRecordingViewController) is used instead of
  LookbackSettingsViewController when you shake the device. You can still access
  the Settings from a button in this new UI. Since it presents itself in a
  separate window, the Recording VC should work in any app even if you don't
  have a root view controller.
- Fix crash on 64-bit iPad. The crash was in [GFIOSurfaceVideoInput
  initForMainScreenWithSync:], if you saw it in your backtrace, this bug has now
  been fixed.
- Redesigned Settings VC.
- From the Recording VC, you can now access a list of experiences that are being
  uploaded, and the ten most recent uploads. Swipe left on an experience to share
  it, or abort the upload and remove it.
- Fix a "crash loop" bug. Lookback is supposed to not load if it thinks it caused
  the most recent crash; this feature had a bug, causing your app to crash
  continuously until you reinstall it.
- Uses SSL to communicate with our backend.
- Note that if you're installing Lookback into your project manually, there are
  a few new png files that you need to add to your project, and some that have
  been removed.
