### PR TITLE
Fix PromiseKit/CoreLocation subspec

### DIFF
--- a/PromiseKit/0.9.6/PromiseKit.podspec
+++ b/PromiseKit/0.9.6/PromiseKit.podspec
@@ -23,6 +23,11 @@ Pod::Spec.new do |s|
     ss.frameworks = 'Foundation'
   end
 
+  s.subspec 'private' do |ss|
+    ss.source_files = 'Private/PMKManualReference.m'
+    ss.preserve_paths = preserved
+  end
+
   s.subspec 'Foundation' do |ss|
     ss.dependency 'PromiseKit/base'
     ss.source_files = 'PromiseKit+Foundation.{h,m}'
@@ -43,6 +48,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'CoreLocation' do |ss|
     ss.dependency 'PromiseKit/base'
+    ss.dependency 'PromiseKit/private'
     ss.source_files = 'PromiseKit+CoreLocation.{h,m}'
     ss.xcconfig = { "GCC_PREPROCESSOR_DEFINITIONS" => "$(inherited) PMK_CORELOCATION=1" }
     ss.frameworks = 'CoreLocation'


### PR DESCRIPTION
A file wasn’t getting compiled into the subspec which was causing it to crash when used at runtime.

Apologies for the update to this spec.
