### PR TITLE
Update Dropbox-Sync-API-SDK to v3.0.1

### DIFF
--- a/Specs/Dropbox-Sync-API-SDK/3.0.0/Dropbox-Sync-API-SDK.podspec.json
+++ b/Specs/Dropbox-Sync-API-SDK/3.0.0/Dropbox-Sync-API-SDK.podspec.json
@@ -1,15 +1,15 @@
 {
   "name": "Dropbox-Sync-API-SDK",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "summary": "The Dropbox Sync & Datastore API SDK for iOS.",
   "homepage": "https://www.dropbox.com/developers/sync",
   "license": {
     "type": "Copyright",
-    "file": "dropbox-ios-sync-sdk-3.0.0/LICENSE.txt"
+    "file": "dropbox-ios-sync-sdk-3.0.1/LICENSE.txt"
   },
   "authors": "Dropbox",
   "source": {
-    "http": "https://www.dropbox.com/developers/downloads/sdks/datastore/ios/dropbox-ios-sync-sdk-3.0.0.zip"
+    "http": "https://www.dropbox.com/developers/downloads/sdks/datastore/ios/dropbox-ios-sync-sdk-3.0.1.zip"
   },
   "platforms": {
     "ios": null
@@ -20,7 +20,7 @@
     "SystemConfiguration",
     "QuartzCore"
   ],
-  "vendored_frameworks": "dropbox-ios-sync-sdk-3.0.0/Dropbox.framework",
+  "vendored_frameworks": "dropbox-ios-sync-sdk-3.0.1/Dropbox.framework",
   "libraries": "c++",
   "requires_arc": false
 }


### PR DESCRIPTION
Unfortunately, this needs to be done ASAP because Dropbox doesn't keep old versions of the source zip file around when they update their SDK.
