### PR TITLE
Quote framework search paths

### DIFF
--- a/Specs/OpenCV/2.4.8/OpenCV.podspec.json
+++ b/Specs/OpenCV/2.4.8/OpenCV.podspec.json
@@ -40,7 +40,7 @@
     "UIKit"
   ],
   "xcconfig": {
-    "FRAMEWORK_SEARCH_PATHS": "$(PODS_ROOT)/OpenCV",
+    "FRAMEWORK_SEARCH_PATHS": %{"$(PODS_ROOT)/OpenCV"},
     "OTHER_LDFLAGS": "-all_load"
   },
   "requires_arc": false


### PR DESCRIPTION
POD_ROOTS could be expanded to a path with spaces which would break the path. Quoting the path avoids that.
