### PR TITLE
EDQueue can be used on OSX as well as iOS

### DIFF
--- a/EDQueue/0.7.0/EDQueue.podspec
+++ b/EDQueue/0.7.0/EDQueue.podspec
@@ -1,14 +1,15 @@
 Pod::Spec.new do |s|
-  s.name         = 'EDQueue'
-  s.version      = '0.7.0'
-  s.license      = 'MIT'
-  s.summary      = 'A persistent background job queue for iOS.'
-  s.homepage     = 'https://github.com/thisandagain/queue'
-  s.authors      = {'Andrew Sliwinski' => 'andrewsliwinski@acm.org', 'Francois Lambert' => 'flambert@mirego.com'}
-  s.source       = { :git => 'https://github.com/thisandagain/queue.git', :tag => 'v0.7.0' }
-  s.platform     = :ios, '5.0'
-  s.source_files = 'EDQueue'
-  s.library      = 'sqlite3.0'
-  s.requires_arc = true
+  s.name                  = 'EDQueue'
+  s.version               = '0.7.1'
+  s.license               = 'MIT'
+  s.summary               = 'A persistent background job queue for iOS.'
+  s.homepage              = 'https://github.com/thisandagain/queue'
+  s.authors               = {'Andrew Sliwinski' => 'andrewsliwinski@acm.org', 'Francois Lambert' => 'flambert@mirego.com'}
+  s.source                = { :git => 'https://github.com/thisandagain/queue.git', :tag => 'v0.7.0' }
+  s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.7'
+  s.source_files          = 'EDQueue'
+  s.library               = 'sqlite3.0'
+  s.requires_arc          = true
   s.dependency 'FMDB', '~> 2.0'
 end

--- a/EDQueue/0.7.0/EDQueue.podspec
+++ b/EDQueue/0.7.0/EDQueue.podspec
@@ -1,15 +1,16 @@
 Pod::Spec.new do |s|
-  s.name                  = 'EDQueue'
-  s.version               = '0.7.1'
-  s.license               = 'MIT'
-  s.summary               = 'A persistent background job queue for iOS.'
-  s.homepage              = 'https://github.com/thisandagain/queue'
-  s.authors               = {'Andrew Sliwinski' => 'andrewsliwinski@acm.org', 'Francois Lambert' => 'flambert@mirego.com'}
-  s.source                = { :git => 'https://github.com/thisandagain/queue.git', :tag => 'v0.7.0' }
-  s.ios.deployment_target = '5.0'
-  s.osx.deployment_target = '10.7'
-  s.source_files          = 'EDQueue'
-  s.library               = 'sqlite3.0'
-  s.requires_arc          = true
+  s.name         = 'EDQueue'
+  s.version      = '0.7.0'
+  s.license      = 'MIT'
+  s.summary      = 'A persistent background job queue for iOS.'
+  s.homepage     = 'https://github.com/thisandagain/queue'
+  s.authors      = {'Andrew Sliwinski' => 'andrewsliwinski@acm.org', 'Francois Lambert' => 'flambert@mirego.com'}
+  s.source       = { :git => 'https://github.com/thisandagain/queue.git', :tag => 'v0.7.0' }
+  s.platform     = :ios, '5.0'
+  s.source_files = 'EDQueue'
+  s.library      = 'sqlite3.0'
+  s.requires_arc = true
   s.dependency 'FMDB', '~> 2.0'
 end
+
+ 

--- a/EDQueue/0.7.1/EDQueue.podspec
+++ b/EDQueue/0.7.1/EDQueue.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name                  = 'EDQueue'
+  s.version               = '0.7.1'
+  s.license               = 'MIT'
+  s.summary               = 'A persistent background job queue for iOS.'
+  s.homepage              = 'https://github.com/thisandagain/queue'
+  s.authors               = {'Andrew Sliwinski' => 'andrewsliwinski@acm.org', 'Francois Lambert' => 'flambert@mirego.com'}
+  s.source                = { :git => 'https://github.com/thisandagain/queue.git', :tag => 'v0.7.0' }
+  s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.7'
+  s.source_files          = 'EDQueue'
+  s.library               = 'sqlite3.0'
+  s.requires_arc          = true
+  s.dependency 'FMDB', '~> 2.0'
+end


### PR DESCRIPTION
Changed the pod spec to 0.7.1 to include the OSX development target
