### PR TITLE
Patch to fix compiler warning.

### DIFF
--- a/Specs/AFNetworking-RACExtensions/0.1.2/AFNetworking-RACExtensions.podspec.json
+++ b/Specs/AFNetworking-RACExtensions/0.1.2/AFNetworking-RACExtensions.podspec.json
@@ -32,5 +32,5 @@
       "2.0"
     ]
   },
-  "prefix_header_contents": #import <SystemConfiguration/SystemConfiguration.h>\n #import <MobileCoreServices/MobileCoreServices.h>\n"
+  "prefix_header_contents": "#import <SystemConfiguration/SystemConfiguration.h>\n #import <MobileCoreServices/MobileCoreServices.h>\n"
 }

--- a/Specs/AFNetworking-RACExtensions/0.1.2/AFNetworking-RACExtensions.podspec.json
+++ b/Specs/AFNetworking-RACExtensions/0.1.2/AFNetworking-RACExtensions.podspec.json
@@ -32,5 +32,5 @@
       "2.0"
     ]
   },
-  "prefix_header_contents": "#import <Availability.h>\n\n#if __IPHONE_OS_VERSION_MIN_REQUIRED\n #import <SystemConfiguration/SystemConfiguration.h>\n #import <MobileCoreServices/MobileCoreServices.h>\n #import <Security/Security.h>\n#else\n #import <SystemConfiguration/SystemConfiguration.h>\n #import <CoreServices/CoreServices.h>\n #import <Security/Security.h>\n#endif\n"
+  "prefix_header_contents": #import <SystemConfiguration/SystemConfiguration.h>\n #import <MobileCoreServices/MobileCoreServices.h>\n"
 }

--- a/Specs/AFNetworking-RACExtensions/0.1.2/AFNetworking-RACExtensions.podspec.json
+++ b/Specs/AFNetworking-RACExtensions/0.1.2/AFNetworking-RACExtensions.podspec.json
@@ -18,6 +18,10 @@
     "ios": "5.0",
     "osx": "10.7"
   },
+  "frameworks": [
+    "MobileCoreServices",
+    "SystemConfiguration"
+  ],
   "source_files": "ReactiveAFNetworking",
   "requires_arc": true,
   "dependencies": {
@@ -27,5 +31,6 @@
     "ReactiveCocoa": [
       "2.0"
     ]
-  }
+  },
+  "prefix_header_contents": "#import <Availability.h>\n\n#if __IPHONE_OS_VERSION_MIN_REQUIRED\n #import <SystemConfiguration/SystemConfiguration.h>\n #import <MobileCoreServices/MobileCoreServices.h>\n #import <Security/Security.h>\n#else\n #import <SystemConfiguration/SystemConfiguration.h>\n #import <CoreServices/CoreServices.h>\n #import <Security/Security.h>\n#endif\n"
 }


### PR DESCRIPTION
Link MobileCoreServices and SystemConfiguration frameworks, and include them into prefix.pch file to fix compile-time #warning.
