### PR TITLE
Correct library reference to version with 64-bit support

### DIFF
--- a/Localytics-AMP/2.23.1/Localytics-AMP.podspec
+++ b/Localytics-AMP/2.23.1/Localytics-AMP.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
 
   s.weak_frameworks = 'AdSupport'
   s.frameworks = 'SystemConfiguration'
-  s.libraries   = 'LocalyticsAMP', 'z', 'sqlite3'
+  s.libraries   = 'LocalyticsAMP_x64', 'z', 'sqlite3'
 end


### PR DESCRIPTION
Special request: The last change to this spec earlier today was broken. This fixes the library reference to the correct name.
