### PR TITLE
Swap source since old URL returns a 404

### DIFF
--- a/FontLabel/0.0.1/FontLabel.podspec
+++ b/FontLabel/0.0.1/FontLabel.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.authors   = {
     'Zynga, Inc.' => 'http://code.zynga.com'
   }
-  s.source   = { :git => 'https://github.com/zynga/FontLabel.git', :commit => "2fe3721146b9607a1154823fc98c4cb003551557"}
+  s.source   = { :git => 'https://github.com/JPluto/FontLabel.git', :commit => "339cf005252935173c5be7ccd4a82e6811b792e3"}
   s.source_files = 'FontLabel/Classes/FontLabel/*.{h,m}'
 
 end


### PR DESCRIPTION
The old source: https://github.com/zynga/FontLabel.git
Is not reachable and returns a 404, Page not found.

Not sure if the repo became private or whether it was removed.
This pull request suggests to replace s.source with another existing repo on github that is reachable.
