### PR TITLE
Adding the ArtisanSDK (www.useartisan.com) folder to the main Specs repo.

### DIFF
--- a/ArtisanSDK/2.0.10/ArtisanSDK.podspec
+++ b/ArtisanSDK/2.0.10/ArtisanSDK.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = "ArtisanSDK"
+  s.version      = '2.0.10'
+  s.summary      = "Artisan is the first all-in-one platform for mobile app analytics, A/B testing, and personalization."
+  s.homepage     = "http://www.useartisan.com"
+  s.license      = { :type => 'Proprietary', :file => 'FILE_LICENSE' }
+  s.author       = { "Artisan" => "support@useartisan.com" }
+  s.source       = { :git => "https://github.com/ArtisanMobile/ArtisanSDK.git", :tag => '2.0.10.1' }
+  s.platform     = :ios, '6.0'
+  s.resources    = 'ArtisanSDK.bundle'
+  s.frameworks   = 'ArtisanSDK', 'CoreData', 'CFNetwork', 'Security', 'QuartzCore', 'SystemConfiguration', 'CoreLocation'
+  s.library      = 'z'
+  s.requires_arc = true
+  s.preserve_path = '*.framework'
+  s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)"', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/ArtisanSDK"', 'OTHER_LDFLAGS' => '-ObjC, -lz'}
+end

--- a/ArtisanSDK/2.0.11/ArtisanSDK.podspec
+++ b/ArtisanSDK/2.0.11/ArtisanSDK.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = "ArtisanSDK"
+  s.version      = '2.0.11'
+  s.summary      = "Artisan is the first all-in-one platform for mobile app analytics, A/B testing, and personalization."
+  s.homepage     = "http://www.useartisan.com"
+  s.license      = { :type => 'Proprietary', :file => 'FILE_LICENSE' }
+  s.author       = { "Artisan" => "support@useartisan.com" }
+  s.source       = { :git => "https://github.com/ArtisanMobile/ArtisanSDK.git", :tag => '2.0.11' }
+  s.platform     = :ios, '6.0'
+  s.resources    = 'ArtisanSDK.bundle'
+  s.frameworks   = 'ArtisanSDK', 'CoreData', 'CFNetwork', 'Security', 'QuartzCore', 'SystemConfiguration', 'CoreLocation'
+  s.library      = 'z'
+  s.requires_arc = true
+  s.preserve_path = '*.framework'
+  s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)"', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/ArtisanSDK"', 'OTHER_LDFLAGS' => '-ObjC, -lz'}
+end

--- a/ArtisanSDK/2.0.12/ArtisanSDK.podspec
+++ b/ArtisanSDK/2.0.12/ArtisanSDK.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name         = "ArtisanSDK"
+  s.version      = '2.0.12'
+  s.summary      = "Artisan is the first all-in-one platform for mobile app analytics, A/B testing, and personalization."
+  s.homepage     = "http://useartisan.com"
+  s.license      = { :type => 'Proprietary', :file => 'FILE_LICENSE' }
+  s.author       = { "Artisan" => "support@useartisan.com" }
+  s.source       = { :git => "https://github.com/ArtisanMobile/ArtisanSDK.git", :tag => '2.0.12' }
+  s.platform     = :ios, '6.0'
+  s.resources    = 'ArtisanSDK.bundle'
+  s.frameworks   = 'ArtisanSDK', 'CoreData', 'CFNetwork', 'Security', 'QuartzCore', 'SystemConfiguration', 'CoreLocation'
+  s.library      = 'z'
+  s.requires_arc = true
+  s.documentation_url = 'http://docs.useartisan.com/user-guide/'
+  s.preserve_path = '*.framework'
+  s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)"', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/ArtisanSDK"', 'OTHER_LDFLAGS' => '-ObjC, -lz'}
+end

--- a/ArtisanSDK/2.0.13/ArtisanSDK.podspec
+++ b/ArtisanSDK/2.0.13/ArtisanSDK.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name         = "ArtisanSDK"
+  s.version      = "2.0.13"
+  s.summary      = "Artisan is the first all-in-one platform for mobile app analytics, A/B testing, and personalization."
+  s.homepage     = "http://useartisan.com"
+  s.license      = { :type => 'Proprietary', :file => 'FILE_LICENSE' }
+  s.author       = { "Artisan" => "support@useartisan.com" }
+  s.source       = { :git => "https://github.com/ArtisanMobile/ArtisanSDK.git", :tag => '2.0.13' }
+  s.platform     = :ios, '6.0'
+  s.resources    = 'ArtisanSDK.bundle'
+  s.frameworks   = 'ArtisanSDK', 'CoreData', 'CFNetwork', 'Security', 'QuartzCore', 'SystemConfiguration', 'CoreLocation'
+  s.library      = 'z'
+  s.requires_arc = true
+  s.documentation_url = 'http://docs.useartisan.com/user-guide/'
+  s.preserve_path = '*.framework'
+  s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)"', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/ArtisanSDK"', 'OTHER_LDFLAGS' => '-ObjC, -lz'}
+end

--- a/ArtisanSDK/2.0.14/ArtisanSDK.podspec
+++ b/ArtisanSDK/2.0.14/ArtisanSDK.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name         = "ArtisanSDK"
+  s.version      = '2.0.14'
+  s.summary      = "Artisan is the first all-in-one platform for mobile app analytics, A/B testing, and personalization."
+  s.homepage     = "http://useartisan.com"
+  s.license      = { :type => 'Proprietary', :file => 'FILE_LICENSE' }
+  s.author       = { "Artisan" => "support@useartisan.com" }
+  s.source       = { :git => "https://github.com/ArtisanMobile/ArtisanSDK.git", :tag => '2.0.14' }
+  s.source_files = 'ArtisanSDK.framework/Headers/*.h'
+  s.platform     = :ios, '6.0'
+  s.resources    = 'ArtisanSDK.bundle'
+  s.frameworks   = 'ArtisanSDK', 'CoreData', 'CFNetwork', 'Security', 'QuartzCore', 'SystemConfiguration', 'CoreLocation'
+  s.library      = 'z'
+  s.requires_arc = true
+  s.documentation_url = 'http://docs.useartisan.com/user-guide/'
+  s.preserve_path = 'ArtisanSDK.framework'
+  s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)"', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/ArtisanSDK"', 'OTHER_LDFLAGS' => '-ObjC, -lz'}
+end

--- a/ArtisanSDK/2.0.15/ArtisanSDK.podspec
+++ b/ArtisanSDK/2.0.15/ArtisanSDK.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name         = "ArtisanSDK"
+  s.version      = '2.0.15'
+  s.summary      = "Artisan is the first all-in-one platform for mobile app analytics, A/B testing, and personalization."
+  s.homepage     = "http://useartisan.com"
+  s.license      = { :type => 'Proprietary', :file => 'FILE_LICENSE' }
+  s.author       = { "Artisan" => "support@useartisan.com" }
+  s.source       = { :git => "https://github.com/ArtisanMobile/ArtisanSDK.git", :tag => '2.0.15' }
+  s.source_files = 'ArtisanSDK.framework/Headers/*.h'
+  s.platform     = :ios, '6.0'
+  s.resources    = 'ArtisanSDK.bundle'
+  s.frameworks   = 'ArtisanSDK', 'CoreData', 'CFNetwork', 'Security', 'QuartzCore', 'SystemConfiguration', 'CoreLocation'
+  s.library      = 'z'
+  s.requires_arc = true
+  s.documentation_url = 'http://docs.useartisan.com/user-guide/'
+  s.preserve_path = 'ArtisanSDK.framework'
+  s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)"', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/ArtisanSDK"', 'OTHER_LDFLAGS' => '-ObjC, -lz'}
+end

--- a/ArtisanSDK/2.0.16/ArtisanSDK.podspec
+++ b/ArtisanSDK/2.0.16/ArtisanSDK.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name         = "ArtisanSDK"
+  s.version      = '2.0.16'
+  s.summary      = "Artisan is the first all-in-one platform for mobile app analytics, A/B testing, and personalization."
+  s.homepage     = "http://useartisan.com"
+  s.license      = { :type => 'Proprietary', :file => 'FILE_LICENSE' }
+  s.author       = { "Artisan" => "support@useartisan.com" }
+  s.source       = { :git => "https://github.com/ArtisanMobile/ArtisanSDK.git", :tag => '2.0.16' }
+  s.source_files = 'ArtisanSDK.framework/Headers/*.h'
+  s.platform     = :ios, '6.0'
+  s.resources    = 'ArtisanSDK.bundle'
+  s.frameworks   = 'ArtisanSDK', 'CoreData', 'CFNetwork', 'Security', 'QuartzCore', 'SystemConfiguration', 'CoreLocation'
+  s.library      = 'z'
+  s.requires_arc = true
+  s.documentation_url = 'http://docs.useartisan.com/user-guide/'
+  s.preserve_path = 'ArtisanSDK.framework'
+  s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)"', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/ArtisanSDK"', 'OTHER_LDFLAGS' => '-ObjC, -lz'}
+end

--- a/ArtisanSDK/2.0.17/ArtisanSDK.podspec
+++ b/ArtisanSDK/2.0.17/ArtisanSDK.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name         = "ArtisanSDK"
+  s.version      = '2.0.17'
+  s.summary      = "Artisan is the first all-in-one platform for mobile app analytics, A/B testing, and personalization."
+  s.homepage     = "http://useartisan.com"
+  s.license      = { :type => 'Proprietary', :file => 'FILE_LICENSE' }
+  s.author       = { "Artisan" => "support@useartisan.com" }
+  s.source       = { :git => "https://github.com/ArtisanMobile/ArtisanSDK.git", :tag => '2.0.17' }
+  s.source_files = 'ArtisanSDK.framework/Headers/*.h'
+  s.platform     = :ios, '6.0'
+  s.resources    = 'ArtisanSDK.bundle'
+  s.frameworks   = 'ArtisanSDK', 'CoreData', 'CFNetwork', 'Security', 'QuartzCore', 'SystemConfiguration', 'CoreLocation'
+  s.library      = 'z'
+  s.requires_arc = true
+  s.documentation_url = 'http://docs.useartisan.com/user-guide/'
+  s.preserve_path = 'ArtisanSDK.framework'
+  s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)"', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/ArtisanSDK"', 'OTHER_LDFLAGS' => '-ObjC, -lz'}
+end

--- a/ArtisanSDK/2.0.18/ArtisanSDK.podspec
+++ b/ArtisanSDK/2.0.18/ArtisanSDK.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name         = "ArtisanSDK"
+  s.version      = '2.0.18'
+  s.summary      = "Artisan is the first all-in-one platform for mobile app analytics, A/B testing, and personalization."
+  s.homepage     = "http://useartisan.com"
+  s.license      = { :type => 'Proprietary', :file => 'FILE_LICENSE' }
+  s.author       = { "Artisan" => "support@useartisan.com" }
+  s.source       = { :git => "https://github.com/ArtisanMobile/ArtisanSDK.git", :tag => '2.0.18' }
+  s.source_files = 'ArtisanSDK.framework/Headers/*.h'
+  s.platform     = :ios, '6.0'
+  s.resources    = 'ArtisanSDK.bundle'
+  s.frameworks   = 'ArtisanSDK', 'CoreData', 'CFNetwork', 'Security', 'QuartzCore', 'SystemConfiguration', 'CoreLocation'
+  s.library      = 'z'
+  s.requires_arc = true
+  s.documentation_url = 'http://docs.useartisan.com/user-guide/'
+  s.preserve_path = 'ArtisanSDK.framework'
+  s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)"', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/ArtisanSDK"', 'OTHER_LDFLAGS' => '-ObjC, -lz'}
+end

--- a/ArtisanSDK/2.0.9/ArtisanSDK.podspec
+++ b/ArtisanSDK/2.0.9/ArtisanSDK.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = "ArtisanSDK"
+  s.version      = '2.0.9'
+  s.summary      = "Artisan is the first all-in-one platform for mobile app analytics, A/B testing, and personalization."
+  s.homepage     = "http://www.useartisan.com"
+  s.license      = { :type => 'Proprietary', :file => 'FILE_LICENSE' }
+  s.author       = { "Kevin Jenkins" => "kevin.jenkins@useartisan.com" }
+  s.source       = { :git => "https://github.com/ArtisanMobile/ArtisanSDK.git", :tag => '2.0.9' }
+  s.platform     = :ios, '5.0'
+  s.resources    = 'ArtisanSDK.bundle', 'ArtisanAnalytics.bundle'
+  s.frameworks   = 'ArtisanSDK', 'CoreData', 'CFNetwork', 'Security', 'QuartzCore', 'SystemConfiguration', 'CoreLocation'
+  s.library      = 'z'
+  s.requires_arc = true
+  s.preserve_path = '*.framework'
+  s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)"', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/ArtisanSDK"', 'OTHER_LDFLAGS' => '-ObjC, -lz'}
+end

--- a/ArtisanSDK/2.1.0/ArtisanSDK.podspec
+++ b/ArtisanSDK/2.1.0/ArtisanSDK.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name         = "ArtisanSDK"
+  s.version      = '2.1.0'
+  s.summary      = "Artisan is the first all-in-one platform for mobile app analytics, A/B testing, and personalization."
+  s.homepage     = "http://useartisan.com"
+  s.license      = { :type => 'Proprietary', :file => 'FILE_LICENSE' }
+  s.author       = { "Artisan" => "support@useartisan.com" }
+  s.source       = { :git => "https://github.com/ArtisanMobile/ArtisanSDK.git", :tag => '2.1.0' }
+  s.source_files = 'ArtisanSDK.framework/Headers/*.h'
+  s.platform     = :ios, '6.0'
+  s.resources    = 'ArtisanSDK.bundle'
+  s.frameworks   = 'ArtisanSDK', 'CoreData', 'CFNetwork', 'Security', 'QuartzCore', 'SystemConfiguration', 'CoreLocation'
+  s.library      = 'z'
+  s.requires_arc = true
+  s.documentation_url = 'http://docs.useartisan.com/user-guide/'
+  s.preserve_path = 'ArtisanSDK.framework'
+  s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)"', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/ArtisanSDK"', 'OTHER_LDFLAGS' => '-ObjC, -lz'}
+end

--- a/ArtisanSDK/2.1.1/ArtisanSDK.podspec
+++ b/ArtisanSDK/2.1.1/ArtisanSDK.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name         = "ArtisanSDK"
+  s.version      = '2.1.1'
+  s.summary      = "Artisan is the first all-in-one platform for mobile app analytics, A/B testing, and personalization."
+  s.homepage     = "http://useartisan.com"
+  s.license      = { :type => 'Proprietary', :file => 'FILE_LICENSE' }
+  s.author       = { "Artisan" => "support@useartisan.com" }
+  s.source       = { :git => "https://github.com/ArtisanMobile/ArtisanSDK.git", :tag => '2.1.1' }
+  s.source_files = 'ArtisanSDK.framework/Headers/*.h'
+  s.platform     = :ios, '6.0'
+  s.resources    = 'ArtisanSDK.bundle'
+  s.frameworks   = 'ArtisanSDK', 'CoreData', 'CFNetwork', 'Security', 'QuartzCore', 'SystemConfiguration', 'CoreLocation'
+  s.library      = 'z'
+  s.requires_arc = true
+  s.documentation_url = 'http://docs.useartisan.com/user-guide/'
+  s.preserve_path = 'ArtisanSDK.framework'
+  s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)"', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/ArtisanSDK"', 'OTHER_LDFLAGS' => '-ObjC, -lz'}
+end


### PR DESCRIPTION
Artisan is a Mobile Experience Management SDK that native iOS apps can use to collect analytics, perform full-native A/B tests, and create personalized app experiences without writing any code.

More info is available at www.useartisan.com.

Cheers, and let us know if we need to do anything to get this fully ready to merge!
