### PR TITLE
sqlite3: Update to 3.8.5 (from 2014-06-04)

### DIFF
--- a/Specs/sqlite3/3.8.5/sqlite3.podspec.json
+++ b/Specs/sqlite3/3.8.5/sqlite3.podspec.json
@@ -1,0 +1,112 @@
+{
+  "name": "sqlite3",
+  "version": "3.8.5",
+  "summary": "SQLite is an embedded SQL database engine.",
+  "homepage": "http://www.sqlite.org",
+  "license": "Public Domain",
+  "authors": {
+    "D. Richard Hipp": "drh@hwaci.com"
+  },
+  "source": {
+    "http": "http://www.sqlite.org/2014/sqlite-amalgamation-3080500.zip"
+  },
+  "default_subspec": "common",
+  "requires_arc": false,
+  "subspecs": [
+    {
+      "name": "common",
+      "source_files": "sqlite-amalgamation-3080500/sqlite3*.{h,c}"
+    },
+    {
+      "name": "fts",
+      "dependencies": {
+        "sqlite3/common": [
+
+        ]
+      },
+      "xcconfig": {
+        "GCC_PREPROCESSOR_DEFINITIONS": "SQLITE_ENABLE_FTS4=1 SQLITE_ENABLE_FTS3_PARENTHESIS=1"
+      }
+    },
+    {
+      "name": "unicode61",
+      "dependencies": {
+        "sqlite3/common": [
+
+        ],
+        "sqlite3/fts": [
+
+        ]
+      },
+      "xcconfig": {
+        "GCC_PREPROCESSOR_DEFINITIONS": "SQLITE_ENABLE_FTS4_UNICODE61=1"
+      }
+    },
+    {
+      "name": "coldata",
+      "dependencies": {
+        "sqlite3/common": [
+
+        ]
+      },
+      "xcconfig": {
+        "GCC_PREPROCESSOR_DEFINITIONS": "SQLITE_ENABLE_COLUMN_METADATA=1"
+      }
+    },
+    {
+      "name": "unlock_notify",
+      "dependencies": {
+        "sqlite3/common": [
+
+        ]
+      },
+      "xcconfig": {
+        "GCC_PREPROCESSOR_DEFINITIONS": "SQLITE_ENABLE_UNLOCK_NOTIFY=1"
+      }
+    },
+    {
+      "name": "rtree",
+      "dependencies": {
+        "sqlite3/common": [
+
+        ]
+      },
+      "xcconfig": {
+        "GCC_PREPROCESSOR_DEFINITIONS": "SQLITE_ENABLE_RTREE=1"
+      }
+    },
+    {
+      "name": "stat3",
+      "dependencies": {
+        "sqlite3/common": [
+
+        ]
+      },
+      "xcconfig": {
+        "GCC_PREPROCESSOR_DEFINITIONS": "SQLITE_ENABLE_STAT3=1"
+      }
+    },
+    {
+      "name": "stat4",
+      "dependencies": {
+        "sqlite3/common": [
+
+        ]
+      },
+      "xcconfig": {
+        "GCC_PREPROCESSOR_DEFINITIONS": "SQLITE_ENABLE_STAT4=1"
+      }
+    },
+    {
+      "name": "soundex",
+      "dependencies": {
+        "sqlite3/common": [
+
+        ]
+      },
+      "xcconfig": {
+        "GCC_PREPROCESSOR_DEFINITIONS": "SQLITE_SOUNDEX=1"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Updated SQLite, see: https://sqlite.org/releaselog/3_8_5.html
_Version 3.8.5 fixes more than a dozen obscure bugs. None of these bugs should be a problem for existing applications. Nor do any of the bugs represent a security vulnerability. Nevertheless, upgrading is recommended to prevent future problems._

**I previously updated the sqlite podspec, for the last 5 or so versions but I am not the original spec author, do I have to "claim" this pod if I want to update it in the future? In the last months, nobody cared about updating this pod except myself**
