### PR TITLE
Fixing Google Mobile Ads SDK 6.9.2 Podspec

### DIFF
--- a/Google-Mobile-Ads-SDK/6.9.2/Google-Mobile-Ads-SDK.podspec
+++ b/Google-Mobile-Ads-SDK/6.9.2/Google-Mobile-Ads-SDK.podspec
@@ -15,10 +15,10 @@ Pod::Spec.new do |s|
   }
 
   s.author = "Google Inc."
-  s.platform = :ios, "4.3"
-  s.source = { :http => "http://dl.google.com/googleadmobadssdk/googlemobileadssdkios.zip" }
+  s.platform = :ios, "5.0"
+  s.source = { :http => "http://dl.google.com/googleadmobadssdk/googlemobileadssdkios-6.9.2.zip" }
 
-  s.source_files = "GoogleAdMobAdsSdkiOS-6.9.2/*.h", "GoogleAdMobAdsSdkiOS-6.9.2/Add-ons/Search/*.h", "GoogleMobileAdsSdkiOS-6.9.2/Add-ons/Mediation/*.h", "GoogleMobileAdsSdkiOS-6.9.2/Add-ons/DoubleClick/*.h"
+  s.source_files = "GoogleMobileAdsSdkiOS-6.9.2/*.h", "GoogleMobileAdsSdkiOS-6.9.2/Add-ons/Search/*.h", "GoogleMobileAdsSdkiOS-6.9.2/Add-ons/Mediation/*.h", "GoogleMobileAdsSdkiOS-6.9.2/Add-ons/DoubleClick/*.h"
   s.preserve_paths = "GoogleMobileAdsSdkiOS-6.9.2"
   s.vendored_libraries = "GoogleMobileAdsSdkiOS-6.9.2/libGoogleAdMobAds.a"
   
@@ -27,5 +27,5 @@ Pod::Spec.new do |s|
   s.xcconfig = {
     "OTHER_LDFLAGS" => "-ObjC"
   }
-  s.requires_arc = false
+  s.requires_arc = true
 end


### PR DESCRIPTION
Some changes were made with 6.9.2 that weren't accounted for with the previous submit:
- The version specific zip should be used.
- Directory name for source files changed.
- SDK now only supports iOS 5.0 and up.
- Not sure how "requires_arc" is interpreted, but this SDK now uses ARC's zeroing weak references so I bumped this to yes.
