### PR TITLE
Update OpenSSL.podspec

### DIFF
--- a/OpenSSL/1.0.1/OpenSSL.podspec
+++ b/OpenSSL/1.0.1/OpenSSL.podspec
@@ -48,7 +48,7 @@ Pod::Spec.new do |s|
       echo "Building openssl-${VERSION} for ${PLATFORM} ${SDKVERSION} ${ARCH}"
       echo "Please stand by..."
 
-      export CC="/Applications/Xcode.app/Contents/Developer/usr/bin/gcc -arch ${ARCH} -miphoneos-version-min=${SDKVERSION}"
+      export CC="${DEVELOPER}/usr/bin/gcc -arch ${ARCH} -miphoneos-version-min=${SDKVERSION}"
       mkdir -p "${CURRENTPATH}/bin/${PLATFORM}${SDKVERSION}-${ARCH}.sdk"
       LOG="${CURRENTPATH}/bin/${PLATFORM}${SDKVERSION}-${ARCH}.sdk/build-openssl-${VERSION}.log"
 


### PR DESCRIPTION
Bug fix: Build fails if Xcode is in unexpected location. 

Updated to use variable path instead of using hardcoded path to gcc in Xcode app directory.

Script expects Xcode to be located in Applications/Xcode.app. Some development environments require multiple versions of Xcode, which requires the app to use a non-standard path, e.g. Applications/Xcode5.1.1.app.
