### PR TITLE
Change spec name to be consistent with github page

### DIFF
--- a/UIImageView-Gravatar/1.0/UIImageView-Gravatar.podspec
+++ b/UIImageView-Gravatar/1.0/UIImageView-Gravatar.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name         = "UIImageView-Gravatar"
+  s.name         = "UIImageView+Gravatar"
   s.version      = "1.0"
   s.summary      = "A simple and quickly put together UIImageView subclass for dealing with http://gravatar.com images."
   s.homepage     = "https://github.com/rexfinn/UIImageView-Gravatar"


### PR DESCRIPTION
The previous name UIImageView-Gravatar was not what is listed in the UIImageView+Gravatar github readme or podspec and prevented the pod from downloading.
Changed UIImageView-Gravatar to UIImageView+Gravatar.
