### PR TITLE
STK: added Podspec for v4.4.4

### DIFF
--- a/STK/4.4.4/STK.podspec
+++ b/STK/4.4.4/STK.podspec
@@ -1,14 +1,25 @@
 Pod::Spec.new do |s|
+
   s.name         = "STK"
   s.version      = "4.4.4"
+
   s.summary      = "The Synthesis ToolKit in C++ is a set of open source audio signal processing and algorithmic synthesis classes."
   s.homepage     = "https://ccrma.stanford.edu/software/stk/"
   s.license      = { :type => "MIT" }
   s.authors      = { "Gary Scavone" => "gary@ccrma.stanford.edu", "Perry Cook" => "prc@CS.Princeton.EDU" }
   s.source       = { :git => "https://github.com/thestk/stk.git", :tag => "4.4.4" }
-  s.platform     = :ios, '5.1'
+
+  s.ios.deployment_target = "5.1"
+  s.osx.deployment_target = "10.7"
+
   s.source_files = "src/*.cpp", "include/*.h"
   s.public_header_files = "include/*.h", "include/SKINI.msg", "include/SKINI.tbl"
+
   s.exclude_files = "include/Thread.h", "src/Thread.cpp", "include/Mutex.h", "src/Mutex.cpp", "include/UdpSocket.h", "src/UdpSocket.cpp", "include/Socket.h", "src/Socket.cpp", "include/TcpClient.h", "src/TcpClient.cpp", "include/TcpServer.h", "src/TcpServer.cpp", "include/InetWvIn.h", "src/InetWvIn.cpp", "include/InetWvOut.h", "src/InetWvOut.cpp", "include/RtAudio.h", "src/RtAudio.cpp", "include/RtMidi.h", "src/RtMidi.cpp", "include/RtWvIn.h", "src/RtWvIn.cpp", "include/RtWvOut.h", "src/RtWvOut.cpp", "include/RtError.h"
-  s.resources    = "rawwaves/*.raw"
+
+  s.preserve_path = "README.MD"
+  s.resource_bundle = { "rawwaves" => "rawwaves/*.raw" }
+
+  s.requires_arc = true
+
 end

--- a/STK/4.4.4/STK.podspec
+++ b/STK/4.4.4/STK.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name         = "STK"
+  s.version      = "4.4.4"
+  s.summary      = "The Synthesis ToolKit in C++ is a set of open source audio signal processing and algorithmic synthesis classes."
+  s.homepage     = "https://ccrma.stanford.edu/software/stk/"
+  s.license      = { :type => "MIT" }
+  s.authors      = { "Gary Scavone" => "gary@ccrma.stanford.edu", "Perry Cook" => "prc@CS.Princeton.EDU" }
+  s.source       = { :git => "https://github.com/thestk/stk.git", :tag => "4.4.4" }
+  s.platform     = :ios, '5.1'
+  s.source_files = "src/*.cpp", "include/*.h"
+  s.public_header_files = "include/*.h", "include/SKINI.msg", "include/SKINI.tbl"
+  s.exclude_files = "include/Thread.h", "src/Thread.cpp", "include/Mutex.h", "src/Mutex.cpp", "include/UdpSocket.h", "src/UdpSocket.cpp", "include/Socket.h", "src/Socket.cpp", "include/TcpClient.h", "src/TcpClient.cpp", "include/TcpServer.h", "src/TcpServer.cpp", "include/InetWvIn.h", "src/InetWvIn.cpp", "include/InetWvOut.h", "src/InetWvOut.cpp", "include/RtAudio.h", "src/RtAudio.cpp", "include/RtMidi.h", "src/RtMidi.cpp", "include/RtWvIn.h", "src/RtWvIn.cpp", "include/RtWvOut.h", "src/RtWvOut.cpp", "include/RtError.h"
+  s.resources    = "rawwaves/*.raw"
+end


### PR DESCRIPTION
We've updated our repository and the spec passes lint. The Travis messages are probably referring to an earlier ill-fated pull request I submitted. 
