### PR TITLE
Update QBImagePickerController 2.1 podspec

### DIFF
--- a/QBImagePickerController/2.1/QBImagePickerController.podspec
+++ b/QBImagePickerController/2.1/QBImagePickerController.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/questbeat/QBImagePickerController"
   s.license      = 'MIT'
   s.author       = { "questbeat" => "questbeat@gmail.com" }
-  s.platform     = :ios, '6.1'
+  s.platform     = :ios, '6.0'
   s.frameworks   = 'AssetsLibrary'
   s.source       = { :git => "https://github.com/questbeat/QBImagePickerController.git", :tag => "v2.1" }
   s.source_files = 'QBImagePickerController', 'QBImagePickerController/**/*.{h,m}'


### PR DESCRIPTION
QBImagePickerController 2.1 supports iOS 6.0
