### PR TITLE
Update Google-API-Client.podspec.json

### DIFF
--- a/Specs/Google-API-Client/0.1.1/Google-API-Client.podspec.json
+++ b/Specs/Google-API-Client/0.1.1/Google-API-Client.podspec.json
@@ -9,7 +9,7 @@
   "homepage": "https://code.google.com/p/google-api-objectivec-client/",
   "source": {
     "svn": "http://google-api-objectivec-client.googlecode.com/svn/trunk/",
-    "revision": "393"
+    "revision": "416"
   },
   "summary": "Google APIs Client Library for Objective-C",
   "description": "                    Written by Google, this library is a flexible and efficient Objective-C\n                    framework for accessing JSON APIs.\n\n                    This is the recommended library for accessing JSON-based Google APIs\n                    for iOS and Mac OS X applications.\n                    \n                    This version can be used with iOS ≥ 5.0 or OS X ≥ 10.7.\n                    To target earlier versions of iOS or OS X, use\n\n                      pod 'Google-API-Client', '~> 0.0.1'\n",
@@ -154,6 +154,16 @@
       },
       "source_files": "Source/Services/Drive/Generated/*.{h,m}",
       "exclude_files": "Source/Services/Drive/Generated/GTLDrive_Sources.m"
+    },
+    {
+      "name": "Gmail",
+      "dependencies": {
+        "Google-API-Client/Common": [
+
+        ]
+      },
+      "source_files": "Source/Services/Gmail/Generated/*.{h,m}",
+      "exclude_files": "Source/Services/Gmail/Generated/GTLDrive_Sources.m"
     },
     {
       "name": "Groupssettings",


### PR DESCRIPTION
Update Google-API-Client.podspec.json for [revision 416](https://code.google.com/p/google-api-objectivec-client/source/list) - the latest version as of August 19, 2014; the current version of this spec is for revision 393.
This update adds the [Gmail API](https://code.google.com/p/google-api-objectivec-client/source/browse/#svn%2Ftrunk%2FSource%2FServices%2FGmail%2FGenerated) to the list of subspecs
