### PR TITLE
[Update] XtifyLib (2.57)

### DIFF
--- a/XtifyLib/2.57/XtifyLib.podspec
+++ b/XtifyLib/2.57/XtifyLib.podspec
@@ -1,5 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'XtifyLib'
+  # Only change the version - everything else is automatic
   s.version      = '2.57'
   s.summary      = 'Xtify library for iOS application with CocoaPods integration.'
   s.platform     = :ios, '6.0'
@@ -20,6 +21,7 @@ Pod::Spec.new do |s|
   
   s.xcconfig = { 'ARCHS' => '$ARCHS_STANDARD_32_BIT' }
   
+  # This downloads the ZIP direct from Xtify and extras it using it as the source
   s.prepare_command = <<-CMD
   		curl -sSL -o xtify-ios-sdk.zip http://developer.xtify.com/download/attachments/5440150/xtify-ios-sdk-#{s.version.to_s}.zip
   		unzip -qq xtify-ios-sdk.zip

--- a/XtifyLib/2.57/XtifyLib.podspec
+++ b/XtifyLib/2.57/XtifyLib.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |s|
+  s.name         = 'XtifyLib'
+  s.version      = '2.57'
+  s.summary      = 'Xtify library for iOS application with CocoaPods integration.'
+  s.platform     = :ios, '6.0'
+  s.author 		 = {
+    'Xtify' => 'support@xtify.com',
+    'Rich H' => 'github@rhodgkins.co.uk'
+  }
+  s.license =  { :type => 'Apache License, Version 2.0', :file => 'Source/license/LA_en.rtf' }
+  s.homepage = 'https://github.com/rhodgkins/XtifyLib'
+  s.source = { :http => 'https://github.com/rhodgkins/XtifyLib/raw/master/empty.zip' }
+
+  s.source_files = 'Source/XtifyLib/**/*.{h,m}',
+  s.vendored_frameworks = 'Source/XtifyLib/XtifyPush.embeddedframework/XtifyPush.framework'
+  s.preserve_paths = 'Source/XtifyLib/XtifyPush.embeddedframework/XtifyPush.framework/*', 'Source/copyright.txt'
+  
+  s.frameworks = 'Foundation', 'UIKit', 'CoreGraphics', 'SystemConfiguration', 'MapKit', 'CoreData', 'MessageUI', 'CoreLocation', 'CFNetwork', 'MobileCoreServices', 'CoreTelephony'
+  s.library = 'xml2.2', 'z'
+  
+  s.xcconfig = { 'ARCHS' => '$ARCHS_STANDARD_32_BIT' }
+  
+  s.prepare_command = <<-CMD
+  		curl -sSL -o xtify-ios-sdk.zip http://developer.xtify.com/download/attachments/5440150/xtify-ios-sdk-#{s.version.to_s}.zip
+  		unzip -qq xtify-ios-sdk.zip
+  		mv xtify-ios-sdk-#{s.version.to_s} Source
+  	CMD
+end


### PR DESCRIPTION
Now using the exact source from Xtify instead of a repo with the source file dumped inside. This does mean the source is an empty zip file but then in the `prepare_command` the actual source is downloaded. It cannot be specified as a `:http` source due to it not directly pointing to a zip file.
