### PR TITLE
Bumped commit hash to the latest.

### DIFF
--- a/SBTickerView/0.0.1/SBTickerView.podspec
+++ b/SBTickerView/0.0.1/SBTickerView.podspec
@@ -8,6 +8,6 @@ Pod::Spec.new do |s|
   s.license   = 'MIT'
   s.requires_arc = true
   s.source    = { :git => 'https://github.com/blommegard/SBTickerView.git',
-                  :commit => '9d45f5b320861354a269714b42c831e61ff1ad09' }
+                  :commit => '4eb654916b1e7be83e343e6907a30c0a81368e06' }
   s.source_files  = '*.{h,m}'
 end


### PR DESCRIPTION
As SBTickerView does not use tags & therefore has no
official release I just bumped the commit hash to the latest.

This resolves a waring about assigning a variable to itself.

/brianjriddle
