### PR TITLE
ZXing without recompiles

### DIFF
--- a/ZXing/2.2/ZXing.podspec
+++ b/ZXing/2.2/ZXing.podspec
@@ -33,7 +33,7 @@ EOS
     ios.ios.deployment_target   = '4.3'
 
     ios.preserve_paths          = 'cpp/core/src/zxing/**/*.h', 'objc/src/ZXing/*.h', 'cpp/core/src/bigint/*.hh'
-    ios.source_files            = 'cpp/core/src/zxing/**/*.cpp', 'objc/src/ZXing/*.{m,mm}', 'iphone/ZXingWidget/Classes/**/*.{h,m,mm}', 'cpp/core/src/bigint/*.cc'
+    ios.source_files            = 'iphone/ZXingWidget/Classes/**/*.{h,m,mm}'
     ios.compiler_flags          = '-IZXing/cpp/core/src/ -IZXing/objc/src/', '-IZXing/cpp/core/src/zxing/', '-IZXing/iphone/ZXingWidget/Classes/'
     # There are two MultiFormatReader.h files, it appears this one is unused
     ios.exclude_files           = 'iphone/ZXingWidget/Classes/MultiFormatReader.h'

--- a/ZXing/2.2/ZXing.podspec
+++ b/ZXing/2.2/ZXing.podspec
@@ -34,7 +34,7 @@ EOS
 
     ios.preserve_paths          = 'cpp/core/src/zxing/**/*.h', 'objc/src/ZXing/*.h', 'cpp/core/src/bigint/*.hh'
     ios.source_files            = 'iphone/ZXingWidget/Classes/**/*.{h,m,mm}'
-    ios.compiler_flags          = '-IZXing/cpp/core/src/ -IZXing/objc/src/', '-IZXing/cpp/core/src/zxing/', '-IZXing/iphone/ZXingWidget/Classes/'
+    ios.compiler_flags          = '-IZXing/cpp/core/src/zxing/', '-IZXing/iphone/ZXingWidget/Classes/'
     # There are two MultiFormatReader.h files, it appears this one is unused
     ios.exclude_files           = 'iphone/ZXingWidget/Classes/MultiFormatReader.h'
 


### PR DESCRIPTION
ZXing was recompiling on any change in the dependent project. This is very time consuming, since it contains 500+ source files.

There was an issue for this problem in the main CocoaPods repo (CocoaPods/CocoaPods#1523), but it was closed. This change solves the problem for me. 
