### PR TITLE
Removes Adjust SDK's dependency on AdSupport framework.

### DIFF
--- a/Adjust/3.1.0/Adjust.podspec
+++ b/Adjust/3.1.0/Adjust.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author       = { "Christian Wellenbrock" => "welle@adeven.com" }
   s.source       = { :git => "https://github.com/adeven/adjust_ios_sdk.git", :tag => "v3.1.0" }
   s.platform     = :ios, '4.3'
-  s.framework    = 'AdSupport', 'SystemConfiguration'
+  s.framework    = 'SystemConfiguration'
   s.source_files = 'Adjust/*.{h,m}', 'Adjust/AIAdditions/*.{h,m}'
   s.requires_arc = true
 end


### PR DESCRIPTION
This dependency is no longer necessary for the current version. However, including it by default can lead to app rejections when the app is not otherwise using the AdSupport framework.
