### PR TITLE
Bump AFNetworking-RACExtensions to 0.1.4

### DIFF
--- a/AFNetworking-RACExtensions/0.1.4/AFNetworking-RACExtensions.podspec
+++ b/AFNetworking-RACExtensions/0.1.4/AFNetworking-RACExtensions.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name         = "AFNetworking-RACExtensions"
+  s.version      = "0.1.4"
+  s.summary      = "AFNetworking-RACExtensions is a delightful extension to the AFNetworking classes for iOS and Mac OS X."
+  s.homepage     = "https://github.com/CodaFi/AFNetworking-RACExtensions"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author       = { "Robert Widmann" => "devteam.codafi@gmail.com" }
+  s.source       = { :git => "https://github.com/CodaFi/AFNetworking-RACExtensions.git", :tag => "0.1.4" }
+  s.ios.deployment_target = '6.0'
+  s.osx.deployment_target = '10.8'
+  s.source_files = 'ReactiveAFNetworking'
+  s.requires_arc = true
+  s.dependency 'AFNetworking', '~> 2.0'
+  s.dependency 'ReactiveCocoa', '~> 2.0'
+end


### PR DESCRIPTION
Referring to AFNetworking-RACExtensions tag `0.1.4`
