### PR TITLE
[Update] MDCSwipeToChoose 0.2.0

### DIFF
--- a/MDCSwipeToChoose/0.2.0/MDCSwipeToChoose.podspec
+++ b/MDCSwipeToChoose/0.2.0/MDCSwipeToChoose.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name = 'MDCSwipeToChoose'
+  s.version = '0.2.0'
+  s.summary = 'Swipe to "like" or "dislike" any view, just like Tinder.app. Build a flashcard app, a photo viewer, and more, in minutes, not hours!'
+  s.homepage = 'https://github.com/modocache/MDCSwipeToChoose'
+  s.license = 'MIT'
+  s.author = { 'modocache' => 'modocache@gmail.com' }
+  s.social_media_url = 'https://twitter.com/modocache'
+  s.source = { :git => 'https://github.com/modocache/MDCSwipeToChoose.git', :tag => "v#{s.version}" }
+  s.source_files = 'MDCSwipeToChoose/**/*.{h,m}'
+  s.public_header_files = 'MDCSwipeToChoose/Public/**/*.{h,m}'
+  s.requires_arc = true
+  s.platform = :ios, '7.0'
+  s.framework = 'UIKit'
+end


### PR DESCRIPTION
Swipe to "like" or "dislike" any view, just like Tinder.app. Build a
flashcard app, a photo viewer, and more, in minutes, not hours!

New in v0.2.0: Added the `-mdc_swipe:` method for programmatic swiping.

![](http://cl.ly/image/0M1j1J0E0s3G/MDCSwipeToChoose-v0.2.0.gif)
