### PR TITLE
Fix all Cocos2D podspecs with versions <=2 by pointing to the Cocos2d git repository backup

### DIFF
--- a/cocos2d/1.1.rc0/cocos2d.podspec
+++ b/cocos2d/1.1.rc0/cocos2d.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name         =  'cocos2d'
   s.license      =  { :type => 'MIT', :file => 'LICENSE_cocos2d.txt' }
-  s.version      =  '1.1.rc0'
+  s.version      =  '1.1-RC0'
   s.summary      =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications.'
   s.description  =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications for iPod Touch, iPhone, iPad and Mac. It is based on the cocos2d design but instead of using python it, uses Objective-C.'
   s.homepage     =  'http://www.cocos2d-iphone.org'
   s.author       =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
-  s.source       =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone.git', :commit => '7ee5b9abf645c32379a45317986a308204277bb1'}
+  s.source       =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone.git', :tag => 'release-1.1-RC0'}
   s.preferred_dependency = 'cocos2d'
 
   s.subspec 'cocos2d' do |cc|

--- a/cocos2d/1.1.rc0/cocos2d.podspec
+++ b/cocos2d/1.1.rc0/cocos2d.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications for iPod Touch, iPhone, iPad and Mac. It is based on the cocos2d design but instead of using python it, uses Objective-C.'
   s.homepage     =  'http://www.cocos2d-iphone.org'
   s.author       =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
-  s.source       =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone', :commit => '7ee5b9abf645c32379a45317986a308204277bb1'}
+  s.source       =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone.git', :commit => '7ee5b9abf645c32379a45317986a308204277bb1'}
   s.preferred_dependency = 'cocos2d'
 
   s.subspec 'cocos2d' do |cc|

--- a/cocos2d/1.1.rc0/cocos2d.podspec
+++ b/cocos2d/1.1.rc0/cocos2d.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications for iPod Touch, iPhone, iPad and Mac. It is based on the cocos2d design but instead of using python it, uses Objective-C.'
   s.homepage     =  'http://www.cocos2d-iphone.org'
   s.author       =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
-  s.source       =  {:git => 'https://github.com/cocos2d/cocos2d-iphone.git', :commit => '7ee5b9abf645c32379a45317986a308204277bb1'}
+  s.source       =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone', :commit => '7ee5b9abf645c32379a45317986a308204277bb1'}
   s.preferred_dependency = 'cocos2d'
 
   s.subspec 'cocos2d' do |cc|

--- a/cocos2d/2.0-rc1/cocos2d.podspec
+++ b/cocos2d/2.0-rc1/cocos2d.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications for iPod Touch, iPhone, iPad and Mac. It is based on the cocos2d design but instead of using python it, uses objective-c.'
   s.homepage    =  'http://www.cocos2d-iphone.org'
   s.author      =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
-  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone', :tag => 'release-2.0-rc1'}
+  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone.git', :tag => 'release-2.0-rc1'}
 
   s.source_files = 'cocos2d/**/*.{h,m,c}', 'CocosDenshion/CocosDenshion/*.{h,m}',
     'external/libpng/*.{h,c}', 'external/kazmath/src/**/*.{c,h}', 'external/kazmath/include/**/*.{c,h}'

--- a/cocos2d/2.0-rc1/cocos2d.podspec
+++ b/cocos2d/2.0-rc1/cocos2d.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications for iPod Touch, iPhone, iPad and Mac. It is based on the cocos2d design but instead of using python it, uses objective-c.'
   s.homepage    =  'http://www.cocos2d-iphone.org'
   s.author      =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
-  s.source      =  {:git => 'https://github.com/cocos2d/cocos2d-iphone.git', :tag => 'release-2.0-rc1'}
+  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone', :tag => 'release-2.0-rc1'}
 
   s.source_files = 'cocos2d/**/*.{h,m,c}', 'CocosDenshion/CocosDenshion/*.{h,m}',
     'external/libpng/*.{h,c}', 'external/kazmath/src/**/*.{c,h}', 'external/kazmath/include/**/*.{c,h}'

--- a/cocos2d/2.0/cocos2d.podspec
+++ b/cocos2d/2.0/cocos2d.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications for iPod Touch, iPhone, iPad and Mac. It is based on the cocos2d design but instead of using python it, uses objective-c.'
   s.homepage    =  'http://www.cocos2d-iphone.org'
   s.author      =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
-  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone', :tag => 'release-2.0'}
+  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone.git', :tag => 'release-2.0'}
 
   s.source_files = 'cocos2d/**/*.{h,m,c}', 'external/kazmath/src/**/*.{c,h}', 'external/kazmath/include/**/*.{c,h}', 'external/libpng/*.{h,c}'
   s.exclude_files = 'external/libpng/pngtest.c', 'external/libpng/example.c'                    

--- a/cocos2d/2.0/cocos2d.podspec
+++ b/cocos2d/2.0/cocos2d.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications for iPod Touch, iPhone, iPad and Mac. It is based on the cocos2d design but instead of using python it, uses objective-c.'
   s.homepage    =  'http://www.cocos2d-iphone.org'
   s.author      =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
-  s.source      =  {:git => 'https://github.com/cocos2d/cocos2d-iphone.git', :tag => 'release-2.0'}
+  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone', :tag => 'release-2.0'}
 
   s.source_files = 'cocos2d/**/*.{h,m,c}', 'external/kazmath/src/**/*.{c,h}', 'external/kazmath/include/**/*.{c,h}', 'external/libpng/*.{h,c}'
   s.exclude_files = 'external/libpng/pngtest.c', 'external/libpng/example.c'                    

--- a/cocos2d/2.1-rc0/cocos2d.podspec
+++ b/cocos2d/2.1-rc0/cocos2d.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications for iPod Touch, iPhone, iPad and Mac. It is based on the cocos2d design but instead of using python it, uses objective-c.'
   s.homepage    =  'http://www.cocos2d-iphone.org'
   s.author      =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
-  s.source      =  {:git => 'https://github.com/cocos2d/cocos2d-iphone.git', :tag => 'release-2.1-rc0'}
+  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone', :tag => 'release-2.1-rc0'}
 
   s.source_files = [
     'cocos2d/**/*.{h,m,mm,c}',

--- a/cocos2d/2.1-rc0/cocos2d.podspec
+++ b/cocos2d/2.1-rc0/cocos2d.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications for iPod Touch, iPhone, iPad and Mac. It is based on the cocos2d design but instead of using python it, uses objective-c.'
   s.homepage    =  'http://www.cocos2d-iphone.org'
   s.author      =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
-  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone', :tag => 'release-2.1-rc0'}
+  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone.git', :tag => 'release-2.1-rc0'}
 
   s.source_files = [
     'cocos2d/**/*.{h,m,mm,c}',

--- a/cocos2d/2.1-rc1/cocos2d.podspec
+++ b/cocos2d/2.1-rc1/cocos2d.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications for iPod Touch, iPhone, iPad and Mac. It is based on the cocos2d design but instead of using python it, uses objective-c.'
   s.homepage    =  'http://www.cocos2d-iphone.org'
   s.author      =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
-  s.source      =  {:git => 'https://github.com/cocos2d/cocos2d-iphone.git', :tag => 'release-2.1-rc1'}
+  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone', :tag => 'release-2.1-rc1'}
 
   s.source_files = [
     'cocos2d/**/*.{h,m,mm,c}',

--- a/cocos2d/2.1-rc1/cocos2d.podspec
+++ b/cocos2d/2.1-rc1/cocos2d.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications for iPod Touch, iPhone, iPad and Mac. It is based on the cocos2d design but instead of using python it, uses objective-c.'
   s.homepage    =  'http://www.cocos2d-iphone.org'
   s.author      =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
-  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone', :tag => 'release-2.1-rc1'}
+  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone.git', :tag => 'release-2.1-rc1'}
 
   s.source_files = [
     'cocos2d/**/*.{h,m,mm,c}',

--- a/cocos2d/2.1-rc2/cocos2d.podspec
+++ b/cocos2d/2.1-rc2/cocos2d.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications for iPod Touch, iPhone, iPad and Mac. It is based on the cocos2d design but instead of using python it, uses objective-c.'
   s.homepage    =  'http://www.cocos2d-iphone.org'
   s.author      =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
-  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone', :tag => 'release-2.1-rc2'}
+  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone.git', :tag => 'release-2.1-rc2'}
 
   s.source_files = 'cocos2d/**/*.{h,m,mm,c}', 'CocosDenshion/*.{h,m}',
     'external/libpng/*.{h,c}', 'external/kazmath/src/**/*.{c,h}', 'external/kazmath/include/**/*.{c,h}'

--- a/cocos2d/2.1-rc2/cocos2d.podspec
+++ b/cocos2d/2.1-rc2/cocos2d.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications for iPod Touch, iPhone, iPad and Mac. It is based on the cocos2d design but instead of using python it, uses objective-c.'
   s.homepage    =  'http://www.cocos2d-iphone.org'
   s.author      =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
-  s.source      =  {:git => 'https://github.com/cocos2d/cocos2d-iphone.git', :tag => 'release-2.1-rc2'}
+  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone', :tag => 'release-2.1-rc2'}
 
   s.source_files = 'cocos2d/**/*.{h,m,mm,c}', 'CocosDenshion/*.{h,m}',
     'external/libpng/*.{h,c}', 'external/kazmath/src/**/*.{c,h}', 'external/kazmath/include/**/*.{c,h}'

--- a/cocos2d/2.1/cocos2d.podspec
+++ b/cocos2d/2.1/cocos2d.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications for iPod Touch, iPhone, iPad and Mac. It is based on the cocos2d design but instead of using python it, uses objective-c.'
   s.homepage    =  'http://www.cocos2d-iphone.org'
   s.author      =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
-  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone', :tag => 'release-2.1'}
+  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone.git', :tag => 'release-2.1'}
 
   s.source_files = 'cocos2d/**/*.{h,m,mm,c}', 'external/kazmath/src/**/*.{c,h}', 'external/kazmath/include/**/*.{c,h}', 'external/libpng/*.{h,c}'
   s.exclude_files = 'external/libpng/pngtest.c', 'external/libpng/example.c'

--- a/cocos2d/2.1/cocos2d.podspec
+++ b/cocos2d/2.1/cocos2d.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description =  'cocos2d for iPhone is a framework for building 2D games, demos, and other graphical/interactive applications for iPod Touch, iPhone, iPad and Mac. It is based on the cocos2d design but instead of using python it, uses objective-c.'
   s.homepage    =  'http://www.cocos2d-iphone.org'
   s.author      =  { 'Ricardo Quesada' => 'ricardoquesada@gmail.com', 'Zynga Inc.' => 'https://zynga.com/' }
-  s.source      =  {:git => 'https://github.com/cocos2d/cocos2d-iphone.git', :tag => 'release-2.1'}
+  s.source      =  {:git => 'https://github.com/cocos2d-classic/cocos2d-iphone', :tag => 'release-2.1'}
 
   s.source_files = 'cocos2d/**/*.{h,m,mm,c}', 'external/kazmath/src/**/*.{c,h}', 'external/kazmath/include/**/*.{c,h}', 'external/libpng/*.{h,c}'
   s.exclude_files = 'external/libpng/pngtest.c', 'external/libpng/example.c'


### PR DESCRIPTION
The old cocos2d repository was changed and its history rewritten in order to reduce its size.(http://www.cocos2d-iphone.org/forums/topic/important-read-me-git-users/) 
Only the new 3.x tags were kept, so that makes installing cocos2d via CocoaPods impossible as the specs reference versions <=2.1

Fortunately a copy of the old cocos2d repository was kept at https://github.com/cocos2d-classic/cocos2d-iphone.

This PR modifies all the cocos2s pod specs to point to the cocos2d-classic repository.
