### PR TITLE
Add GoogleTagManager v3.06

### DIFF
--- a/Specs/GoogleTagManager/3.06/GoogleTagManager.podspec.json
+++ b/Specs/GoogleTagManager/3.06/GoogleTagManager.podspec.json
@@ -1,0 +1,33 @@
+{
+  "name": "GoogleTagManager",
+  "version": "3.06",
+  "summary": "Google Tag Manager SDK.",
+  "description": "Google Tag Manager enables developers to change configuration values in their mobile applications using the Google Tag Manager interface without having to rebuild and resubmit application binaries to app marketplaces.",
+  "homepage": "http://developers.google.com/tag-manager/ios",
+  "license": {
+    "type": "Copyright",
+    "text": "Copyright 2013 Google, Inc. All rights reserved.\n"
+  },
+  "authors": "Google Inc.",
+  "source": {
+    "http": "http://dl.google.com/googleanalyticsservices/GoogleAnalyticsServicesiOS_3.06.zip",
+    "flatten": true
+  },
+  "platforms": {
+    "ios": null
+  },
+  "frameworks": [
+    "CFNetwork",
+    "CoreData",
+    "SystemConfiguration",
+    "AdSupport"
+  ],
+  "source_files": "GoogleTagManager/Library/*.h",
+  "preserve_paths": "libGoogleAnalyticsServices.a",
+  "libraries": "GoogleAnalyticsServices",
+  "xcconfig": {
+    "OTHER_LDFLAGS": "-ObjC",
+    "LIBRARY_SEARCH_PATHS": "\"$(PODS_ROOT)/GoogleTagManager\""
+  },
+  "requires_arc": false
+}


### PR DESCRIPTION
The current latest version (3.02) does not have an x86_64 slice in the .a while this new version does.
