### PR TITLE
Fixing Avro-C Spec

### DIFF
--- a/Avro-C/1.7.6/Avro-C.podspec
+++ b/Avro-C/1.7.6/Avro-C.podspec
@@ -20,9 +20,18 @@ Pod::Spec.new do |s|
 	s.osx.deployment_target = '10.8'
 	s.requires_arc = true
 
+
+
 	s.source_files = 'lang/c/src/**/*.{h,c}'
 	s.header_mappings_dir = 'lang/c/src'
 	s.exclude_files = "lang/c/src/schema_specific.c"
+
+	s.prefix_header_contents = <<-PREFIX_HEADER
+								#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050 
+									#define AVRO_NON_ATOMIC_REFCOUNT"
+								#endif
+
+								PREFIX_HEADER
 
 	s.dependency 'Jansson', '~> 2.5'
 end

--- a/Avro-C/1.7.6/Avro-C.podspec
+++ b/Avro-C/1.7.6/Avro-C.podspec
@@ -20,8 +20,6 @@ Pod::Spec.new do |s|
 	s.osx.deployment_target = '10.8'
 	s.requires_arc = true
 
-
-
 	s.source_files = 'lang/c/src/**/*.{h,c}'
 	s.header_mappings_dir = 'lang/c/src'
 	s.exclude_files = "lang/c/src/schema_specific.c"


### PR DESCRIPTION
#9262 had indeed an issue.

After running `pod spec lint Avro-C.podspec --verbose`, I was able to found that the error only occurred when building for iOS devices.
