### PR TITLE
Fixed IMA iOS SDKs beta 9

### DIFF
--- a/Specs/GoogleAds-IMA-iOS-SDK-For-AdMob/3.0.beta.9/GoogleAds-IMA-iOS-SDK-For-AdMob.podspec.json
+++ b/Specs/GoogleAds-IMA-iOS-SDK-For-AdMob/3.0.beta.9/GoogleAds-IMA-iOS-SDK-For-AdMob.podspec.json
@@ -37,7 +37,7 @@
     ]
   },
   "xcconfig": {
-    "LIBRARY_SEARCH_PATHS": "\"$(PODS_ROOT)/GoogleAds-IMA-iOS-SDK-For-AdMob/\""
+    "LIBRARY_SEARCH_PATHS": "\"$(PODS_ROOT)/GoogleAds-IMA-iOS-SDK-For-AdMob/GoogleIMASDK3/\""
   },
   "requires_arc": true
 }

--- a/Specs/GoogleAds-IMA-iOS-SDK/3.0.beta.9/GoogleAds-IMA-iOS-SDK.podspec.json
+++ b/Specs/GoogleAds-IMA-iOS-SDK/3.0.beta.9/GoogleAds-IMA-iOS-SDK.podspec.json
@@ -32,7 +32,7 @@
     "UIKit"
   ],
   "xcconfig": {
-    "LIBRARY_SEARCH_PATHS": "\"$(PODS_ROOT)/GoogleAds-IMA-iOS-SDK/\""
+    "LIBRARY_SEARCH_PATHS": "\"$(PODS_ROOT)/GoogleAds-IMA-iOS-SDK/GoogleIMASDK3/\""
   },
   "requires_arc": true
 }


### PR DESCRIPTION
Hi, I'm hoping we'll be able to update our Podspecs due to an error in our last push. I know the recommended way of doing this is to just bump the version number, but our library is also available via other means, and we don't want them to fall out of sync (see our [documentation](https://developers.google.com/interactive-media-ads/docs/sdks/ios/v3/history)). We don't want to bump the release version in our release notes, because bumping the version without actually making a change would be confusing to our users. Thanks!
