### PR TITLE
Updates iOSContextualMenu for Rotation Bug

### DIFF
--- a/iOSContextualMenu/1.1.2/iOSContextualMenu.podspec
+++ b/iOSContextualMenu/1.1.2/iOSContextualMenu.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name                    = "iOSContextualMenu"
+  s.version                 = "1.1.2"
+  s.summary                 = "An easy-to-plug-in Contextual Menu for iOS inspired by Pinterest."
+  s.homepage                = "https://github.com/hectormatos2011/iOSContextualMenu.git"
+  s.license                 = 'MIT'
+  s.author                  = { "Hector Matos" => "hectormatos2011@gmail.com" }
+  s.source                  = { :git => "https://github.com/hectormatos2011/iOSContextualMenu.git", 
+  								:tag => s.version.to_s }
+  s.platform              = :ios, '7.0'
+  s.requires_arc            = true
+  s.source_files            = 'Classes/*.{h,m}'
+end


### PR DESCRIPTION
There was a weird issue with UIWindow where UIWindow does not apply rotation transformations to any other subview other than the highest subview. This caused the secondary subview (iOSContextualMenu instances) to not have rotation for iPads. This fixes that by moving the iOSContextualMenu as a subview to [[[[UIApplication sharedApplication] delegate] window] rootViewController]'s view.
