### PR TITLE
Updated AD-X Sdk source url

### DIFF
--- a/Specs/AD-X-SDK/4.2.4/AD-X-SDK.podspec.json
+++ b/Specs/AD-X-SDK/4.2.4/AD-X-SDK.podspec.json
@@ -10,7 +10,7 @@
   },
   "authors": "Paul Hayton, Ad-X Ltd",
   "source": {
-    "http": "https://ad-x.co.uk/latest/SDKs/AD-X_iOS_SDK.zip",
+    "http": "https://dashboard.ad-x.co.uk/latest/SDKs/AD-X_iOS_SDK.zip",
     "flatten": true
   },
   "platforms": {


### PR DESCRIPTION
I think due to some issue ad-x has been updated it's sdk source location.
