### PR TITLE
Adding public header files to GeotriggerSDK

### DIFF
--- a/Specs/GeotriggerSDK/1.0.0/GeotriggerSDK.podspec.json
+++ b/Specs/GeotriggerSDK/1.0.0/GeotriggerSDK.podspec.json
@@ -23,6 +23,7 @@
     "SystemConfiguration",
     "MobileCoreServices"
   ],
+  "public_header_files": "GeotriggerSDK.framework/**/*.h",
   "vendored_frameworks": "GeotriggerSDK.framework",
   "preserve_paths": "GeotriggerSDK.framework",
   "requires_arc": true


### PR DESCRIPTION
This is necessary to use GeotriggerSDK pod as dependency of other pods.
