### PR TITLE
Pull request for useful .clang-format that adheres to Apples code style

### DIFF
--- a/Apple-clang-format/0.0.1/Apple-clang-format.podspec
+++ b/Apple-clang-format/0.0.1/Apple-clang-format.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = "Apple-clang-format"
+  s.version      = "0.0.1"
+  s.summary      = "A .clang-format file as similar as you can get to Apples code style."
+  s.homepage     = "https://github.com/haaakon/Apple-clang-format"
+  s.license      = { :type => 'MIT' }
+  s.author       = { "Haaakon Bogen" => "hakon.bogen@gmail.com" }
+  s.source       = { :git => "https://github.com/haaakon/Apple-clang-format.git", :tag => "0.0.1" }
+  s.platform     = :ios, '5.0'
+  s.source_files = ".*"
+end
+


### PR DESCRIPTION
.clang-format file needs another plugin to work, which is linked to in the installation guide.
