### PR TITLE
Drop RPBorderlessSegmentedControl deployment target to 10.8

### DIFF
--- a/RPBorderlessSegmentedControl/1.0.1/RPBorderlessSegmentedControl.podspec
+++ b/RPBorderlessSegmentedControl/1.0.1/RPBorderlessSegmentedControl.podspec
@@ -8,8 +8,7 @@ Pod::Spec.new do |s|
   s.author           = { "Brandon Evans" => "brandon.evans@robotsandpencils.com" }
   s.source           = { :git => "https://github.com/RobotsAndPencils/RPBorderlessSegmentedControl.git", :tag => s.version.to_s }
 
-  s.platform     = :osx, '10.9'
-  s.osx.deployment_target = '10.9'
+  s.platform     = :osx, '10.8'
   s.requires_arc = true
 
   s.source_files = 'Classes', 'Categories'


### PR DESCRIPTION
There's no source changes that have been made to the repo, just the podspec and moving the current 1.0.1 tag up one commit.
