### PR TITLE
LTHMonthYearPickerView 1.3.2

### DIFF
--- a/LTHMonthYearPickerView/1.3.2/LTHMonthYearPickerView.podspec
+++ b/LTHMonthYearPickerView/1.3.2/LTHMonthYearPickerView.podspec
@@ -3,9 +3,7 @@ Pod::Spec.new do |s|
   s.version      = "1.3.2"
   s.summary      = "Simple to use month & year picker view"
   s.homepage     = "https://github.com/rolandleth/LTHMonthYearPickerView"
-  s.screenshots  = 
-      "http://rolandleth.com/assets/monthyearpickerview/Screenshot.png", 
-
+  s.screenshot  = "http://rolandleth.com/assets/monthyearpickerview/Screenshot.png"
   s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }
   s.author       = { "Roland Leth" => "roland@rolandleth.com" }
   s.platform     = :ios, '6.0'

--- a/LTHMonthYearPickerView/1.3.2/LTHMonthYearPickerView.podspec
+++ b/LTHMonthYearPickerView/1.3.2/LTHMonthYearPickerView.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name         = "LTHMonthYearPickerView"
+  s.version      = "1.3.2"
+  s.summary      = "Simple to use month & year picker view"
+  s.homepage     = "https://github.com/rolandleth/LTHMonthYearPickerView"
+  s.screenshots  = 
+      "http://rolandleth.com/assets/monthyearpickerview/Screenshot.png", 
+
+  s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }
+  s.author       = { "Roland Leth" => "roland@rolandleth.com" }
+  s.platform     = :ios, '6.0'
+  s.source       = { 
+    :git => "https://github.com/rolandleth/LTHMonthYearPickerView.git", 
+    :tag => "1.3.2" 
+  }
+  s.source_files  = 'LTHMonthYearPickerView', 'LTHMonthYearPickerView/*.{h,m}'
+  s.requires_arc = true
+end


### PR DESCRIPTION
Changed years array elements from NSNumbers to NSStrings, meaning year
and month now both properly return a NSString type.
Previously year was returning an int type.
