### PR TITLE
Fixes wrong metadata for TAOOverlayHelp podspec

### DIFF
--- a/TAOOverlayHelp/0.1.0/TAOOverlayHelp.podspec
+++ b/TAOOverlayHelp/0.1.0/TAOOverlayHelp.podspec
@@ -17,8 +17,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '7.0'
   s.requires_arc = true
 
-  s.source_files = 'Classes'
-  
-  # s.public_header_files = 'Classes/**/*.h'
-  # s.frameworks = 'QuartzCore'
+  s.source_files = "Classes/*.{h,m}"
+  s.public_header_files = 'Classes/TAOOverlayHelp.h'
+  s.frameworks = 'QuartzCore'
 end


### PR DESCRIPTION
source_files, public_header_files and frameworks settings were accidentally not setup right.
