### PR TITLE
sqlite3: important update to 3.8.4.1 and add stat4 subspec

### DIFF
--- a/sqlite3/3.8.4.1/sqlite3.podspec
+++ b/sqlite3/3.8.4.1/sqlite3.podspec
@@ -1,0 +1,51 @@
+Pod::Spec.new do |s|
+  s.name         = "sqlite3"
+  s.version      = "3.8.4.1"
+  s.summary      = "SQLite is an embedded SQL database engine."
+  s.homepage     = "http://www.sqlite.org"
+  s.license      = "Public Domain"
+  s.author       = {"D. Richard Hipp" => "drh@hwaci.com"}
+
+  sqlite_version_format = "%.1d%.2d%.2d%.2d" % s.version.to_s.split('.').push(0)
+  s.source       = {:http => "http://www.sqlite.org/2014/sqlite-amalgamation-#{sqlite_version_format}.zip"}
+  s.default_subspec = 'common'
+
+  s.subspec 'common' do |ss|
+    ss.source_files = "sqlite-amalgamation-#{sqlite_version_format}/sqlite3*.{h,c}"
+  end
+
+  # built with fts support
+  s.subspec 'fts' do |ss|
+    ss.dependency 'sqlite3/common'
+    ss.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'SQLITE_ENABLE_FTS4=1 SQLITE_ENABLE_FTS3_PARENTHESIS=1' }
+  end
+  s.subspec 'unicode61' do |ss|
+    ss.dependency 'sqlite3/common'
+    ss.dependency 'sqlite3/fts'
+    ss.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'SQLITE_ENABLE_FTS4_UNICODE61=1' }
+  end
+  s.subspec 'coldata' do |ss|
+    ss.dependency 'sqlite3/common'
+    ss.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'SQLITE_ENABLE_COLUMN_METADATA=1' }
+  end
+  s.subspec 'unlock_notify' do |ss|
+    ss.dependency 'sqlite3/common'
+    ss.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'SQLITE_ENABLE_UNLOCK_NOTIFY=1' }
+  end
+  s.subspec 'rtree' do |ss|
+    ss.dependency 'sqlite3/common'
+    ss.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'SQLITE_ENABLE_RTREE=1' }
+  end
+  s.subspec 'stat3' do |ss|
+    ss.dependency 'sqlite3/common'
+    ss.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'SQLITE_ENABLE_STAT3=1' }
+  end
+  s.subspec 'stat4' do |ss|
+    ss.dependency 'sqlite3/common'
+    ss.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'SQLITE_ENABLE_STAT4=1' }
+  end
+  s.subspec 'soundex' do |ss|
+    ss.dependency 'sqlite3/common'
+    ss.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'SQLITE_SOUNDEX=1' }
+  end
+end


### PR DESCRIPTION
I updated the podspec to the current sqlite stable release (3.8.4.1) and also added STAT4 as a subspec.
Best regards, Clemens
