### PR TITLE
Fix xcode warning

### DIFF
--- a/Specs/GoogleAds-IMA-iOS-SDK-For-AdMob/3.0.beta.5/GoogleAds-IMA-iOS-SDK-For-AdMob.podspec.json
+++ b/Specs/GoogleAds-IMA-iOS-SDK-For-AdMob/3.0.beta.5/GoogleAds-IMA-iOS-SDK-For-AdMob.podspec.json
@@ -16,7 +16,7 @@
     "http": "https://dl.google.com/in-stream/google_sdk/ios/beta/googleimasdk3-ios-3.0.b5.zip",
     "flatten": true
   },
-  "source_files": "*.{h,a}",
+  "source_files": "*.h",
   "preserve_paths": "libGoogleIMA3ForAdMob.a",
   "libraries": "GoogleIMA3ForAdMob",
   "exclude_files": "libGoogleIMA3.a",


### PR DESCRIPTION
warning: no rule to process file
'Pods/GoogleAds-IMA-iOS-SDK-For-AdMob/libGoogleIMA3ForAdMob.a'
of type archive.ar for architecture arm64
