### PR TITLE
GoogleCast framework should be compatible with iOS 6 and later not 7

### DIFF
--- a/Specs/google-cast-sdk/2.4.0/google-cast-sdk.podspec.json
+++ b/Specs/google-cast-sdk/2.4.0/google-cast-sdk.podspec.json
@@ -13,7 +13,7 @@
     "http": "https://developers.google.com/cast/downloads/GoogleCastFramework-2.4.0-Release-ios.zip"
   },
   "platforms": {
-    "ios": "7.0"
+    "ios": "6.0"
   },
   "source_files": "GoogleCastFramework-2.4.0-Release/GoogleCast.framework/Versions/A/Headers/*.h",
   "preserve_paths": "GoogleCastFramework-2.4.0-Release/GoogleCast.framework",


### PR DESCRIPTION
The last update set the minimum iOS version to iOS 7 but according to the release notes it's compatible with iOS 6. 
