### PR TITLE
Version Localytics-AMP download URLs

### DIFF
--- a/Localytics-AMP/2.21.0/Localytics-AMP.podspec
+++ b/Localytics-AMP/2.21.0/Localytics-AMP.podspec
@@ -7,15 +7,15 @@ Pod::Spec.new do |s|
 
   s.license      = {
     :type => 'Copyright',
-    :file => 'LICENSE'
+    :file => 'AMP-SDK-2.21.0.bin/LICENSE'
   }
   s.author       = 'Char Software, Inc. d/b/a Localytics'
-  s.source       = { :http => "http://downloads.localytics.com/SDKs/iOS/AMP-SDK-latest.bin.zip" }
+  s.source       = { :http => "http://downloads.localytics.com/SDKs/iOS/archive/AMP-SDK-2.21.0.bin.zip" }
   s.platform     = :ios, '5.1.1'
 
-  s.source_files = '*.h'
-  s.preserve_paths = 'libLocalyticsAMP.a'
-  s.xcconfig = { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Localytics-AMP"' }
+  s.source_files = 'AMP-SDK-2.21.0.bin/*.h'
+  s.preserve_paths = 'AMP-SDK-2.21.0.bin/libLocalyticsAMP.a'
+  s.xcconfig = { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Localytics-AMP/AMP-SDK-2.21.0.bin"' }
 
   s.weak_frameworks = 'AdSupport'
   s.frameworks = 'SystemConfiguration'

--- a/Localytics-AMP/2.21.0/Localytics-AMP.podspec
+++ b/Localytics-AMP/2.21.0/Localytics-AMP.podspec
@@ -7,15 +7,15 @@ Pod::Spec.new do |s|
 
   s.license      = {
     :type => 'Copyright',
-    :file => 'AMP-SDK-2.21.0.bin/LICENSE'
+    :file => 'LICENSE'
   }
   s.author       = 'Char Software, Inc. d/b/a Localytics'
   s.source       = { :http => "http://downloads.localytics.com/SDKs/iOS/archive/AMP-SDK-2.21.0.bin.zip" }
   s.platform     = :ios, '5.1.1'
 
-  s.source_files = 'AMP-SDK-2.21.0.bin/*.h'
-  s.preserve_paths = 'AMP-SDK-2.21.0.bin/libLocalyticsAMP.a'
-  s.xcconfig = { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Localytics-AMP/AMP-SDK-2.21.0.bin"' }
+  s.source_files = '*.h'
+  s.preserve_paths = 'libLocalyticsAMP.a'
+  s.xcconfig = { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Localytics-AMP"' }
 
   s.weak_frameworks = 'AdSupport'
   s.frameworks = 'SystemConfiguration'

--- a/Localytics-AMP/2.22.0/Localytics-AMP.podspec
+++ b/Localytics-AMP/2.22.0/Localytics-AMP.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
     :file => 'AMP-SDK-2.22.0.bin/LICENSE'
   }
   s.author       = 'Char Software, Inc. d/b/a Localytics'
-  s.source       = { :http => "http://downloads.localytics.com/SDKs/iOS/AMP-SDK-latest.bin.zip" }
+  s.source       = { :http => "http://downloads.localytics.com/SDKs/iOS/archive/AMP-SDK-2.22.0.bin.zip" }
   s.platform     = :ios, '5.1.1'
 
   s.source_files = 'AMP-SDK-2.22.0.bin/*.h'

--- a/Localytics-AMP/2.23.0/Localytics-AMP.podspec
+++ b/Localytics-AMP/2.23.0/Localytics-AMP.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
     :file => 'AMP-SDK-2.23.0.bin/LICENSE'
   }
   s.author       = 'Char Software, Inc. d/b/a Localytics'
-  s.source       = { :http => "http://downloads.localytics.com/SDKs/iOS/AMP-SDK-latest.bin.zip" }
+  s.source       = { :http => "http://downloads.localytics.com/SDKs/iOS/archive/AMP-SDK-2.23.0.bin.zip" }
   s.platform     = :ios, '5.1.1'
 
   s.source_files = 'AMP-SDK-2.23.0.bin/*.h'


### PR DESCRIPTION
Converting Localytics-AMP specs to use version specific download URLs, so they continue to work when the "latest" download URL has been updated.
