### PR TITLE
Add ZXing 2.3

### DIFF
--- a/Specs/ZXing/2.3/ZXing.podspec.json
+++ b/Specs/ZXing/2.3/ZXing.podspec.json
@@ -1,0 +1,65 @@
+{
+  "name": "ZXing",
+  "version": "2.3",
+  "summary": "Multi-format 1D/2D barcode image processing library.",
+  "homepage": "http://code.google.com/p/zxing/",
+  "authors": "ZXing team (http://code.google.com/p/zxing/people/list)",
+  "license": {
+    "type": "Apache License, Version 2.0",
+    "file": "COPYING"
+  },
+  "source": {
+    "git": "https://github.com/applidget/zxing-ios.git",
+    "tag": "v2.3"
+  },
+  "source_files": [
+    "cpp/core/src/zxing/**/*.cpp",
+    "objc/src/ZXing/*.{m,mm}",
+    "cpp/core/src/bigint/*.cc"
+  ],
+  "preserve_paths": [
+    "cpp/core/src/zxing/**/*.h",
+    "objc/src/ZXing/*.h",
+    "cpp/core/src/bigint/*.hh"
+  ],
+  "compiler_flags": "-IZXing/cpp/core/src/ -IZXing/objc/src/",
+  "requires_arc": false,
+  "libraries": [
+    "stdc++",
+    "iconv"
+  ],
+  "frameworks": [
+    "AddressBook",
+    "AudioToolbox",
+    "AVFoundation",
+    "CoreGraphics",
+    "CoreMedia",
+    "CoreVideo",
+    "ImageIO"
+  ],
+  "prefix_header_contents": "#ifdef __OBJC__\n  #import <ImageIO/CGImageSource.h>\n#endif\n",
+  "xcconfig": {
+    "CLANG_CXX_LANGUAGE_STANDARD": "c++98",
+    "CLANG_CXX_LIBRARY": "libstdc++"
+  },
+  "platforms": {
+    "ios": "6.0"
+  },
+  "ios": {
+    "requires_arc": false,
+    "preserve_paths": "iphone/ZXingWidget/Classes/**/*.{h}",
+    "source_files": "iphone/ZXingWidget/Classes/**/*.{m,mm}",
+    "compiler_flags": [
+      "-IZXing/cpp/core/src/zxing/",
+      "-IZXing/iphone/ZXingWidget/Classes/"
+    ],
+    "exclude_files": "iphone/ZXingWidget/Classes/MultiFormatReader.h",
+    "xcconfig": {
+      "HEADER_SEARCH_PATHS": "${PODS_ROOT}/ZXing/cpp/core/src/ ${PODS_ROOT}/ZXing/iphone/ZXingWidget/Classes/**"
+    },
+    "frameworks": [
+      "AddressBookUI",
+      "QuartzCore"
+    ]
+  }
+}


### PR DESCRIPTION
Hi, 
ZXing 2.2 would not build anymore on XCode 6. I am a former maintainer of ZXing so I created a separate repo for ZXing specific iOS code. As explained in [this readme](https://github.com/applidget/zxing-ios). 
The enhancement of this new version are:
- Now working with Xcode 6
- A lot faster to install since it does not clone the whole ZXing codebase and test suite
