### PR TITLE
PromiseKit requires modules

### DIFF
--- a/PromiseKit/0.9.1/PromiseKit.podspec
+++ b/PromiseKit/0.9.1/PromiseKit.podspec
@@ -7,6 +7,7 @@ Pod::Spec.new do |s|
   s.license = 'MIT'
   s.summary = 'A delightful Promises implementation for iOS.'
   s.requires_arc = true
+  s.compiler_flags = '-fmodules'
 
   s.homepage = 'http://promisekit.org'
   s.social_media_url = 'https://twitter.com/mxcl'


### PR DESCRIPTION
For old projects that have modules off it seems that the default pod targets don't have modules enabled. This hopefully will fix that as I couldn't reproduce it by creating a new xcodeproj.
