### PR TITLE
OKSpecHelper 0.7

### DIFF
--- a/OKSpecHelper/0.5/OKSpecHelper.podspec
+++ b/OKSpecHelper/0.5/OKSpecHelper.podspec
@@ -1,0 +1,27 @@
+Pod::Spec.new do |s|
+
+  s.name         = "OKSpecHelper"
+  s.version      = "0.5"
+  s.summary      = "Simple helpers for using Objection framework with Kiwi tests"
+
+  s.description  = <<-DESC
+  Simple helpers for using Objection framework with Kiwi tests.
+                   DESC
+
+  s.homepage     = "https://github.com/garyjohnson/okspechelper"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author             = { "Gary Johnson" => "gary@gjtt.com" }
+  s.social_media_url = "http://twitter.com/GaryGJohnson"
+
+  s.platform     = :ios, '7.0'
+  s.source       = { :git => "https://github.com/garyjohnson/okspechelper.git", :tag => "0.5" }
+
+  s.source_files  = '*.{h,m}'
+  s.public_header_files = '*.h'
+  s.requires_arc = true
+
+  s.framework = 'XCTest', 'Foundation'
+
+  s.dependency 'Kiwi/XCTest'
+
+end

--- a/OKSpecHelper/0.6/OKSpecHelper.podspec
+++ b/OKSpecHelper/0.6/OKSpecHelper.podspec
@@ -1,0 +1,27 @@
+Pod::Spec.new do |s|
+
+  s.name         = "OKSpecHelper"
+  s.version      = "0.6"
+  s.summary      = "Simple helpers for using Objection framework with Kiwi tests"
+
+  s.description  = <<-DESC
+  Simple helpers for using Objection framework with Kiwi tests.
+                   DESC
+
+  s.homepage     = "https://github.com/garyjohnson/okspechelper"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author             = { "Gary Johnson" => "gary@gjtt.com" }
+  s.social_media_url = "http://twitter.com/GaryGJohnson"
+
+  s.platform     = :ios, '7.0'
+  s.source       = { :git => "https://github.com/garyjohnson/okspechelper.git", :tag => "0.6" }
+
+  s.source_files  = '*.{h,m}'
+  s.public_header_files = '*.h'
+  s.requires_arc = true
+
+  s.framework = 'XCTest', 'Foundation'
+
+  s.dependency 'Kiwi/XCTest'
+
+end


### PR DESCRIPTION
0.7 - Suppressing unused warning for people who run tests with warnings treated as errors. Fixing an issue with the way this was done in 0.5.
