### PR TITLE
[Update] XCDFormInputAccessoryView7 (1.1.2)

### DIFF
--- a/XCDFormInputAccessoryView7/1.1.2/XCDFormInputAccessoryView7.podspec
+++ b/XCDFormInputAccessoryView7/1.1.2/XCDFormInputAccessoryView7.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "XCDFormInputAccessoryView7"
+  s.version      = "1.1.2"
+  s.summary      = "Input accessory view with previous, next and done buttons updated to iOS 7 style."
+  s.homepage     = "https://github.com/jessearmand/XCDFormInputAccessoryView"
+  s.license      = { :type => 'MIT', :file => 'README.md' }
+  s.authors      = { "Cédric Luthi" => "cedric.luthi@gmail.com", "Jesse Armand" => "jesse@jessearmand.com" }
+  s.source       = { :git => "https://github.com/jessearmand/XCDFormInputAccessoryView.git", :tag => "1.1.2" }
+  s.platform     = :ios, "7.0"
+  s.source_files = 'XCDFormInputAccessoryView'
+  s.resource     = 'XCDFormInputAccessoryView/Resources/XCDButtonBarArrow.bundle'
+  s.requires_arc = true
+end


### PR DESCRIPTION
Support for black colored toolbar.

Moved the resources to inside bundle.
