### PR TITLE
Added 'NSDate+Calendar' podspec version 0.0.4

### DIFF
--- a/NSDate+Calendar/0.0.4/NSDate+Calendar.podspec
+++ b/NSDate+Calendar/0.0.4/NSDate+Calendar.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name         = "NSDate+Calendar"
+  s.version      = "0.0.4"
+  s.summary      = "NSDate categories to access date components and many more."
+  s.homepage     = "https://github.com/belkevich/nsdate-calendar"
+  s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }
+  s.author       = { "Alexey Belkevich" => "belkevich.alexey@gmail.com" }
+  s.source       = { :git => "https://github.com/belkevich/nsdate-calendar.git",
+		     :tag => s.version.to_s}
+  s.platform     = :ios
+  s.source_files = 'Categories/**/*.{h,m}'
+  s.ios.deployment_target = "5.0"
+  s.osx.deployment_target = "10.7"
+  s.requires_arc = true
+end


### PR DESCRIPTION
Changes:
- Fixed potential bug in `dateWeekStart` and `dateWeekEnd` if local calendar's first weekday isn't sunday
