### PR TITLE
Change Google Cast version to match latest release 2.2.1

### DIFF
--- a/Specs/google-cast-sdk/2.2.1/google-cast-sdk.podspec.json
+++ b/Specs/google-cast-sdk/2.2.1/google-cast-sdk.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cast-sdk",
-  "version": "2.1.0",
+  "version": "2.2.1",
   "license": {
     "type": "Commercial",
     "text": "https://developers.google.com/terms/"
@@ -10,16 +10,16 @@
   "homepage": "https://developers.google.com/cast/",
   "authors": "Google, Inc.",
   "source": {
-    "http": "https://developers.google.com/cast/downloads/GoogleCastFramework-2.1.0-Release.zip"
+    "http": "https://developers.google.com/cast/downloads/GoogleCastFramework-2.2.1-Release.zip"
   },
   "platforms": {
-    "ios": "6.0"
+    "ios": "5.0"
   },
-  "source_files": "GoogleCastFramework-2.1.0-Release/GoogleCast.framework/Versions/A/Headers/*.h",
-  "preserve_paths": "GoogleCastFramework-2.1.0-Release/GoogleCast.framework",
+  "source_files": "GoogleCastFramework-2.2.1-Release/GoogleCast.framework/Versions/A/Headers/*.h",
+  "preserve_paths": "GoogleCastFramework-2.2.1-Release/GoogleCast.framework",
   "frameworks": "GoogleCast",
   "xcconfig": {
-    "FRAMEWORK_SEARCH_PATHS": "$(PODS_ROOT)/google-cast-sdk/GoogleCastFramework-2.1.0-Release",
+    "FRAMEWORK_SEARCH_PATHS": "$(PODS_ROOT)/google-cast-sdk/GoogleCastFramework-2.2.1-Release",
     "OTHER_LDFLAGS": "-framework GoogleCast"
   },
   "requires_arc": false


### PR DESCRIPTION
Remove 2.1.0 since it it no longer publicly available for download

Also changed iOS version to 5.0, since Cast SDK supports it
