### PR TITLE
Fixing Errors in Flannel Podspec

### DIFF
--- a/Flannel/1.0.1/Flannel.podspec
+++ b/Flannel/1.0.1/Flannel.podspec
@@ -5,15 +5,14 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                     Flannel is a stylish log formatter for CocoaLumberjack. Flannel is thread safe and formats your CocoaLumberjack log statements so that you know the class and method from which your log statement originated.
                    DESC
-  s.homepage     = "http://https://github.com/groomsy/flannel"
+  s.homepage     = "https://github.com/groomsy/flannel"
   s.license      = 'MIT'
   s.author       = { "Todd Grooms" => "todd.grooms@gmail.com" }
   s.source       = { :git => "https://github.com/groomsy/flannel.git", :tag => "#{s.version}" }
-
-  s.platform     = :ios, '7.0'
-  s.osx.platform   = :osx, '10.9'
   
   s.requires_arc = true
+  s.ios.platform   = :ios, '7.0'
+  s.osx.platform   = :osx, '10.9'
 
   s.dependency 'CocoaLumberjack', '~> 1.8.1'
 


### PR DESCRIPTION
Fixed botched homepage URL.
Fixed platform descriptions so that the podspec accurately reflects
that both iOS and OSX are supported.

There is no change in the actual code, just a change in the podspec.
Therefore, I saw no need in bumping version.
