### PR TITLE
Removed platform restrictions from JSONKit-NoWarning

### DIFF
--- a/JSONKit-NoWarning/1.1/JSONKit-NoWarning.podspec
+++ b/JSONKit-NoWarning/1.1/JSONKit-NoWarning.podspec
@@ -5,7 +5,6 @@ Pod::Spec.new do |s|
   s.summary  = 'A Very High Performance Objective-C JSON Library.'
   s.homepage = 'https://github.com/ignazioc/JSONKit-NoWarning'
   s.author   = 'John Engelhart'
-  s.platform     = :ios, '7.0'
   s.source   = { :git => 'https://github.com/ignazioc/JSONKit-NoWarning.git', :tag => "1.1", :commit => "35360aeb577f58a49cdf4ce58dbf286e2fab39e0" }
 
   s.source_files   = 'JSONKit.*'


### PR DESCRIPTION
To match the original JSONKit.podspec.
JSONKit-NoWarning is forked from JSONKit 1.5pre and it works exactly same so this spec should be updated in order to use JSONKit-NoWarning in the exactly same environment of the original JSONKit.
