### PR TITLE
Add ChuzzleKit 1.0

### DIFF
--- a/ChuzzleKit/1.0/ChuzzleKit.podspec
+++ b/ChuzzleKit/1.0/ChuzzleKit.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name         = 'ChuzzleKit'
+  s.version      = '1.0'
+  s.homepage     = 'https://github.com/mxcl/ChuzzleKit'
+  s.source       = { :git => "#{s.homepage}.git", :tag => "#{s.version}" }
+  s.requires_arc = true
+  s.source_files = '*.{m,h}'
+  s.authors      = 'mxcl'
+  s.license      = 'Public Domain'
+  s.summary      = 'A chuzzled object is `nil` if it is falsy, otherwise it has its falsy parts removed.'
+end


### PR DESCRIPTION
ChuzzleKit is a tool for adding "falsy"-style behavior to Objective-C development.
