### PR TITLE
Fix reference to the Framework Search Path

### DIFF
--- a/LookbackSafe/0.6.1/LookbackSafe.podspec
+++ b/LookbackSafe/0.6.1/LookbackSafe.podspec
@@ -53,5 +53,5 @@ Pod::Spec.new do |s|
 
   s.frameworks = 'AVFoundation', 'AudioToolbox', 'CoreVideo', 'CoreMedia', 'SystemConfiguration', 'MediaPlayer', 'QuartzCore', 'Lookback'
 
-  s.xcconfig  =  { 'FRAMEWORK_SEARCH_PATHS' => "\"$(PODS_ROOT)/Lookback/lookback-#{s.version}/Safe\"" }
+  s.xcconfig  =  { 'FRAMEWORK_SEARCH_PATHS' => "\"$(PODS_ROOT)/#{s.name}/lookback-#{s.version}/Safe\"" }
 end


### PR DESCRIPTION
It was setup to search in `"\"$(PODS_ROOT)/Lookback/lookback-#{s.version}/Safe\""`, but should actually be looking in `"\"$(PODS_ROOT)/LookbackSafe/lookback-#{s.version}/Safe\""`. This uses the more generic `#{s.name}` to fix that.

/cc @nevyn
