### PR TITLE
add deprecation for MapBox

### DIFF
--- a/Specs/MapBox/0.4.0/MapBox.podspec.json
+++ b/Specs/MapBox/0.4.0/MapBox.podspec.json
@@ -1,6 +1,7 @@
 {
   "name": "MapBox",
   "version": "0.4.0",
+  "deprecated_in_favor_of": "Mapbox-iOS-SDK",
   "summary": "Open source alternative to MapKit.",
   "description": "Open source alternative to MapKit supporting custom tile sources, offline use, and complete cache control.",
   "homepage": "http://mapbox.com/mobile",

--- a/Specs/MapBox/0.4.1/MapBox.podspec.json
+++ b/Specs/MapBox/0.4.1/MapBox.podspec.json
@@ -1,6 +1,7 @@
 {
   "name": "MapBox",
   "version": "0.4.1",
+  "deprecated_in_favor_of": "Mapbox-iOS-SDK",
   "summary": "Open source alternative to MapKit.",
   "description": "Open source alternative to MapKit supporting custom tile sources, offline use, and complete cache control.",
   "homepage": "http://mapbox.com/mobile",

--- a/Specs/MapBox/0.4.2/MapBox.podspec.json
+++ b/Specs/MapBox/0.4.2/MapBox.podspec.json
@@ -1,6 +1,7 @@
 {
   "name": "MapBox",
   "version": "0.4.2",
+  "deprecated_in_favor_of": "Mapbox-iOS-SDK",
   "summary": "Open source alternative to MapKit.",
   "description": "Open source alternative to MapKit supporting custom tile sources, offline use, and complete cache control.",
   "homepage": "http://mapbox.com/mobile",

--- a/Specs/MapBox/0.4.3/MapBox.podspec.json
+++ b/Specs/MapBox/0.4.3/MapBox.podspec.json
@@ -1,6 +1,7 @@
 {
   "name": "MapBox",
   "version": "0.4.3",
+  "deprecated_in_favor_of": "Mapbox-iOS-SDK",
   "summary": "Open source alternative to MapKit.",
   "description": "Open source alternative to MapKit supporting custom tile sources, offline use, and complete cache control.",
   "homepage": "http://mapbox.com/mobile",

--- a/Specs/MapBox/0.5.0/MapBox.podspec.json
+++ b/Specs/MapBox/0.5.0/MapBox.podspec.json
@@ -1,6 +1,7 @@
 {
   "name": "MapBox",
   "version": "0.5.0",
+  "deprecated_in_favor_of": "Mapbox-iOS-SDK",
   "summary": "Open source alternative to MapKit.",
   "description": "Open source alternative to MapKit supporting custom tile sources, offline use, and complete cache control.",
   "homepage": "http://mapbox.com/mobile",

--- a/Specs/MapBox/0.5.1/MapBox.podspec.json
+++ b/Specs/MapBox/0.5.1/MapBox.podspec.json
@@ -1,6 +1,7 @@
 {
   "name": "MapBox",
   "version": "0.5.1",
+  "deprecated_in_favor_of": "Mapbox-iOS-SDK",
   "summary": "Open source alternative to MapKit.",
   "description": "Open source alternative to MapKit supporting custom tile sources, offline use, and complete cache control.",
   "homepage": "http://mapbox.com/mobile",

--- a/Specs/MapBox/0.5.2/MapBox.podspec.json
+++ b/Specs/MapBox/0.5.2/MapBox.podspec.json
@@ -1,6 +1,7 @@
 {
   "name": "MapBox",
   "version": "0.5.2",
+  "deprecated_in_favor_of": "Mapbox-iOS-SDK",
   "summary": "Open source alternative to MapKit.",
   "description": "Open source alternative to MapKit supporting custom tile sources, offline use, and complete cache control.",
   "homepage": "http://mapbox.com/mobile",

--- a/Specs/MapBox/1.0.0/MapBox.podspec.json
+++ b/Specs/MapBox/1.0.0/MapBox.podspec.json
@@ -1,6 +1,7 @@
 {
   "name": "MapBox",
   "version": "1.0.0",
+  "deprecated_in_favor_of": "Mapbox-iOS-SDK",
   "summary": "Open source alternative to MapKit.",
   "description": "Open source alternative to MapKit supporting custom tile sources, offline use, and complete cache control.",
   "homepage": "http://mapbox.com/mapbox-ios-sdk",

--- a/Specs/MapBox/1.0.1/MapBox.podspec.json
+++ b/Specs/MapBox/1.0.1/MapBox.podspec.json
@@ -1,6 +1,7 @@
 {
   "name": "MapBox",
   "version": "1.0.1",
+  "deprecated_in_favor_of": "Mapbox-iOS-SDK",
   "summary": "Open source alternative to MapKit.",
   "description": "Open source alternative to MapKit supporting custom tile sources, offline use, and complete cache control.",
   "homepage": "http://mapbox.com/mapbox-ios-sdk",

--- a/Specs/MapBox/1.0.2/MapBox.podspec.json
+++ b/Specs/MapBox/1.0.2/MapBox.podspec.json
@@ -1,6 +1,7 @@
 {
   "name": "MapBox",
   "version": "1.0.2",
+  "deprecated_in_favor_of": "Mapbox-iOS-SDK",
   "summary": "Open source alternative to MapKit.",
   "description": "Open source alternative to MapKit supporting custom tile sources, offline use, and complete cache control.",
   "homepage": "http://mapbox.com/mapbox-ios-sdk",

--- a/Specs/MapBox/1.0.3/MapBox.podspec.json
+++ b/Specs/MapBox/1.0.3/MapBox.podspec.json
@@ -1,6 +1,7 @@
 {
   "name": "MapBox",
   "version": "1.0.3",
+  "deprecated_in_favor_of": "Mapbox-iOS-SDK",
   "summary": "Open source alternative to MapKit.",
   "description": "Open source alternative to MapKit supporting custom tile sources, offline use, and complete cache control.",
   "homepage": "http://mapbox.com/mapbox-ios-sdk",

--- a/Specs/MapBox/1.1.0/MapBox.podspec.json
+++ b/Specs/MapBox/1.1.0/MapBox.podspec.json
@@ -1,6 +1,7 @@
 {
   "name": "MapBox",
   "version": "1.1.0",
+  "deprecated_in_favor_of": "Mapbox-iOS-SDK",
   "summary": "Open source alternative to MapKit.",
   "description": "Open source alternative to MapKit supporting custom tile sources, offline use, and complete cache control.",
   "homepage": "http://mapbox.com/mobile",


### PR DESCRIPTION
I've added a `deprecated_in_favor_of` in order to shepherd folks over to the `Mapbox-iOS-SDK` pod instead. 

Should I be doing this for all of the older, pre-`1.1.0` versions as well, or just this latest one? 

Also, the new `Mapbox-iOS-SDK` picks up at `1.2.0`, which `MapBox` doesn't have. 
