### PR TITLE
[Fix] add post_install-hook-free LibComponentLogging specs and prepare for lcl_configure

### DIFF
--- a/Specs/LibComponentLogging-Core/1.1.4/LibComponentLogging-Core.podspec.json
+++ b/Specs/LibComponentLogging-Core/1.1.4/LibComponentLogging-Core.podspec.json
@@ -12,7 +12,15 @@
   "license": "MIT",
   "summary": "Logging library which provides log levels, log components, and pluggable logging back-ends.",
   "description": "LibComponentLogging is a small logging library for Objective-C on Mac OS X and iOS which provides log levels, log components, and pluggable logging back-ends, e.g. writing log messages to a file, or sending them to the system log.",
-  "source_files": "lcl*.{h,m}",
+  "prepare_command": "echo '{\"name\": \"Core\", \"type\": \"core\", \"main_header\": \"lcl.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "lcl*.{h,m}"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
   "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  "xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/..\""
+  }
 }

--- a/Specs/LibComponentLogging-Core/1.1.5/LibComponentLogging-Core.podspec.json
+++ b/Specs/LibComponentLogging-Core/1.1.5/LibComponentLogging-Core.podspec.json
@@ -12,7 +12,15 @@
   "license": "MIT",
   "summary": "Logging library which provides log levels, log components, and pluggable logging back-ends.",
   "description": "LibComponentLogging is a small logging library for Objective-C on Mac OS X and iOS which provides log levels, log components, and pluggable logging back-ends, e.g. writing log messages to a file, or sending them to the system log.",
-  "source_files": "lcl*.{h,m}",
+  "prepare_command": "echo '{\"name\": \"Core\", \"type\": \"core\", \"main_header\": \"lcl.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "lcl*.{h,m}"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
   "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  "xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/..\""
+  }
 }

--- a/Specs/LibComponentLogging-Core/1.1.6/LibComponentLogging-Core.podspec.json
+++ b/Specs/LibComponentLogging-Core/1.1.6/LibComponentLogging-Core.podspec.json
@@ -12,7 +12,15 @@
   "license": "MIT",
   "summary": "Logging library which provides log levels, log components, and pluggable logging back-ends.",
   "description": "LibComponentLogging is a small logging library for Objective-C on Mac OS X and iOS which provides log levels, log components, and pluggable logging back-ends, e.g. writing log messages to a file, or sending them to the system log.",
-  "source_files": "lcl*.{h,m}",
+  "prepare_command": "echo '{\"name\": \"Core\", \"type\": \"core\", \"main_header\": \"lcl.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "lcl*.{h,m}"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
   "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  "xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/..\""
+  }
 }

--- a/Specs/LibComponentLogging-Core/1.2.1/LibComponentLogging-Core.podspec.json
+++ b/Specs/LibComponentLogging-Core/1.2.1/LibComponentLogging-Core.podspec.json
@@ -12,7 +12,15 @@
   "license": "MIT",
   "summary": "Logging library which provides log levels, log components, and pluggable logging back-ends.",
   "description": "LibComponentLogging is a small logging library for Objective-C on Mac OS X and iOS which provides log levels, log components, and pluggable logging back-ends, e.g. writing log messages to a file, or sending them to the system log.",
-  "source_files": "lcl*.{h,m}",
+  "prepare_command": "echo '{\"name\": \"Core\", \"type\": \"core\", \"main_header\": \"lcl.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "lcl*.{h,m}"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
   "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  "xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/..\""
+  }
 }

--- a/Specs/LibComponentLogging-Core/1.2.2/LibComponentLogging-Core.podspec.json
+++ b/Specs/LibComponentLogging-Core/1.2.2/LibComponentLogging-Core.podspec.json
@@ -12,7 +12,15 @@
   "license": "MIT",
   "summary": "Logging library which provides log levels, log components, and pluggable logging back-ends.",
   "description": "LibComponentLogging is a small logging library for Objective-C on Mac OS X and iOS which provides log levels, log components, and pluggable logging back-ends, e.g. writing log messages to a file, or sending them to the system log.",
-  "source_files": "lcl*.{h,m}",
+  "prepare_command": "echo '{\"name\": \"Core\", \"type\": \"core\", \"main_header\": \"lcl.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "lcl*.{h,m}"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
   "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  "xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/..\""
+  }
 }

--- a/Specs/LibComponentLogging-Core/1.3.1/LibComponentLogging-Core.podspec.json
+++ b/Specs/LibComponentLogging-Core/1.3.1/LibComponentLogging-Core.podspec.json
@@ -12,7 +12,15 @@
   "license": "MIT",
   "summary": "Logging library which provides log levels, log components, and pluggable logging back-ends.",
   "description": "LibComponentLogging is a small logging library for Objective-C on Mac OS X and iOS which provides log levels, log components, and pluggable logging back-ends, e.g. writing log messages to a file, or sending them to the system log.",
-  "source_files": "lcl*.{h,m}",
+  "prepare_command": "echo '{\"name\": \"Core\", \"type\": \"core\", \"main_header\": \"lcl.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "lcl*.{h,m}"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
   "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  "xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/..\""
+  }
 }

--- a/Specs/LibComponentLogging-Core/1.3.3/LibComponentLogging-Core.podspec.json
+++ b/Specs/LibComponentLogging-Core/1.3.3/LibComponentLogging-Core.podspec.json
@@ -1,9 +1,9 @@
 {
   "name": "LibComponentLogging-Core",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "source": {
     "git": "https://github.com/aharren/LibComponentLogging-Core.git",
-    "tag": "1.3.2"
+    "tag": "1.3.3"
   },
   "homepage": "http://0xc0.de/LibComponentLogging",
   "authors": {

--- a/Specs/LibComponentLogging-Crashlytics/1.0.0/LibComponentLogging-Crashlytics.podspec.json
+++ b/Specs/LibComponentLogging-Crashlytics/1.0.0/LibComponentLogging-Crashlytics.podspec.json
@@ -12,12 +12,17 @@
   "license": "MIT",
   "summary": "LibComponentLogging logging back-end for Crashlytics.",
   "description": "LibComponentLogging-Crashlytics is a logging back-end for LibComponentLogging which redirects log messages to Crashlytics' logging subsystem.",
-  "source_files": "LCLCrashlyticsLog*.{h,m}",
+  "prepare_command": "echo '{\"name\": \"Crashlytics\", \"type\": \"logger\", \"main_header\": \"LCLCrashlyticsLog.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "LCLCrashlyticsLog*.{h,m}"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
+  "requires_arc": false,
   "dependencies": {
     "LibComponentLogging-Core": [
       ">= 1.3.1"
     ]
-  },
-  "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  }
 }

--- a/Specs/LibComponentLogging-LogFile/1.1.5/LibComponentLogging-LogFile.podspec.json
+++ b/Specs/LibComponentLogging-LogFile/1.1.5/LibComponentLogging-LogFile.podspec.json
@@ -12,12 +12,20 @@
   "license": "MIT",
   "summary": "LibComponentLogging logging back-end which writes log messages to an application-specific log file.",
   "description": "LibComponentLogging-LogFile is a logging back-end for LibComponentLogging which writes log messages to an application-specific log file.",
-  "source_files": "LCLLogFile*.{h,m}",
+  "prepare_command": "echo '{\"name\": \"LogFile\", \"type\": \"logger\", \"main_header\": \"LCLLogFile.h\", \"config_template\": \"LCLLogFileConfig.template.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "LCLLogFile*.{h,m}"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
+  "requires_arc": false,
+  "xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/..\""
+  },
   "dependencies": {
     "LibComponentLogging-Core": [
       ">= 1.1.6"
     ]
-  },
-  "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  }
 }

--- a/Specs/LibComponentLogging-LogFile/1.2.1/LibComponentLogging-LogFile.podspec.json
+++ b/Specs/LibComponentLogging-LogFile/1.2.1/LibComponentLogging-LogFile.podspec.json
@@ -12,12 +12,20 @@
   "license": "MIT",
   "summary": "LibComponentLogging logging back-end which writes log messages to an application-specific log file.",
   "description": "LibComponentLogging-LogFile is a logging back-end for LibComponentLogging which writes log messages to an application-specific log file.",
-  "source_files": "LCLLogFile*.{h,m}",
+  "prepare_command": "echo '{\"name\": \"LogFile\", \"type\": \"logger\", \"main_header\": \"LCLLogFile.h\", \"config_template\": \"LCLLogFileConfig.template.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "LCLLogFile*.{h,m}"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
+  "requires_arc": false,
+  "xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/..\""
+  },
   "dependencies": {
     "LibComponentLogging-Core": [
       ">= 1.3.1"
     ]
-  },
-  "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  }
 }

--- a/Specs/LibComponentLogging-LogFile/1.2.2/LibComponentLogging-LogFile.podspec.json
+++ b/Specs/LibComponentLogging-LogFile/1.2.2/LibComponentLogging-LogFile.podspec.json
@@ -12,12 +12,20 @@
   "license": "MIT",
   "summary": "LibComponentLogging logging back-end which writes log messages to an application-specific log file.",
   "description": "LibComponentLogging-LogFile is a logging back-end for LibComponentLogging which writes log messages to an application-specific log file.",
-  "source_files": "LCLLogFile*.{h,m}",
+  "prepare_command": "echo '{\"name\": \"LogFile\", \"type\": \"logger\", \"main_header\": \"LCLLogFile.h\", \"config_template\": \"LCLLogFileConfig.template.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "LCLLogFile*.{h,m}"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
+  "requires_arc": false,
+  "xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/..\""
+  },
   "dependencies": {
     "LibComponentLogging-Core": [
       ">= 1.3.1"
     ]
-  },
-  "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  }
 }

--- a/Specs/LibComponentLogging-NSLog/1.0.2/LibComponentLogging-NSLog.podspec.json
+++ b/Specs/LibComponentLogging-NSLog/1.0.2/LibComponentLogging-NSLog.podspec.json
@@ -12,12 +12,17 @@
   "license": "MIT",
   "summary": "LibComponentLogging logging back-end which redirects logging to NSLog.",
   "description": "LibComponentLogging-NSLog is a very simple logging back-end for LibComponentLogging which redirects log messages to NSLog, but adds information about the log level, the log component, and the log statement's location (file name and line number).",
-  "source_files": "LCLNSLog*.{h,m}",
+  "prepare_command": "echo '{\"name\": \"NSLog\", \"type\": \"logger\", \"main_header\": \"LCLNSLog.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "LCLNSLog*.{h,m}"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
+  "requires_arc": false,
   "dependencies": {
     "LibComponentLogging-Core": [
       ">= 1.1.4"
     ]
-  },
-  "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  }
 }

--- a/Specs/LibComponentLogging-NSLog/1.0.4/LibComponentLogging-NSLog.podspec.json
+++ b/Specs/LibComponentLogging-NSLog/1.0.4/LibComponentLogging-NSLog.podspec.json
@@ -12,12 +12,17 @@
   "license": "MIT",
   "summary": "LibComponentLogging logging back-end which redirects logging to NSLog.",
   "description": "LibComponentLogging-NSLog is a very simple logging back-end for LibComponentLogging which redirects log messages to NSLog, but adds information about the log level, the log component, and the log statement's location (file name and line number).",
-  "source_files": "LCLNSLog*.{h,m}",
+  "prepare_command": "echo '{\"name\": \"NSLog\", \"type\": \"logger\", \"main_header\": \"LCLNSLog.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "LCLNSLog*.{h,m}"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
+  "requires_arc": false,
   "dependencies": {
     "LibComponentLogging-Core": [
       ">= 1.1.6"
     ]
-  },
-  "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  }
 }

--- a/Specs/LibComponentLogging-NSLog/1.1.1/LibComponentLogging-NSLog.podspec.json
+++ b/Specs/LibComponentLogging-NSLog/1.1.1/LibComponentLogging-NSLog.podspec.json
@@ -1,9 +1,9 @@
 {
   "name": "LibComponentLogging-NSLog",
-  "version": "1.0.3",
+  "version": "1.1.1",
   "source": {
     "git": "https://github.com/aharren/LibComponentLogging-NSLog.git",
-    "tag": "1.0.3"
+    "tag": "1.1.1"
   },
   "homepage": "http://0xc0.de/LibComponentLogging",
   "authors": {
@@ -22,7 +22,7 @@
   "requires_arc": false,
   "dependencies": {
     "LibComponentLogging-Core": [
-      ">= 1.1.5"
+      ">= 1.3.1"
     ]
   }
 }

--- a/Specs/LibComponentLogging-NSLogger/1.0.4/LibComponentLogging-NSLogger.podspec.json
+++ b/Specs/LibComponentLogging-NSLogger/1.0.4/LibComponentLogging-NSLogger.podspec.json
@@ -12,15 +12,23 @@
   "license": "MIT",
   "summary": "LibComponentLogging logging back-end for Florent Pillet's NSLogger client.",
   "description": "LibComponentLogging-NSLogger is a logging back-end for LibComponentLogging which integrates the logging client from Florent Pillet's NSLogger project. See http://github.com/fpillet/NSLogger for details about NSLogger.",
-  "source_files": "LCLNSLogger*.{h,m}",
+  "prepare_command": "echo '{\"name\": \"NSLogger\", \"type\": \"logger\", \"main_header\": \"LCLNSLogger.h\", \"config_template\": \"LCLNSLoggerConfig.template.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "LCLNSLogger*.{h,m}"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
+  "requires_arc": false,
+  "xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/..\""
+  },
   "dependencies": {
     "LibComponentLogging-Core": [
       ">= 1.1.6"
     ],
     "NSLogger": [
-
+      ">= 1.2"
     ]
-  },
-  "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  }
 }

--- a/Specs/LibComponentLogging-SystemLog/1.1.4/LibComponentLogging-SystemLog.podspec.json
+++ b/Specs/LibComponentLogging-SystemLog/1.1.4/LibComponentLogging-SystemLog.podspec.json
@@ -12,12 +12,20 @@
   "license": "MIT",
   "summary": "LibComponentLogging logging back-end which sends log messages to the Apple System Log facility (ASL).",
   "description": "LibComponentLogging-SystemLog is a logging back-end for LibComponentLogging which send log messages to the Apple System Log facility (ASL).",
-  "source_files": "LCLSystemLog*.{h,m}",
+  "prepare_command": "echo '{\"name\": \"SystemLog\", \"type\": \"logger\", \"main_header\": \"LCLSystemLog.h\", \"config_template\": \"LCLSystemLogConfig.template.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "LCLSystemLog*.{h,m}"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
+  "requires_arc": false,
+  "xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/..\""
+  },
   "dependencies": {
     "LibComponentLogging-Core": [
       ">= 1.1.6"
     ]
-  },
-  "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  }
 }

--- a/Specs/LibComponentLogging-SystemLog/1.2.1/LibComponentLogging-SystemLog.podspec.json
+++ b/Specs/LibComponentLogging-SystemLog/1.2.1/LibComponentLogging-SystemLog.podspec.json
@@ -12,12 +12,20 @@
   "license": "MIT",
   "summary": "LibComponentLogging logging back-end which sends log messages to the Apple System Log facility (ASL).",
   "description": "LibComponentLogging-SystemLog is a logging back-end for LibComponentLogging which send log messages to the Apple System Log facility (ASL).",
-  "source_files": "LCLSystemLog*.{h,m}",
+  "prepare_command": "echo '{\"name\": \"SystemLog\", \"type\": \"logger\", \"main_header\": \"LCLSystemLog.h\", \"config_template\": \"LCLSystemLogConfig.template.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "LCLSystemLog*.{h,m}"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
+  "requires_arc": false,
+  "xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/..\""
+  },
   "dependencies": {
     "LibComponentLogging-Core": [
       ">= 1.3.1"
     ]
-  },
-  "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  }
 }

--- a/Specs/LibComponentLogging-SystemLog/1.2.2/LibComponentLogging-SystemLog.podspec.json
+++ b/Specs/LibComponentLogging-SystemLog/1.2.2/LibComponentLogging-SystemLog.podspec.json
@@ -12,12 +12,20 @@
   "license": "MIT",
   "summary": "LibComponentLogging logging back-end which sends log messages to the Apple System Log facility (ASL).",
   "description": "LibComponentLogging-SystemLog is a logging back-end for LibComponentLogging which send log messages to the Apple System Log facility (ASL).",
-  "source_files": "LCLSystemLog*.{h,m}",
+  "prepare_command": "echo '{\"name\": \"SystemLog\", \"type\": \"logger\", \"main_header\": \"LCLSystemLog.h\", \"config_template\": \"LCLSystemLogConfig.template.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "LCLSystemLog*.{h,m}"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
+  "requires_arc": false,
+  "xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/..\""
+  },
   "dependencies": {
     "LibComponentLogging-Core": [
       ">= 1.3.1"
     ]
-  },
-  "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  }
 }

--- a/Specs/LibComponentLogging-UserDefaults/1.0.3/LibComponentLogging-UserDefaults.podspec.json
+++ b/Specs/LibComponentLogging-UserDefaults/1.0.3/LibComponentLogging-UserDefaults.podspec.json
@@ -12,12 +12,20 @@
   "license": "MIT",
   "summary": "A LibComponentLogging extension which stores/restores log level settings to/from the user defaults.",
   "description": "LibComponentLogging-UserDefaults is an extension for LibComponentLogging which stores/restores log level settings to/from the user defaults.",
-  "source_files": "LCLUserDefaults*.{h,m}",
+  "prepare_command": "echo '{\"name\": \"UserDefaults\", \"type\": \"extension\", \"main_header\": \"LCLUserDefaults.h\", \"config_template\": \"LCLUserDefaultsConfig.template.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "LCLUserDefaults*.{h,m}"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
+  "requires_arc": false,
+  "xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/..\""
+  },
   "dependencies": {
     "LibComponentLogging-Core": [
       ">= 1.1.6"
     ]
-  },
-  "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  }
 }

--- a/Specs/LibComponentLogging-pods/0.0.1/LibComponentLogging-pods.podspec.json
+++ b/Specs/LibComponentLogging-pods/0.0.1/LibComponentLogging-pods.podspec.json
@@ -3,28 +3,24 @@
   "version": "0.0.1",
   "source": {
     "git": "https://github.com/aharren/LibComponentLogging-pods.git",
-    "tag": "0.0.1"
+    "tag": "0.0.1",
+    "submodules" : true
   },
   "homepage": "http://0xc0.de/LibComponentLogging",
   "authors": {
     "Arne Harren": "ah@0xc0.de"
   },
-  "license": {
-    "type": "MIT",
-    "text": "\nCopyright (c) 2012 Arne Harren <ah@0xc0.de>\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE.\n\n"
-  },
-  "summary": "LibComponentLogging auto-configuration for CocoaPods.",
-  "description": "LibComponentLogging-pods provides a configuration mechanism for LibComponentLogging and CocoaPods which automatically configures logging back-ends and extensions based on your project's CocoaPods pod file.",
-  "source_files": "lcl_pods.h",
+  "license": "MIT",
+  "summary": "LibComponentLogging configuration for CocoaPods.",
+  "description": "LibComponentLogging-pods provides a configuration mechanism for LibComponentLogging and CocoaPods which configures logging back-ends and extensions based on your project's CocoaPods Podfile file.",
+  "source_files": [
+  ],
+  "preserve_paths": [
+    "*"
+  ],
+  "requires_arc": false,
   "dependencies": {
     "LibComponentLogging-Core": [
-
     ]
-  },
-  "xcconfig": {
-    "PODS_PUBLIC_HEADERS_SEARCH_PATHS": "\"${PODS_ROOT}/LibComponentLogging-pods\"",
-    "PODS_BUILD_HEADERS_SEARCH_PATHS": "\"${PODS_ROOT}/LibComponentLogging-pods\""
-  },
-  "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  }
 }

--- a/Specs/LibComponentLogging-qlog/1.0.3/LibComponentLogging-qlog.podspec.json
+++ b/Specs/LibComponentLogging-qlog/1.0.3/LibComponentLogging-qlog.podspec.json
@@ -12,12 +12,17 @@
   "license": "MIT",
   "summary": "A set of quick logging macros for LibComponentLogging.",
   "description": "qlog is a small header file which defines a short logging macro for every log level of LibComponentLogging, e.g. qlerror() for error messages and qltrace() for trace messages. Additionally, all logging macros take the current log component from the ql_component preprocessor define which can be (re)defined in your application at a file-level, section-based, or global scope.",
-  "source_files": "qlog.h",
+  "prepare_command": "echo '{\"name\": \"qlog\", \"type\": \"extension\", \"main_header\": \"qlog.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "qlog.h"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
+  "requires_arc": false,
   "dependencies": {
     "LibComponentLogging-Core": [
       ">= 1.1.6"
     ]
-  },
-  "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  }
 }

--- a/Specs/LibComponentLogging-qlog/1.1.1/LibComponentLogging-qlog.podspec.json
+++ b/Specs/LibComponentLogging-qlog/1.1.1/LibComponentLogging-qlog.podspec.json
@@ -12,12 +12,17 @@
   "license": "MIT",
   "summary": "A set of quick logging macros for LibComponentLogging.",
   "description": "qlog is a small header file which defines a short logging macro for every log level of LibComponentLogging, e.g. qlerror() for error messages and qltrace() for trace messages. Additionally, all logging macros take the current log component from the ql_component preprocessor define which can be (re)defined in your application at a file-level, section-based, or global scope.",
-  "source_files": "qlog.h",
+  "prepare_command": "echo '{\"name\": \"qlog\", \"type\": \"extension\", \"main_header\": \"qlog.h\"}' > pod.lcl_configure",
+  "source_files": [
+    "qlog.h"
+  ],
+  "preserve_paths": [
+    "*.lcl_configure"
+  ],
+  "requires_arc": false,
   "dependencies": {
     "LibComponentLogging-Core": [
       ">= 1.2.1"
     ]
-  },
-  "requires_arc": false,
-  "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1"
+  }
 }


### PR DESCRIPTION
Merge specs from https://github.com/aharren/LibComponentLogging-CocoaPods-Specs to fix LibComponentLogging specs which got broken due to the removal of the post_install hook.
See https://github.com/aharren/LibComponentLogging-Core/issues/24
Spec tests: https://github.com/aharren/LibComponentLogging-CocoaPods-Specs/tree/master/test

The LibComponentLogging specs require configuration files which must be present in the root folder of the project. These files can either be created manually or by using `lcl_configure`. The specs create `pod.lcl_configure` files which are picked up and processed by `lcl_configure pod`.
See https://github.com/aharren/LibComponentLogging-configure for details about `lcl_configure`.

The `LibComponentLogging-pods` spec contains `lcl_configure`, so it can be called via

```
Pods/LibComponentLogging-pods/configure/lcl_configure pod
```

after a

```
pod install/update
```

/cc @orta, @alloy, @irrationalfab
