### PR TITLE
TransformerKit 0.5.0

### DIFF
--- a/TransformerKit/0.5.0/TransformerKit.podspec
+++ b/TransformerKit/0.5.0/TransformerKit.podspec
@@ -1,0 +1,50 @@
+Pod::Spec.new do |s|
+  s.name     = 'TransformerKit'
+  s.version  = '0.5.0'
+  s.license  = 'MIT'
+  s.summary  = 'A block-based API for NSValueTransformer, with a growing collection of useful examples.'
+  s.homepage = 'https://github.com/mattt/TransformerKit'
+  s.authors  = { 'Mattt Thompson' => 'm@mattt.me' }
+  s.source   = { :git => 'https://github.com/mattt/TransformerKit.git', :tag => '0.5.0' }
+
+  s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.7'
+
+  s.requires_arc = true
+
+  s.subspec 'Core' do |ss|
+    ss.source_files = 'TransformerKit/NSValueTransformer+TransformerKit.{h,m}'
+  end
+
+  s.subspec 'Cryptography' do |ss|
+    ss.dependency 'TransformerKit/Core'
+    ss.source_files = 'TransformerKit/TTTCryptographyTransformers.{h,m}'
+    ss.osx.frameworks = "CommonCrypto"
+  end
+
+  s.subspec 'Data' do |ss|
+    ss.dependency 'TransformerKit/Core'
+    ss.source_files = 'TransformerKit/TTTDataTransformers.{h,m}'
+    ss.frameworks = "Security"
+  end
+
+  s.subspec 'Date' do |ss|
+    ss.dependency 'TransformerKit/Core'
+    ss.source_files = 'TransformerKit/TTTDateTransformers.{h,m}'
+  end
+
+  s.subspec 'JSON' do |ss|
+    ss.dependency 'TransformerKit/Core'
+    ss.source_files = 'TransformerKit/TTTJSONTransformer.{h,m}'
+  end
+
+  s.subspec 'Image' do |ss|
+    ss.dependency 'TransformerKit/Core'
+    ss.source_files = 'TransformerKit/TTTImageTransformers.{h,m}'
+  end
+
+  s.subspec 'String' do |ss|
+    ss.dependency 'TransformerKit/Core'
+    ss.source_files = 'TransformerKit/TTTStringTransformers.{h,m}'
+  end
+end


### PR DESCRIPTION
It's a copy of the [latest spec in the repo](https://github.com/mattt/TransformerKit/blob/6c6634054f7848d9c095415fd4e08f21181748d6/TransformerKit.podspec), but also I've removed `s.source_files = 'TransformerKit'`. Because of that line all source files were added to the project when you specify `pod 'TransformerKit'` and `pod spec lint` was failing because `Security` framework is needed for `TransformerKit/Data`, but wasn't added as dependency. Looks like now people need to specify what parts (subspecs) of the library do they need. For example in my case `pod 'TransformerKit/String'` works well.

/cc @mattt

P.S. @mattt please let me know if you want me to send a pull request to the TransformerKit's repo with the same spec update. 
