### PR TITLE
Upgraded starIOPrintSDK to 3.10.1

### DIFF
--- a/Specs/starIOPrintSDK/3.10.1/starIOPrintSDK.podspec.json
+++ b/Specs/starIOPrintSDK/3.10.1/starIOPrintSDK.podspec.json
@@ -1,0 +1,30 @@
+{
+  "name": "starIOPrintSDK",
+  "version": "3.10.1",
+  "summary": "Star Micronics iOS Print SDK",
+  "description": "                    This software is StarIO for iOS.\n                    StarIO is a high level programming tool that simplifies the development\n                    and creation of software for Star printers. \n                    This SDK support iOS from 4.3 to 7.0.\n                    Please refer to document in zip file.\n",
+  "homepage": "http://www.starmicronics.com/support/sdkdocumentation.aspx",
+  "license": {
+    "type": "Commercial",
+    "text": "                      This software is StarIO for iOS.\n                      StarIO is a high level programming tool that simplifies the development\n                      and creation of software for Star printers. \n                      This SDK support iOS from 4.3 to 7.0.\n                      Please refer to document in zip file.\n"
+  },
+  "authors": {
+    "Star Micronics Co., Ltd.": "contact@starmicronics.com"
+  },
+  "platforms": {
+    "ios": "5.1.1"
+  },
+  "source": {
+    "http": "http://www.starmicronics.com/support/ZipFile.aspx?sat2=203#file.zip"
+  },
+  "frameworks": [
+    "UIKit",
+    "CoreGraphics",
+    "ExternalAccessory"
+  ],
+  "libraries": "z",
+  "preserve_paths": "StarIO_iOS_SDK_V3_10_1/Distributables/*.framework",
+  "public_header_files": "StarIO_iOS_SDK_V3_10_1/Distributables/StarIO.framework/**/*.h",
+  "vendored_frameworks": "StarIO_iOS_SDK_V3_10_1/Distributables/StarIO.framework",
+  "requires_arc": false
+}


### PR DESCRIPTION
Upgrade starIOPrintSDK to 3.10.1. HTTP source always downloads the latest version so we should probably remove any older versions of this spec.
