### PR TITLE
Updated EZAudio to version 0.0.4

### DIFF
--- a/EZAudio/0.0.4/EZAudio.podspec
+++ b/EZAudio/0.0.4/EZAudio.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name         = "EZAudio"
+  s.version      = "0.0.4"
+  s.summary      = "A simple, intuitive audio framework for iOS and OSX useful for anyone doing audio processing and/or audio-based visualizations."
+  s.homepage     = "http://syedharisali.com/projects/EZAudio/getting-started"
+  s.screenshots  = "https://s3-us-west-1.amazonaws.com/ezaudio-media/EZAudioSummary.png"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author       = { "Syed Haris Ali" => "syedhali07@gmail.com" }
+  s.ios.deployment_target = '6.0'
+  s.osx.deployment_target = '10.8'
+  s.source       = { :git => "https://github.com/syedhali/EZAudio.git", :tag => "0.0.4" }
+  s.source_files  = 'EZAudio/*.{h,m,c}'
+  s.exclude_files = 'EZAudio/VERSION'
+  s.ios.frameworks = 'AudioToolbox','AVFoundation','GLKit'
+  s.osx.frameworks = 'AudioToolbox','AudioUnit','CoreAudio','QuartzCore','OpenGL','GLKit'
+  s.requires_arc = true;
+end


### PR DESCRIPTION
Rebased with master Cocoapods Specs and resetup pods repo.

Changelog:
Added ‘closeAudioFile’ to EZRecorder to properly dispose of internal audio file prior to trying to reload it using the EZAudioFile.
Added new EZOutputDataSource method that provides pre-allocated AudioBufferList to fill instead of caller allocating and disposing on AudioBufferList. Much less errors.
Added EZAudioPlayer for playback and visualization of local audio files (no network streaming yet).
Merged bug fixes from community for EZAudio file.
