### PR TITLE
Mixpanel v2.3.4

### DIFF
--- a/Mixpanel/2.3.3/Mixpanel.podspec
+++ b/Mixpanel/2.3.3/Mixpanel.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = "Mixpanel"
+  s.version      = "2.3.3"
+  s.summary      = "iPhone tracking library for Mixpanel Analytics"
+  s.homepage     = "http://mixpanel.com"
+  s.license      = 'Apache License, Version 2.0'
+  s.author       = { "Mixpanel, Inc" => "support@mixpanel.com" }
+  s.platform     = :ios, '6.0'
+  s.source       = { :git => "https://github.com/mixpanel/mixpanel-iphone.git", :tag => "v#{s.version}" }
+  s.source_files  = 'Mixpanel/**/*.{m,h}'
+  s.private_header_files =  'Mixpanel/Library/**/*.h'
+  s.resources 	 = ["Mixpanel/**/*.{png,storyboard}"]
+  s.frameworks = 'UIKit', 'Foundation', 'SystemConfiguration', 'CoreTelephony', 'Accelerate', 'CoreGraphics', 'QuartzCore'
+  s.requires_arc = true
+  s.compiler_flags = '-Wno-gnu'
+end

--- a/Mixpanel/2.3.4/Mixpanel.podspec
+++ b/Mixpanel/2.3.4/Mixpanel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Mixpanel"
-  s.version      = "2.3.3"
+  s.version      = "2.3.4"
   s.summary      = "iPhone tracking library for Mixpanel Analytics"
   s.homepage     = "http://mixpanel.com"
   s.license      = 'Apache License, Version 2.0'
@@ -12,5 +12,4 @@ Pod::Spec.new do |s|
   s.resources 	 = ["Mixpanel/**/*.{png,storyboard}"]
   s.frameworks = 'UIKit', 'Foundation', 'SystemConfiguration', 'CoreTelephony', 'Accelerate', 'CoreGraphics', 'QuartzCore'
   s.requires_arc = true
-  s.compiler_flags = '-Wno-gnu'
 end


### PR DESCRIPTION
v2.3.3 added a compiler flag, Wno-gnu, that suppressed warnings caused by the MIN() macro in XCode 5.1. Because this counted as podspec lint, the relevant commits were reverted leaving only the more critical bugfixes in the release.
