### PR TITLE
Add hoedown, a very good fork of sundown

### DIFF
--- a/hoedown/2.0.0/hoedown.podspec
+++ b/hoedown/2.0.0/hoedown.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name         = "hoedown"
+  s.version      = "2.0.0"
+  s.summary      = "Standards compliant, fast, secure markdown processing library in C. A fork of sundown."
+  s.homepage     = "https://github.com/hoedown/hoedown"
+  s.authors      = { "Natacha Porte" => "", "Vicent Marti" => "", "Devin Torres and the Hoedown authors" => "" }
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+
+  s.source       =  { :git => "https://github.com/hoedown/hoedown.git", :tag => "2.0.0" }
+  s.source_files = 'src/*.{h,c,m}'
+end


### PR DESCRIPTION
Add the best sundown fork, called "hoedown", to CocoaPods.
I plan to open-source my tiny Hoedown Objective C abstraction-layer too, either as a subspec or a separate spec. But first I'd like to add hoedown itself because it's also easy to use directly.

Best regards,
Clemens
