### PR TITLE
Update MHTabBarController to v1.0.0 release

### DIFF
--- a/Specs/MHTabBarController/0.0.1/MHTabBarController.podspec.json
+++ b/Specs/MHTabBarController/0.0.1/MHTabBarController.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "MHTabBarController",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "summary": "A custom tab bar controller for iOS 5.",
   "description": "                    This is a custom container view controller for iOS 5 that works just like a regular UITabBarController, except the tabs are at the top and look different.\n",
   "homepage": "http://www.hollance.com/2011/11/mhtabbarcontroller-a-custom-tab-bar-for-ios-5-using-the-new-container-apis/",
@@ -13,10 +13,10 @@
   },
   "source": {
     "git": "https://github.com/hollance/MHTabBarController.git",
-    "commit": "073f751521d6c998364a3671ec3edd6cecc7b4e7"
+    "commit": "45a56d7db82427319ab9912d4150dd9020d00cfe"
   },
   "platforms": {
-    "ios": "5.0"
+    "ios": "7.0"
   },
   "source_files": [
     "Classes",


### PR DESCRIPTION
- updating spec to most recent v1.0.0 release
- https://github.com/hollance/MHTabBarController/releases
