### PR TITLE
change DeployGateSDK wrong source url

### DIFF
--- a/Specs/DeployGateSDK/1.0.0/DeployGateSDK.podspec.json
+++ b/Specs/DeployGateSDK/1.0.0/DeployGateSDK.podspec.json
@@ -9,7 +9,7 @@
   },
   "authors": "DeployGate",
   "source": {
-    "http": "https://stg.deploygate.com/client/deploygatesdkforios.zip"
+    "http": "https://deploygate.com/client/deploygatesdkforios.zip"
   },
   "platforms": {
     "ios": "6.0"


### PR DESCRIPTION
I'm Kazuhiro Hayashi, owner of this Spec.

I've assigned the wrong location of the source.
It was the test server, so I'd like to change the correct location.
Could you merge this revision?
