### PR TITLE
Add libpd

### DIFF
--- a/libpd/0.7.0/libpd.podspec
+++ b/libpd/0.7.0/libpd.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name         = "libpd"
+  s.version      = "0.7.0"
+
+  s.license      = { :type => 'Standard Improved BSD License', :file => 'License.txt' }
+
+  s.summary      = "libpd turns Pd into an embeddable library, so you can use Pd as a sound engine in mobile phone apps, games, web pages, and art projects."
+  s.homepage     = "http://libpd.cc/"
+  s.author       = { "Jasper Blues (spec maintainer only)" => "jasper@appsquick.ly" }
+
+  s.source       = { :git => "https://github.com/libpd/libpd.git", :tag => s.version.to_s }
+  s.source_files = 'cpp/**/*.{hpp,cpp}', 'libpd_wrapper/**/*.{h,c}', 'objc/**/*.{h,m}', 'pure-data/src/**/*.{h,c}'
+
+  s.ios.deployment_target = '5.0'
+  s.requires_arc = false
+
+  s.frameworks = 'Foundation'
+  s.compiler_flags = '-w -DPD -DUSEAPI_DUMMY -DHAVE_LIBDL -DHAVE_UNISTD_H'
+end
+


### PR DESCRIPTION
Add the excellent libpd library. 

Pd (stands for Pure Data) is a visual programming language especially suited to audio and visual signal processing. It creates software models of the real hardware found in a recording studio. Its programs are called 'patches'. 

libpd allows embedding Pd patches in mobile devices. Its is used in for example, the award winning Inception app, by Warner Brothers or the very cool Rj Explorer synth app. 

I'm submitting this Spec on behalf of the Pd team, as they're hardcore C and C++ devs, and don't often get the chance to work with Ruby. 

Issue: https://github.com/libpd/libpd/pull/39
