### PR TITLE
Add LSNewsletterInvite.

### DIFF
--- a/LSNewsletterInvite/0.6/LSNewsletterInvite.podspec
+++ b/LSNewsletterInvite/0.6/LSNewsletterInvite.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = "LSNewsletterInvite"
+  s.version      = "0.6"
+  s.summary      = "A simple newsletter invite popup that works with MailChimp"
+  s.homepage     = "https://github.com/learnstack/lsnewsletterinvite"
+  s.license      = "MIT"
+  s.author       = { 'Joshua Howland' => 'mail@jkhowland.com' }
+  s.source       = { :git => "https://github.com/LearnStack/LSNewsletterInvite.git", :tag => "0.6" }
+  s.source_files = 'LSNewsletterInvite'
+  s.platform     = :ios, '6.1'
+  s.public_header_files = 'LSNewsletterInvite', '*.h'
+  
+  s.dependency 'ChimpKit', '~> 3.0.2'
+  s.dependency 'SVProgressHUD', '~> 1.0'
+  
+end


### PR DESCRIPTION
LSNewsletterInvite is a simple newsletter invite popup that works with MailChimp to help you get more newsletter signups.

https://github.com/LearnStack/LSNewsletterInvite
