### PR TITLE
Update Gigya for unofficial versioned source.

### DIFF
--- a/Gigya-iOS-SDK/3.0.1/Gigya-iOS-SDK.podspec
+++ b/Gigya-iOS-SDK/3.0.1/Gigya-iOS-SDK.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name         = "Gigya-iOS-SDK"
+  s.version      = "3.0.1"
+  s.summary      = "The iOS client library provides an Objective-C interface for the Gigya API"
+  s.homepage     = "http://developers.gigya.com/035_Mobile_SDKs/010_iPhone/"
+  s.license      = {
+    :type => 'Copyright',
+    :text => 'Copyright 2013 Gigya'
+  }
+  s.author       = 'Gigya'
+  s.source       = { :http => "https://raw.githubusercontent.com/jshier/GigyaSDK/master/#{s.version}/GigyaSDK.zip" }
+  s.platform     = :ios, '5.0'
+  s.source_files = 'GigyaSDK.framework/Versions/A/Headers/*.h'
+  s.preserve_paths = 'GigyaSDK.framework/*'
+  s.frameworks   = 'GigyaSDK', 'Foundation', 'Security'
+  s.xcconfig     = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/Gigya-iOS-SDK"' }
+  s.requires_arc = false
+end


### PR DESCRIPTION
The linter complains about the homepage not being reachable even though it clearly is. Hopefully Gigya will move to a versioned released scheme soon but until then this seems like the best compromise. Also, I have the zip file downloaded by raw versioned URL instead of tag or anything as I'd like to let users add old versions and just tagging a zip file would be confusing.
