### PR TITLE
Update AppsFlyer-SDK.podspec.json

### DIFF
--- a/Specs/AppsFlyer-SDK/2.5.3.10/AppsFlyer-SDK.podspec.json
+++ b/Specs/AppsFlyer-SDK/2.5.3.10/AppsFlyer-SDK.podspec.json
@@ -17,6 +17,10 @@
   "platforms": {
     "ios": "5.0"
   },
+  "frameworks": [
+    "AdSupport",
+    "iAd"
+  ],
   "requires_arc": false,
   "source_files": "*.h",
   "vendored_libraries": "libAppsFlyerLib.a"


### PR DESCRIPTION
The AppsFlyer-SDK requires iAd and AdSupport iOS frameworks. The owner of this pod is not reachable so I made the necessary changes. This commit adds these frameworks into the podspec.
