### PR TITLE
Fixing repository url for UIView-I7ShakeAnimation

### DIFF
--- a/UIView-I7ShakeAnimation/0.1/UIView-I7ShakeAnimation.podspec
+++ b/UIView-I7ShakeAnimation/0.1/UIView-I7ShakeAnimation.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Jonas Schnelli" => "jonas.schnelli@include7.ch" }
   s.platform     = :ios, '5.0'
-  s.source       = { :git => "https://github.com/rudensm/UIView-I7ShakeAnimation.git", :tag => "0.1" }
+  s.source       = { :git => "https://github.com/jonasschnelli/UIView-I7ShakeAnimation.git", :tag => "0.1" }
   s.source_files  = 'UIView+I7ShakeAnimation.{h,m}'
   s.requires_arc = true
 end


### PR DESCRIPTION
Moving to jonasschenlli's podspec as rudensm's repo is not active anymore. The repository now have a tag, and can be used with pod.

https://raw.githubusercontent.com/jonasschnelli/UIView-I7ShakeAnimation/master/UIView-I7ShakeAnimation.podspec
