### PR TITLE
Update URLMock 1.1.1 podspec to fix Xcode 5.1 warnings

### DIFF
--- a/URLMock/1.1.1/URLMock.podspec
+++ b/URLMock/1.1.1/URLMock.podspec
@@ -10,19 +10,25 @@ Pod::Spec.new do |s|
                    your code.
                    DESC
 
-  s.author       = { "Prachi Gauriar" => "prachi@twotoasters.com" }
-  s.homepage     = "https://github.com/prachigauriar/URLMock"
+  s.author       = { "Two Toasters" => "general@twotoasters.com" }
+  s.homepage     = "https://github.com/twotoasters/URLMock"
   s.license      = { :type => "MIT", :file => "LICENSE" }
 
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'
-
-  s.source       = { :git => "https://github.com/prachigauriar/URLMock.git", :tag => "1.1.1" }
-  s.source_files  = 'URLMock', 'URLMock/**/*.{h,m}'
+  s.requires_arc = true
 
   s.dependency 'OCMock', '~> 2.0'
 
-  s.requires_arc = true
+  s.source       = { :git => "https://github.com/twotoasters/URLMock.git", :tag => s.version.to_s }
+
+  s.source_files  = 'URLMock/URLMock.h',
+                    'URLMock/Mock Messages/UMKMockHTTPMessage.{h,m}',
+                    'URLMock/Mock Messages/UMKMockHTTPRequest.{h,m}',
+                    'URLMock/Mock Messages/UMKMockHTTPResponder.{h,m}',
+                    'URLMock/Mock URL Protocol/UMKMockURLProtocol+UMKHTTPConvenienceMethods.{h,m}',
+                    'URLMock/Mock URL Protocol/UMKMockURLProtocol.{h,m}',
+                    'URLMock/Utilities/UMKMessageCountingProxy.{h,m}'
 
   s.subspec 'TestHelpers' do |ss|
     ss.source_files = 'URLMock/Utilities/UMKTestUtilities.{h,m}',
@@ -34,7 +40,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'SubclassResponsibility' do |ss|
-    ss.source_files = 'URLMock/Utilities/UMKErrorUtilities.{h,m}',
-                      'URLMock/Categories/NSException+UMKSubclassResponsibility.{h,m}'
+    ss.dependency 'URLMock/TestHelpers'
+    ss.source_files = 'URLMock/Categories/NSException+UMKSubclassResponsibility.{h,m}'
   end
 end


### PR DESCRIPTION
We’re updating the existing pod spec instead of pushing a new version of the library, as the library itself has no warnings. Users who use URLMock will have warnings in their Pods.xcodeproj because of headers being copied multiple times during the Copy Files phase.
