### PR TITLE
Update JGAFImageCache to 2.0.0

### DIFF
--- a/JGAFImageCache/2.0.0/JGAFImageCache.podspec
+++ b/JGAFImageCache/2.0.0/JGAFImageCache.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+    s.name         = 'JGAFImageCache'
+    s.version      = '2.0.0'
+    s.license      = 'MIT'
+    s.summary      = 'A fast reliable image cache for iOS built with NSURLSession.'
+    s.homepage     = 'https://github.com/jaminguy/JGAFImageCache'
+    s.author       = 'Jamin Guy'
+    s.source       = { :git => 'https://github.com/jaminguy/JGAFImageCache.git', :tag => '2.0.0' }
+    s.source_files = '*.[hm]'
+    s.platform     = :ios, '7.0'
+    s.requires_arc = true
+end

--- a/JGAFImageCache/2.0.1/JGAFImageCache.podspec
+++ b/JGAFImageCache/2.0.1/JGAFImageCache.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+    s.name         = 'JGAFImageCache'
+    s.version      = '2.0.1'
+    s.license      = 'MIT'
+    s.summary      = 'A fast reliable image cache for iOS built with NSURLSession.'
+    s.homepage     = 'https://github.com/jaminguy/JGAFImageCache'
+    s.author       = 'Jamin Guy'
+    s.source       = { :git => 'https://github.com/jaminguy/JGAFImageCache.git', :tag => '2.0.1' }
+    s.source_files = '*.[hm]'
+    s.platform     = :ios, '7.0'
+    s.requires_arc = true
+end


### PR DESCRIPTION
Version 2.0.0 removes the AFNetworking dependency in favor of NSURLSession.
