### PR TITLE
spec for version 1.1.0

### DIFF
--- a/Specs/FastDTW-x/1.1.0/FastDTW-x.podspec
+++ b/Specs/FastDTW-x/1.1.0/FastDTW-x.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = "FastDTW-x"
+  s.version      = "1.1.0"
+  s.summary      = "C++ porting of Stan Salvador's FastDTW."
+  s.homepage     = "https://github.com/melode11/FastDTW-x"
+  s.license      = {:type => 'MIT'}
+  s.author       = {"Melo Yao" => "melode11@gmail.com" }
+  s.source       = {:git => "https://github.com/melode11/FastDTW-x.git", :tag => "#{s.version}" }
+  s.source_files = 'FastDTW-x/Classes/**/*.{h,cpp}'
+  s.requires_arc = false
+  s.xcconfig = {
+    'CLANG_CXX_LANGUAGE_STANDARD' => 'gnu++11',
+    'CLANG_CXX_LIBRARY' => 'libstdc++'
+  }
+
+end


### PR DESCRIPTION
Add pod spec for FastDTW-x version 1.1.0
The major improvement focus on the compilation on windows/windows phone platform.
Complilaton of version 1.1.0 are tested on Linux/iOS/Android/Win32/Windows phone 8
