### PR TITLE
MTDirectionsKit was missing a resource bundle, corrected

### DIFF
--- a/MTDirectionsKit/1.7.0/MTDirectionsKit.podspec
+++ b/MTDirectionsKit/1.7.0/MTDirectionsKit.podspec
@@ -44,5 +44,6 @@ Pod::Spec.new do |s|
 
   s.libraries   = 'xml2', 'c++', 'icucore', 'z'
   s.requires_arc = true
+  s.resource_bundle = { 'MTDirectionsKit' => 'Resources/MTDirectionsKit.bundle' }
 
 end


### PR DESCRIPTION
I originally missed including the resources bundle, corrected this.
