### PR TITLE
add UISS iOS 7-compatible version 1.1.1-pdtgct.1

### DIFF
--- a/UISS-iOS7/1.1.1-pdtgct.1/UISS-iOS7.podspec
+++ b/UISS-iOS7/1.1.1-pdtgct.1/UISS-iOS7.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
-  s.name     = 'UISS'
+  s.name     = 'UISS-iOS7'
   s.version  = '1.1.1-pdtgct.1'
 
   s.platform = :ios, '7.0'
   
   s.license  = 'MIT'
   s.summary  = 'UIKit Style Sheets.'
-  s.homepage = 'https://github.com/robertwijas/UISS'
+  s.homepage = 'https://github.com/pdtgct/UISS'
   s.author   = { 'Robert Wijas' => 'https://robertwijas.com' }
   s.description = 'UISS stands for UIKit Style Sheets. UISS is an iOS library that provides you with a convenient way to define the style of your application. UISS is built on top of UIKit UIAppearance proxies.  This version is compatible with iOS 7'  
 

--- a/UISS/1.1.1-pdtgct.1/UISS.podspec
+++ b/UISS/1.1.1-pdtgct.1/UISS.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name     = 'UISS'
+  s.version  = '1.1.1-pdtgct.1'
+
+  s.platform = :ios, '7.0'
+  
+  s.license  = 'MIT'
+  s.summary  = 'UIKit Style Sheets.'
+  s.homepage = 'https://github.com/robertwijas/UISS'
+  s.author   = { 'Robert Wijas' => 'https://robertwijas.com' }
+  s.description = 'UISS stands for UIKit Style Sheets. UISS is an iOS library that provides you with a convenient way to define the style of your application. UISS is built on top of UIKit UIAppearance proxies.  This version is compatible with iOS 7'  
+
+  s.source   = { :git => 'https://github.com/pdtgct/UISS.git', :tag => "#{s.version}" }
+
+  s.source_files = 'Project/UISS'
+  s.resources = 'Project/UISSResources.bundle'
+  s.prefix_header_file = 'Project/UISS/UISS-Prefix.pch'
+
+  s.frameworks = 'Foundation', 'UIKit'
+
+  s.requires_arc = true
+end


### PR DESCRIPTION
Corrects iOS 7 warnings for deprecated style usage, especially for text shadow and shadow offset.
