### PR TITLE
[Fix] ZXing broken subspec inheritance.

### DIFF
--- a/ZXing/2.2/ZXing.podspec
+++ b/ZXing/2.2/ZXing.podspec
@@ -29,6 +29,7 @@ EOS
 
   s.ios.platform                = :ios, '4.3'
   s.ios.deployment_target       = '4.3'
+  s.ios.requires_arc            = false
   s.ios.preserve_paths          = 'iphone/ZXingWidget/Classes/**/*.{h}'
   s.ios.source_files            = 'iphone/ZXingWidget/Classes/**/*.{m,mm}'
   s.ios.compiler_flags          = '-IZXing/cpp/core/src/zxing/', '-IZXing/iphone/ZXingWidget/Classes/'
@@ -37,8 +38,5 @@ EOS
   #  must use xcconfig additional to compiler_flag -I to make this header path also available for the including project
   s.ios.xcconfig                = { 'HEADER_SEARCH_PATHS' => '${PODS_ROOT}/ZXing/cpp/core/src/ ${PODS_ROOT}/ZXing/iphone/ZXingWidget/Classes/**' }
   s.ios.frameworks              = 'AddressBookUI', 'QuartzCore'
-
-  # Keep an 'ios' subspec for backward compatibility with old Podfiles
-  s.subspec 'ios'
 
 end

--- a/ZXing/2.2/ZXing.podspec
+++ b/ZXing/2.2/ZXing.podspec
@@ -1,4 +1,5 @@
 Pod::Spec.new do |s|
+
   s.name                        = "ZXing"
   s.version                     = "2.2"
   s.summary                     = "Multi-format 1D/2D barcode image processing library."
@@ -6,11 +7,12 @@ Pod::Spec.new do |s|
   s.author                      = "ZXing team (http://code.google.com/p/zxing/people/list)"
   s.license                     = { :type => 'Apache License, Version 2.0', :file => 'COPYING' }
   s.source                      = { :svn => "http://zxing.googlecode.com/svn/", :tag => "2.2" }
-
-  s.preserve_paths              = 'cpp/core/src/zxing/**/*.h', 'objc/src/ZXing/*.h', 'cpp/core/src/bigint/*.hh'
   s.source_files                = 'cpp/core/src/zxing/**/*.cpp', 'objc/src/ZXing/*.{m,mm}', 'cpp/core/src/bigint/*.cc'
+  s.preserve_paths              = 'cpp/core/src/zxing/**/*.h', 'objc/src/ZXing/*.h', 'cpp/core/src/bigint/*.hh'
   s.compiler_flags              = '-IZXing/cpp/core/src/ -IZXing/objc/src/'
   s.requires_arc                = false
+  s.libraries                   = 'stdc++', 'iconv'
+  s.frameworks                  = 'AddressBook', 'AudioToolbox', 'AVFoundation', 'CoreGraphics', 'CoreMedia', 'CoreVideo', 'ImageIO'
 
 # workaround for a missing import in objc/src/ZXing/ZXImage.mm
   s.prefix_header_contents      = <<-EOS
@@ -25,21 +27,18 @@ EOS
     'CLANG_CXX_LIBRARY' => 'libstdc++'
   }
 
-  s.libraries                   = 'stdc++', 'iconv'
-  s.frameworks                  = 'AddressBook', 'AudioToolbox', 'AVFoundation', 'CoreGraphics', 'CoreMedia', 'CoreVideo', 'ImageIO'
+  s.ios.platform                = :ios, '4.3'
+  s.ios.deployment_target       = '4.3'
+  s.ios.preserve_paths          = 'iphone/ZXingWidget/Classes/**/*.{h}'
+  s.ios.source_files            = 'iphone/ZXingWidget/Classes/**/*.{m,mm}'
+  s.ios.compiler_flags          = '-IZXing/cpp/core/src/zxing/', '-IZXing/iphone/ZXingWidget/Classes/'
+  # There are two MultiFormatReader.h files, it appears this one is unused
+  s.ios.exclude_files           = 'iphone/ZXingWidget/Classes/MultiFormatReader.h'
+  #  must use xcconfig additional to compiler_flag -I to make this header path also available for the including project
+  s.ios.xcconfig                = { 'HEADER_SEARCH_PATHS' => '${PODS_ROOT}/ZXing/cpp/core/src/ ${PODS_ROOT}/ZXing/iphone/ZXingWidget/Classes/**' }
+  s.ios.frameworks              = 'AddressBookUI', 'QuartzCore'
 
-  s.subspec 'ios' do |ios|
-    ios.platform                = :ios, '4.3'
-    ios.ios.deployment_target   = '4.3'
+  # Keep an 'ios' subspec for backward compatibility with old Podfiles
+  s.subspec 'ios'
 
-    ios.preserve_paths          = 'cpp/core/src/zxing/**/*.h', 'objc/src/ZXing/*.h', 'cpp/core/src/bigint/*.hh'
-    ios.source_files            = 'iphone/ZXingWidget/Classes/**/*.{h,m,mm}'
-    ios.compiler_flags          = '-IZXing/cpp/core/src/zxing/', '-IZXing/iphone/ZXingWidget/Classes/'
-    # There are two MultiFormatReader.h files, it appears this one is unused
-    ios.exclude_files           = 'iphone/ZXingWidget/Classes/MultiFormatReader.h'
-
-#   must use xcconfig additional to compiler_flag -I to make this header path also available for the including project
-    ios.xcconfig                = { 'HEADER_SEARCH_PATHS' => '${PODS_ROOT}/ZXing/cpp/core/src/ ${PODS_ROOT}/ZXing/iphone/ZXingWidget/Classes/**' }
-    ios.frameworks              = 'AddressBookUI', 'QuartzCore'
-  end
 end


### PR DESCRIPTION
Triggered by fixes from #9626 and CocoaPods/CocoaPods#1523, fixed by moving to normal multi-platform support for iOS dependencies, which do inherit from the main spec. This will require users of the `ZXing/ios` subspec to change to just `ZXing`.

Unfortunately it looks like [ZXing for iOS is no longer supported](https://groups.google.com/forum/#!topic/zxing/L2oGZllqwXI), so it may be a losing battle to keep these specs functional.
