### PR TITLE
Fix Bypass 1.0.1 to include -lstdc++ in xcconfig LDFLAGS.

### DIFF
--- a/Bypass/1.0.1/Bypass.podspec
+++ b/Bypass/1.0.1/Bypass.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.platform = :ios, '6.0'
   s.ios.frameworks = 'Foundation', 'UIKit', 'QuartzCore', 'CoreGraphics', 'CoreText'
   s.ios.requires_arc = true
+  s.xcconfig = { 'OTHER_LDFLAGS' => '-lstdc++' }
   s.compiler_flags = '-stdlib=libc++'
   s.source = {
     :git => 'https://github.com/Uncodin/bypass-ios.git',


### PR DESCRIPTION
I'm not entirely sure what the contribution guidelines are for fixing existing, broken podspecs, but this one needed an additional setting to compile properly into a project, taken from Uncodin/bypass#153.

No change had to be made to the underlying code library (Bypass itself), but as it stands, this podspec is actually broken without this fix.

Is this okay to do to an existing spec? I've got push access but I wanted to check with the team first.
