### PR TITLE
fix Crittercism library name?

### DIFF
--- a/CrittercismSDK/4.3.2/CrittercismSDK.podspec
+++ b/CrittercismSDK/4.3.2/CrittercismSDK.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.source_files = 'CrittercismSDK/*.h'
   s.resource = 'CrittercismSDK/dsym_upload.sh'
   s.preserve_paths = 'CrittercismSDK/libCrittercism_v4_3_2.a'
-  s.library = 'Crittercism_v4_3_2'
+  s.library = 'libCrittercism_v4_3_2'
   s.xcconfig = { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/CrittercismSDK/CrittercismSDK"' }
   s.framework = 'SystemConfiguration'
 end


### PR DESCRIPTION
To get the Crittercism Pod to work in our project, we have to go Build Phases and manually specify the Crittercism library for linking.

I'm not super familiar with Podspec syntax, but since the library's filename is "libCrittercism_v4_3_2.a" it seems to me that the library name should be defined here as "libCrittercism_v4_3_2" instead of "Crittercism_v4_3_2".
