### PR TITLE
Fix svn error when installing RegexKitLite

### DIFF
--- a/Specs/RegexKitLite/4.0/RegexKitLite.podspec.json
+++ b/Specs/RegexKitLite/4.0/RegexKitLite.podspec.json
@@ -8,7 +8,7 @@
     "John Engelhart": "regexkitlite@gmail.com"
   },
   "source": {
-    "svn": "http://svn.code.sf.net/p/regexkit/code/RegexKitLite",
+    "svn": "https://svn.code.sf.net/p/regexkit/code/RegexKitLite",
     "revision": "69"
   },
   "source_files": "**/RegexKitLite.{h,m}",


### PR DESCRIPTION
Changing from http to https seems to fix this error that I encountered when relying on RegexKitLite:

```
Installing RegexKitLite 4.0 (was 4.0)
[!] /opt/local/bin/svn export --non-interactive --trust-server-cert --force "http://svn.code.sf.net/p/regexkit/code/RegexKitLite" -r "69" .../Pods/RegexKitLite
svn: E175002: Unable to connect to a repository at URL 'http://svn.code.sf.net/p/regexkit/code/RegexKitLite'
svn: E175002: OPTIONS request on '/p/regexkit/code/RegexKitLite' failed: 504 Connection Timed Out
```
