### PR TITLE
Fixed an issue where cocoapods would not add in the source files for AD-X

### DIFF
--- a/AD-X-SDK/4.0.3/AD-X-SDK.podspec
+++ b/AD-X-SDK/4.0.3/AD-X-SDK.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios
   s.ios.deployment_target = '5.0'
 
-  s.source_files = '*.[hm]'
+  s.source_files = '*/*.[hm]'
 
   s.frameworks = 'SystemConfiguration'
   s.weak_frameworks = 'AdSupport'


### PR DESCRIPTION
The source for AD-X is actually stored one level deeper than its top level folder in "Ad-X iOS SDK 4.1.2" and was not loading without the extra wildcard.
