### PR TITLE
Rollback ios.deployment_target

### DIFF
--- a/ReactiveCocoa/2.2.4/ReactiveCocoa.podspec
+++ b/ReactiveCocoa/2.2.4/ReactiveCocoa.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description  = "ReactiveCocoa (RAC) is an Objective-C framework for Functional Reactive Programming. It provides APIs for composing and transforming streams of values."
  
   s.requires_arc = true
-  s.ios.deployment_target = '6.0'
+  s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
   s.compiler_flags = '-DOS_OBJECT_USE_OBJC=0'
 

--- a/WTStatusBar/0.0.4/WTStatusBar.podspec
+++ b/WTStatusBar/0.0.4/WTStatusBar.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "WTStatusBar"
+  s.version      = "0.0.4"
+  s.summary      = "iPhone/iPad status bar with text (and optionally Foursquare-like progress bar) display."
+  s.homepage     = "https://github.com/huuhoa/WTStatusBar"
+  s.screenshots  = "https://github.com/huuhoa/WTStatusBar/raw/master/screenshot.png"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author       = 'Alex Skalozub'
+  s.platform     = :ios, '5.0'
+  s.source       = { :git => "https://github.com/huuhoa/WTStatusBar.git", :tag => s.version.to_s }
+  s.source_files  = 'WTStatusBar/*.{h,m}'
+  s.requires_arc  = true
+end


### PR DESCRIPTION
ReactiveCocoa 2.2.4 does set IOS Deployment Target = 5.0, therefore, podspec should not change that.
