### PR TITLE
Update ScanditSDK.podspec.json

### DIFF
--- a/Specs/ScanditSDK/4.1.2/ScanditSDK.podspec.json
+++ b/Specs/ScanditSDK/4.1.2/ScanditSDK.podspec.json
@@ -14,7 +14,7 @@
     "tag": "4.1.2"
   },
   "platforms": {
-    "ios": "7.0"
+    "ios": "5.1.1"
   },
   "requires_arc": false,
   "source_files": "ScanditSDK/*.{h,cpp}",


### PR DESCRIPTION
Plese use the correct platform otherwise any "older than iOS 7" projects will fail to "pod update" this project. 

Scandit has got a deployment target of 5.1.1.

Thanks
