### PR TITLE
Add MessageDisplayKit.podspec 0.2.1

### DIFF
--- a/MessageDisplayKit/0.2.1/MessageDisplayKit.podspec
+++ b/MessageDisplayKit/0.2.1/MessageDisplayKit.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name         = "MessageDisplayKit"
+  s.version      = "0.2.1"
+  s.summary      = "A messages UI for iPhone and iPad,You can send txt, voice, image,video,emotion .etc messages. like WeChat App."
+  s.homepage     = "https://github.com/xhzengAIB/MessageDisplayKit"
+  s.license      = "MIT"
+  s.authors      = { "xhzengAIB" => "xhzengAIB@gmail.com" }
+  s.source       = { :git => "https://github.com/xhzengAIB/MessageDisplayKit.git", :tag => "v0.2.1" }
+  s.frameworks   = 'Foundation', 'CoreGraphics', 'UIKit', 'MobileCoreServices', 'AVFoundation', 'CoreLocation', 'MediaPlayer', 'CoreMedia', 'CoreText', 'AudioTollbox'
+  s.platform     = :ios, '6.0'
+  s.source_files = 'MessageDisplayKit/Classes/**/*.{h,m}'
+  s.resources    = 'MessageDisplayKit/Resources/*'
+  s.requires_arc = true
+end

--- a/MessageDisplayKit/0.2/MessageDisplayKit.podspec
+++ b/MessageDisplayKit/0.2/MessageDisplayKit.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name         = "MessageDisplayKit"
+  s.version      = "0.2"
+  s.summary      = "A messages UI for iPhone and iPad,You can send txt, voice, image,video,emotion .etc messages. like WeChat App."
+  s.homepage     = "https://github.com/xhzengAIB/MessageDisplayKit"
+  s.license      = "MIT"
+  s.authors      = { "xhzengAIB" => "xhzengAIB@gmail.com" }
+  s.source       = { :git => "https://github.com/xhzengAIB/MessageDisplayKit.git", :tag => "v0.2" }
+  s.frameworks   = 'Foundation', 'CoreGraphics', 'UIKit', 'MobileCoreServices', 'AVFoundation', 'CoreLocation', 'MediaPlayer'
+  s.platform     = :ios, '6.0'
+  s.source_files = 'MessageDisplayKit/Classes/**/*.{h,m}'
+  s.resources    = 'MessageDisplayKit/Resources/*'
+  s.requires_arc = true
+end

--- a/MessageDisplayKit/0.2/MessageDisplayKit.podspec
+++ b/MessageDisplayKit/0.2/MessageDisplayKit.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license      = "MIT"
   s.authors      = { "xhzengAIB" => "xhzengAIB@gmail.com" }
   s.source       = { :git => "https://github.com/xhzengAIB/MessageDisplayKit.git", :tag => "v0.2" }
-  s.frameworks   = 'Foundation', 'CoreGraphics', 'UIKit', 'MobileCoreServices', 'AVFoundation', 'CoreLocation', 'MediaPlayer'
+  s.frameworks   = 'Foundation', 'CoreGraphics', 'UIKit', 'MobileCoreServices', 'AVFoundation', 'CoreLocation', 'MediaPlayer', 'CoreMedia', 'CoreText', 'AudioTollbox'
   s.platform     = :ios, '6.0'
   s.source_files = 'MessageDisplayKit/Classes/**/*.{h,m}'
   s.resources    = 'MessageDisplayKit/Resources/*'

--- a/PathCover/0.1.3/PathCover.podspec
+++ b/PathCover/0.1.3/PathCover.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s| 
+  s.name         = "PathCover"
+  s.version      = "0.1.3"
+  s.summary      = "PathCover is pull down refresh and a parallax top view with real time blur effect to any UITableView, inspired by Path for iOS."
+  s.homepage     = "https://github.com/JackTeam/PathCover"
+  s.license      = "MIT"
+  s.authors      = { "xhzengAIB" => "xhzengAIB@gmail.com" }
+  s.source       = { :git => "https://github.com/JackTeam/PathCover.git", :tag => "v0.1.3" }
+  s.frameworks   = 'Foundation', 'CoreGraphics', 'UIKit', 'AudioToolbox', 'Accelerate', 'QuartzCore'
+  s.platform     = :ios, '5.0'
+  s.source_files = 'PathCover'
+  s.resources    = 'PathCover/Resources/*'
+  s.requires_arc = true
+end


### PR DESCRIPTION
JackiMac:0.2.1 JackMacbook$ pod trunk push MessageDisplayKit.podspec
Validating podspec
 -> MessageDisplayKit (0.2.1)

――― MARKDOWN TEMPLATE ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
### Report
- What did you do?
- What did you expect to happen?
- What happened instead?
### Stack

```
   CocoaPods : 0.33.1
        Ruby : ruby 1.8.7 (2012-02-08 patchlevel 358) [universal-darwin12.0]
    RubyGems : 1.3.6
        Host : Mac OS X 10.8.4 (12E55)
       Xcode : 5.1.1 (5B1008)
Ruby lib dir : /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib
Repositories : master - https://github.com/CocoaPods/Specs.git @ c459ea804d41990811d8cb957819383a1e3dff36
```
### Error

```
SocketError - getaddrinfo: nodename nor servname provided, or not known
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/net/http.rb:560:in `initialize'
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/net/http.rb:560:in `open'
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/net/http.rb:560:in `connect'
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/timeout.rb:53:in `timeout'
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/timeout.rb:101:in `timeout'
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/net/http.rb:560:in `connect'
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/net/http.rb:553:in `do_start'
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/net/http.rb:542:in `start'
/Library/Ruby/Gems/1.8/gems/nap-0.7.0/lib/rest/request.rb:187:in `perform'
/Library/Ruby/Gems/1.8/gems/nap-0.7.0/lib/rest/request.rb:199:in `perform'
/Library/Ruby/Gems/1.8/gems/nap-0.7.0/lib/rest.rb:100:in `post'
/Library/Ruby/Gems/1.8/gems/cocoapods-trunk-0.1.1/lib/pod/command/trunk.rb:327:in `send'
/Library/Ruby/Gems/1.8/gems/cocoapods-trunk-0.1.1/lib/pod/command/trunk.rb:327:in `create_request'
/Library/Ruby/Gems/1.8/gems/cocoapods-trunk-0.1.1/lib/pod/command/trunk.rb:310:in `request_url'
/Library/Ruby/Gems/1.8/gems/cocoapods-trunk-0.1.1/lib/pod/command/trunk.rb:318:in `request_path'
/Library/Ruby/Gems/1.8/gems/cocoapods-trunk-0.1.1/lib/pod/command/trunk.rb:265:in `run'
/Library/Ruby/Gems/1.8/gems/claide-0.6.1/lib/claide/command.rb:281:in `run'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.33.1/lib/cocoapods/command.rb:48:in `run'
/Library/Ruby/Gems/1.8/gems/cocoapods-0.33.1/bin/pod:33
/usr/bin/pod:19:in `load'
/usr/bin/pod:19
```

――― TEMPLATE END ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

[!] Oh no, an error occurred.

Search for existing github issues similar to yours:
https://github.com/CocoaPods/CocoaPods/search?q=getaddrinfo%3A+nodename+nor+servname+provided%2C+or+not+known&type=Issues

If none exists, create a ticket, with the template displayed above, on:
https://github.com/CocoaPods/CocoaPods/issues/new

Don't forget to anonymize any private data!
