### PR TITLE
Added iOSContextualMenu

### DIFF
--- a/iOSContextualMenu/1.0.0/iOSContextualMenu.podspec
+++ b/iOSContextualMenu/1.0.0/iOSContextualMenu.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name                    = "iOSContextualMenu"
+  s.version                 = "1.0.0"
+  s.summary                 = "An easy-to-plug-in Long Press Contextual Menu for iOS inspired by Pinterest."
+  s.homepage                = "https://github.com/hectormatos2011/iOSContextualMenu.git"
+  s.license                 = 'MIT'
+  s.author                  = { "Hector Matos" => "hectormatos2011@gmail.com" }
+  s.source                  = { :git => "https://github.com/hectormatos2011/iOSContextualMenu.git", 
+  								:tag => s.version.to_s }
+  s.platform              = :ios, '7.0'
+  s.requires_arc            = true
+  s.source_files            = 'Classes/*.{h,m}'
+end

--- a/iOSContextualMenu/1.0.0/iOSContextualMenu.podspec
+++ b/iOSContextualMenu/1.0.0/iOSContextualMenu.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name                    = "iOSContextualMenu"
   s.version                 = "1.0.0"
-  s.summary                 = "An easy-to-plug-in Long Press Contextual Menu for iOS inspired by Pinterest."
+  s.summary                 = "An easy-to-plug-in Contextual Menu for iOS inspired by Pinterest."
   s.homepage                = "https://github.com/hectormatos2011/iOSContextualMenu.git"
   s.license                 = 'MIT'
   s.author                  = { "Hector Matos" => "hectormatos2011@gmail.com" }


### PR DESCRIPTION
iOSContextualMenu is inspired by Pinterest's Long Press Contextual Menu. This takes it a step further by allowing developers to plug it into to their own app and to allow it to be presented through tap or by default, long press.
