### PR TITLE
Adding version 1.7.1 of the google-plus-ios-sdk

### DIFF
--- a/Specs/google-plus-ios-sdk/1.7.1/google-plus-ios-sdk.podspec.json
+++ b/Specs/google-plus-ios-sdk/1.7.1/google-plus-ios-sdk.podspec.json
@@ -1,0 +1,40 @@
+{
+  "name": "google-plus-ios-sdk",
+  "version": "1.7.1",
+  "summary": "Google+ Platform for iOS.",
+  "description": "                   Create a more engaging experience and connect with more users by integrating social into your app. Extend your app in new and creative ways using these Google+ platform features.\n",
+  "homepage": "https://developers.google.com/+/mobile/ios/",
+  "license": {
+    "type": "Copyright",
+    "text": "Copyright 2013 Google Inc."
+  },
+  "authors": "Google Inc.",
+  "platforms": {
+    "ios": null
+  },
+  "source": {
+    "http": "https://developers.google.com/+/mobile/ios/sdk/google-plus-ios-sdk-1.7.1.zip"
+  },
+  "source_files": "google-plus-ios-sdk-1.7.1/{GoogleOpenSource,GooglePlus}.framework/Versions/A/Headers/*.h",
+  "resources": "google-plus-ios-sdk-1.7.1/GooglePlus.bundle",
+  "vendored_frameworks": [
+    "google-plus-ios-sdk-1.7.1/GoogleOpenSource.framework",
+    "google-plus-ios-sdk-1.7.1/GooglePlus.framework"
+  ],
+  "frameworks": [
+    "AddressBook",
+    "AssetsLibrary",
+    "Foundation",
+    "CoreLocation",
+    "CoreMotion",
+    "CoreGraphics",
+    "CoreText",
+    "GoogleOpenSource",
+    "GooglePlus",
+    "MediaPlayer",
+    "Security",
+    "SystemConfiguration",
+    "UIKit"
+  ],
+  "requires_arc": false
+}


### PR DESCRIPTION
Earlier this morning Google released the 1.7.1 version of the google plus SDK to fix a problem where anyone using the previous versions were not able to send apps to the new iTunes connect.
