### PR TITLE
[Fix] Corrected changed Dropbox-Sync-API-SDK download URL

### DIFF
--- a/Specs/Dropbox-Sync-API-SDK/2.1.2/Dropbox-Sync-API-SDK.podspec.json
+++ b/Specs/Dropbox-Sync-API-SDK/2.1.2/Dropbox-Sync-API-SDK.podspec.json
@@ -9,7 +9,7 @@
   },
   "authors": "Dropbox",
   "source": {
-    "http": "https://www.dropbox.com/developers/downloads/sdks/datastore/ios/dropbox-ios-sync-sdk-2.1.2.zip"
+    "http": "https://dl.dropboxusercontent.com/s/ahbxb6wivxsywex/dropbox-ios-sync-sdk-2.1.2.zip"
   },
   "platforms": {
     "ios": null


### PR DESCRIPTION
Dropbox changed the URL for which to download the Dropbox-Sync-API-SDK 2.1.2 and this pull request updates the Spec to use the new location.
