### PR TITLE
Update M13Checkbox.podspec.json

### DIFF
--- a/Specs/M13Checkbox/1.1.0/M13Checkbox.podspec.json
+++ b/Specs/M13Checkbox/1.1.0/M13Checkbox.podspec.json
@@ -11,7 +11,7 @@
     "Brandon McQuilkin": "marxon13@yahoo.com"
   },
   "platforms": {
-    "ios": "7.0"
+    "ios": "6.0"
   },
   "source": {
     "git": "https://github.com/Marxon13/M13Checkbox.git",


### PR DESCRIPTION
- Now supports iOS 6.0 as per https://github.com/Marxon13/M13Checkbox/blob/master/M13Checkbox.podspec
