### PR TITLE
Fix QuickBlox libraries.

### DIFF
--- a/Specs/QuickBlox/2.0.8/QuickBlox.podspec.json
+++ b/Specs/QuickBlox/2.0.8/QuickBlox.podspec.json
@@ -38,7 +38,8 @@
   },
   "libraries": [
     "resolv",
-    "xml2 -lstdc++",
+    "xml2",
+    "stdc++",
     "z"
   ],
   "xcconfig": {


### PR DESCRIPTION
Compile was failing before with an error which said:
Library not found for -lxml2 -lstdc++
