### PR TITLE
Use official source for Lua

### DIFF
--- a/lua/5.2.1/lua.podspec
+++ b/lua/5.2.1/lua.podspec
@@ -14,7 +14,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 										 LICENSE
 	}
   s.author       = { "The Lua team" => "team@lua.org" }
-  s.source       = { :git => "https://github.com/qmx/lua.git", :tag => "5.2.1" }
+  s.source       = { :http => "http://www.lua.org/ftp/lua-#{s.version}.tar.gz" }
   s.ios.deployment_target = '4.0'
   s.osx.deployment_target = '10.6'
   s.source_files = 'src/'

--- a/lua/5.2.2/lua.podspec
+++ b/lua/5.2.2/lua.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name         = "lua"
+  s.version      = "5.2.2"
+  s.summary      = "The lua language (for embedding)."
+  s.homepage     = "https://github.com/qmx/lua"
+  s.license      = { :type => "MIT",
+										 :text => <<-LICENSE
+Copyright © 1994–2012 Lua.org, PUC-Rio.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+										 LICENSE
+	}
+  s.author       = { "The Lua team" => "team@lua.org" }
+  s.source       = { :http => "http://www.lua.org/ftp/lua-#{s.version}.tar.gz" }
+  s.ios.deployment_target = '4.0'
+  s.osx.deployment_target = '10.6'
+  s.source_files = 'src/'
+  s.requires_arc = false
+end

--- a/lua/5.2.3/lua.podspec
+++ b/lua/5.2.3/lua.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name         = "lua"
+  s.version      = "5.2.3"
+  s.summary      = "The lua language (for embedding)."
+  s.homepage     = "https://github.com/qmx/lua"
+  s.license      = { :type => "MIT",
+										 :text => <<-LICENSE
+Copyright © 1994–2012 Lua.org, PUC-Rio.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+										 LICENSE
+	}
+  s.author       = { "The Lua team" => "team@lua.org" }
+  s.source       = { :http => "http://www.lua.org/ftp/lua-#{s.version}.tar.gz" }
+  s.ios.deployment_target = '4.0'
+  s.osx.deployment_target = '10.6'
+  s.source_files = 'src/'
+  s.requires_arc = false
+end

--- a/lua/5.2.3/lua.podspec
+++ b/lua/5.2.3/lua.podspec
@@ -18,5 +18,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
   s.ios.deployment_target = '4.0'
   s.osx.deployment_target = '10.6'
   s.source_files = 'src/'
+  s.exclude_files = 'src/lua.c', 'src/luac.c'
   s.requires_arc = false
 end


### PR DESCRIPTION
I'm not sure why this wasn't using the official source and instead using a third party git repo. Can someone elaborate on any reasons why that was done?

/cc @Larusso / @qmx
