### PR TITLE
OpenSSL - Fix incorrect LICENSE file name

### DIFF
--- a/Specs/OpenSSL/1.0.108/OpenSSL.podspec.json
+++ b/Specs/OpenSSL/1.0.108/OpenSSL.podspec.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/FredericJacobs/OpenSSL-Pod",
   "license": {
     "type": "OpenSSL (OpenSSL/SSLeay)",
-    "file": "LICENSE.txt"
+    "file": "LICENSE"
   },
   "source": {
     "http": "https://www.openssl.org/source/openssl-1.0.1h.tar.gz",


### PR DESCRIPTION
To verify:
  curl -s https://www.openssl.org/source/openssl-1.0.1h.tar.gz | tar t | grep LICENSE
