### PR TITLE
Deprecate Sparkle-pornel podspec in favor of Sparkle.

### DIFF
--- a/Specs/Sparkle-pornel/1.6.0/Sparkle-pornel.podspec.json
+++ b/Specs/Sparkle-pornel/1.6.0/Sparkle-pornel.podspec.json
@@ -1,4 +1,5 @@
 {
+  "deprecated_in_favor_of": "Sparkle",
   "name": "Sparkle-pornel",
   "version": "1.6.0",
   "summary": "An actively maintained fork of the Sparkle software updater",

--- a/Specs/Sparkle-pornel/1.6.1/Sparkle-pornel.podspec.json
+++ b/Specs/Sparkle-pornel/1.6.1/Sparkle-pornel.podspec.json
@@ -1,4 +1,5 @@
 {
+  "deprecated_in_favor_of": "Sparkle",
   "name": "Sparkle-pornel",
   "version": "1.6.1",
   "summary": "An actively maintained fork of the Sparkle software updater",


### PR DESCRIPTION
The fork has become the official version.
