### PR TITLE
[Update] Evernote-SDK-iOS 1.3.1

### DIFF
--- a/Evernote-SDK-iOS/1.3.1/Evernote-SDK-iOS.podspec
+++ b/Evernote-SDK-iOS/1.3.1/Evernote-SDK-iOS.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.libraries = 'xml2'
   s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '"$(SDKROOT)/usr/include/libxml2"' }
 
-  s.dependency 'SSKeychain', '0.2.1'
+  s.dependency 'SSKeychain', '~> 1.2.2'
 end


### PR DESCRIPTION
Now compatible with up-to-date SSKeychain.

Related to https://github.com/evernote/evernote-sdk-ios/pull/97.
