### PR TITLE
New version of the Facebook SDK - 3.18

### DIFF
--- a/Specs/Facebook-iOS-SDK/3.17.0/Facebook-iOS-SDK.podspec.json
+++ b/Specs/Facebook-iOS-SDK/3.17.0/Facebook-iOS-SDK.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Facebook-iOS-SDK",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "platforms": {
     "ios": 6.0
   },
@@ -11,7 +11,7 @@
   "authors": "Facebook",
   "source": {
     "git": "https://github.com/facebook/facebook-ios-sdk.git",
-    "tag": "sdk-version-3.17.0"
+    "tag": "sdk-version-3.18.0"
   },
   "source_files": [
     "src/*.{h,m}",


### PR DESCRIPTION
The current version (3.17) on CocoaPods is outdated.
