### PR TITLE
renamed framework from ChartboostSDK to Chartboost

### DIFF
--- a/Specs/ChartboostSDK/5.0.2/ChartboostSDK.podspec.json
+++ b/Specs/ChartboostSDK/5.0.2/ChartboostSDK.podspec.json
@@ -33,7 +33,7 @@
     "AVFoundation",
     "CoreData",
     "CoreGraphics",
-    "ChartboostSDK"
+    "Chartboost"
   ],
   "requires_arc": false
 }


### PR DESCRIPTION
The Framework is in fact Chartboost, not ChartboostSDK. 

This should fix https://github.com/CocoaPods/Specs/issues/12668
