### PR TITLE
Version 1.0.5 of FCOverlay, fixed several issues

### DIFF
--- a/Specs/FCOverlay/1.0.5/FCOverlay.podspec.json
+++ b/Specs/FCOverlay/1.0.5/FCOverlay.podspec.json
@@ -1,0 +1,20 @@
+{
+  "name": "FCOverlay",
+  "version": "1.0.5",
+  "summary": "FCOverlay gives you the power to create any type of overlay in a new window",
+  "description": "                   Present or queue view controllers in a new window on top of all other windows.\n                   This allows you to present log in screens, alert style screens and HUD easily from\n                   anywhere in your code. You do not need to find the currently visible view controller\n                   or any of that stuff. Just present it and get on with life. See the full project for\n                   example usage.\n",
+  "homepage": "https://github.com/lickylick/FCOverlayViewController",
+  "license": "MIT",
+  "authors": {
+    "Almer Lucke": "almer.lucke@gmail.com"
+  },
+  "platforms": {
+    "ios": null
+  },
+  "source": {
+    "git": "https://github.com/lickylick/FCOverlayViewController.git",
+    "tag": "v1.0.5"
+  },
+  "source_files": "FCOverlayViewControllerClass/*",
+  "requires_arc": true
+}


### PR DESCRIPTION
I would like to merge version 1.0.5 of FCOverlay into the main podspec repo. Several issues where fixed.
- Fixed delay when presenting view controller
- Fixed view controller not being dismissed while it was in the state of being presented
- Fixed forwarding status bar style method to the view controller to be presented
- Added sanity check on methods forwarded to view controller to be presented
