### PR TITLE
Add AwesomeCache (Swift)

### DIFF
--- a/Specs/AwesomeCache/0.1/AwesomeCache.podspec
+++ b/Specs/AwesomeCache/0.1/AwesomeCache.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = "AwesomeCache"
+  s.version      = "0.1"
+  s.summary      = "Delightful on-disk cache."
+  s.homepage     = "https://github.com/aschuch/AwesomeCache"
+  s.license      = { :type => "MIT", :file => "LICENSE" }
+  s.author       = { "Alexander Schuch" => "alexander@schuch.me" }
+  s.platform     = :ios, "8.0"
+  s.source       = { :git => "https://github.com/aschuch/AwesomeCache.git", :tag => s.version.to_s }
+  s.source_files  = "AwesomeCache/*.swift"
+  s.requires_arc = true
+end


### PR DESCRIPTION
`pod spec lint` currently fails with `unknown option character`X' in: -Xlinker`.

Is this due to missing support for Swift?
