### PR TITLE
add missing settings to CrittercismSDK 4.3.3

### DIFF
--- a/CrittercismSDK/4.3.3/CrittercismSDK.podspec
+++ b/CrittercismSDK/4.3.3/CrittercismSDK.podspec
@@ -8,8 +8,10 @@ Pod::Spec.new do |s|
   s.source = { :http => 'https://app.crittercism.com/images/Crittercism_v4_3_3.zip' }
   s.platform = :ios
   s.source_files = 'CrittercismSDK/*.h'
+  s.resource = 'CrittercismSDK/dsym_upload.sh'
   s.preserve_paths = 'CrittercismSDK/libCrittercism_v4_3_3.a'
   s.library = 'Crittercism_v4_3_3'
   s.xcconfig = { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/CrittercismSDK/CrittercismSDK"' }
+  s.framework = 'SystemConfiguration'
 end
 


### PR DESCRIPTION
After updating CrittercismSDK to 4.3.3, a missing error of dsym_upload.sh occurs

> Pods/CrittercismSDK/CrittercismSDK/dsym_upload.sh: No such file or directory

And comparing with 4.3.2 podspec file, adding these settings would make a go.

Plz test if this workds.
