### PR TITLE
Fix circular dependency issues

### DIFF
--- a/Specs/Analytics/1.0.1/Analytics.podspec.json
+++ b/Specs/Analytics/1.0.1/Analytics.podspec.json
@@ -31,9 +31,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ]
       }
     },
     {
@@ -66,11 +63,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.0.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.0.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -86,6 +86,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Bugsnag": [
@@ -107,6 +110,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Countly": [
           "~> 2.0.0"
         ]
@@ -124,6 +130,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "CrittercismSDK": [
@@ -145,6 +154,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "FlurrySDK": [
           "~> 4.4.0"
         ]
@@ -162,6 +174,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "GoogleAnalytics-iOS-SDK": [
@@ -183,6 +198,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Localytics-iOS-Client": [
           "~> 2.23.0"
         ]
@@ -200,6 +218,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Mixpanel": [
@@ -221,6 +242,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -238,6 +262,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.0.2/Analytics.podspec.json
+++ b/Specs/Analytics/1.0.2/Analytics.podspec.json
@@ -31,9 +31,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ]
       }
     },
     {
@@ -66,11 +63,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.0.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.0.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -86,6 +86,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Bugsnag": [
@@ -107,6 +110,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Countly": [
           "~> 2.0.0"
         ]
@@ -124,6 +130,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "CrittercismSDK": [
@@ -145,6 +154,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "FlurrySDK": [
           "~> 4.4.0"
         ]
@@ -162,6 +174,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "GoogleAnalytics-iOS-SDK": [
@@ -183,6 +198,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Localytics-iOS-Client": [
           "~> 2.23.0"
         ]
@@ -200,6 +218,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Mixpanel": [
@@ -221,6 +242,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -238,6 +262,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.1.0/Analytics.podspec.json
+++ b/Specs/Analytics/1.1.0/Analytics.podspec.json
@@ -31,9 +31,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ]
       }
     },
     {
@@ -66,11 +63,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.0.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.0.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -86,6 +86,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Bugsnag": [
@@ -107,6 +110,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Countly": [
           "~> 2.0.0"
         ]
@@ -124,6 +130,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "CrittercismSDK": [
@@ -145,6 +154,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "FlurrySDK": [
           "~> 4.4.0"
         ]
@@ -162,6 +174,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "GoogleAnalytics-iOS-SDK": [
@@ -183,6 +198,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Localytics-iOS-Client": [
           "~> 2.23.0"
         ]
@@ -200,6 +218,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Mixpanel": [
@@ -221,6 +242,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -238,6 +262,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.2.0/Analytics.podspec.json
+++ b/Specs/Analytics/1.2.0/Analytics.podspec.json
@@ -31,9 +31,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ]
       }
     },
     {
@@ -66,11 +63,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.0.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.0.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -86,6 +86,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Bugsnag": [
@@ -107,6 +110,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Countly": [
           "~> 2.0.0"
         ]
@@ -124,6 +130,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "CrittercismSDK": [
@@ -145,6 +154,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "FlurrySDK": [
           "~> 4.4.0"
         ]
@@ -162,6 +174,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "GoogleAnalytics-iOS-SDK": [
@@ -183,6 +198,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Localytics-iOS-Client": [
           "~> 2.23.0"
         ]
@@ -200,6 +218,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Mixpanel": [
@@ -221,6 +242,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Taplytics": [
           "~> 1.3.0"
         ]
@@ -240,6 +264,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -257,6 +284,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.3.0/Analytics.podspec.json
+++ b/Specs/Analytics/1.3.0/Analytics.podspec.json
@@ -31,9 +31,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ]
       }
     },
     {
@@ -66,11 +63,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.0.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.0.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -86,6 +86,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Apptimize": [
@@ -107,6 +110,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "~> 3.1.2"
         ]
@@ -124,6 +130,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -145,6 +154,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "~> 4.3.3"
         ]
@@ -162,6 +174,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -183,6 +198,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "3.0.7"
         ]
@@ -200,6 +218,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-iOS-Client": [
@@ -221,6 +242,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "~> 2.3.6"
         ]
@@ -238,6 +262,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -259,6 +286,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -276,6 +306,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.3.1/Analytics.podspec.json
+++ b/Specs/Analytics/1.3.1/Analytics.podspec.json
@@ -31,9 +31,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ]
       }
     },
     {
@@ -66,11 +63,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.0.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.0.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -86,6 +86,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Apptimize": [
@@ -107,6 +110,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "~> 3.1.2"
         ]
@@ -124,6 +130,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -145,6 +154,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "~> 4.3.3"
         ]
@@ -162,6 +174,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -183,6 +198,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "3.0.7"
         ]
@@ -200,6 +218,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-iOS-Client": [
@@ -221,6 +242,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "~> 2.3.6"
         ]
@@ -238,6 +262,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -259,6 +286,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -276,6 +306,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.3.2/Analytics.podspec.json
+++ b/Specs/Analytics/1.3.2/Analytics.podspec.json
@@ -31,9 +31,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ]
       }
     },
     {
@@ -66,11 +63,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.0.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.0.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -86,6 +86,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Apptimize": [
@@ -107,6 +110,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "~> 3.1.2"
         ]
@@ -124,6 +130,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -145,6 +154,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "~> 4.3.3"
         ]
@@ -162,6 +174,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -183,6 +198,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "3.0.7"
         ]
@@ -200,6 +218,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-iOS-Client": [
@@ -221,6 +242,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "~> 2.3.6"
         ]
@@ -238,6 +262,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -259,6 +286,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -276,6 +306,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.3.3/Analytics.podspec.json
+++ b/Specs/Analytics/1.3.3/Analytics.podspec.json
@@ -31,9 +31,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ]
       }
     },
     {
@@ -66,11 +63,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -86,6 +86,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Apptimize": [
@@ -107,6 +110,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "~> 3.1.2"
         ]
@@ -124,6 +130,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -145,6 +154,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "~> 4.3.3"
         ]
@@ -162,6 +174,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -183,6 +198,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "3.0.7"
         ]
@@ -200,6 +218,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-iOS-Client": [
@@ -221,6 +242,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "~> 2.3.6"
         ]
@@ -238,6 +262,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -259,6 +286,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -276,6 +306,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.4.0/Analytics.podspec.json
+++ b/Specs/Analytics/1.4.0/Analytics.podspec.json
@@ -31,9 +31,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ]
       }
     },
     {
@@ -66,11 +63,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -86,6 +86,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Apptimize": [
@@ -107,6 +110,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "~> 3.1.2"
         ]
@@ -124,6 +130,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -145,6 +154,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "~> 4.3.3"
         ]
@@ -162,6 +174,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -183,6 +198,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "3.0.7"
         ]
@@ -200,6 +218,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-iOS-Client": [
@@ -221,6 +242,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "~> 2.3.6"
         ]
@@ -238,6 +262,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -259,6 +286,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -276,6 +306,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.5.0/Analytics.podspec.json
+++ b/Specs/Analytics/1.5.0/Analytics.podspec.json
@@ -31,9 +31,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ]
       }
     },
     {
@@ -66,11 +63,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -86,6 +86,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Bugsnag": [
@@ -107,6 +110,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Countly": [
           "~> 2.0.0"
         ]
@@ -124,6 +130,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "CrittercismSDK": [
@@ -145,6 +154,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "FlurrySDK": [
           "~> 4.4.0"
         ]
@@ -162,6 +174,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "GoogleAnalytics-iOS-SDK": [
@@ -183,6 +198,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Localytics-iOS-Client": [
           "~> 2.23.0"
         ]
@@ -200,6 +218,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Mixpanel": [
@@ -221,6 +242,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "~> 0.5.51"
         ]
@@ -238,6 +262,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -259,6 +286,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -276,6 +306,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.5.1/Analytics.podspec.json
+++ b/Specs/Analytics/1.5.1/Analytics.podspec.json
@@ -31,9 +31,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ]
       }
     },
     {
@@ -66,11 +63,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -86,6 +86,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Bugsnag": [
@@ -107,6 +110,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Countly": [
           "~> 2.0.0"
         ]
@@ -124,6 +130,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "CrittercismSDK": [
@@ -145,6 +154,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "FlurrySDK": [
           "~> 4.4.0"
         ]
@@ -162,6 +174,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "GoogleAnalytics-iOS-SDK": [
@@ -183,6 +198,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Localytics-iOS-Client": [
           "~> 2.23.0"
         ]
@@ -200,6 +218,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Mixpanel": [
@@ -221,6 +242,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "~> 0.5.51"
         ]
@@ -238,6 +262,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -259,6 +286,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -276,6 +306,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.5.10/Analytics.podspec.json
+++ b/Specs/Analytics/1.5.10/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -81,11 +78,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -101,6 +101,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Bugsnag": [
@@ -122,6 +125,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Countly": [
           "~> 1.0.0"
         ]
@@ -139,6 +145,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "CrittercismSDK": [
@@ -160,6 +169,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "FlurrySDK": [
           "~> 4.4.0"
         ]
@@ -177,6 +189,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "GoogleAnalytics-iOS-SDK": [
@@ -198,6 +213,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Localytics-iOS-Client": [
           "~> 2.23.0"
         ]
@@ -215,6 +233,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Mixpanel": [
@@ -236,6 +257,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "~> 0.6.52"
         ]
@@ -253,6 +277,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -274,6 +301,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -291,6 +321,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.5.2/Analytics.podspec.json
+++ b/Specs/Analytics/1.5.2/Analytics.podspec.json
@@ -31,9 +31,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -69,11 +66,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -89,6 +89,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Bugsnag": [
@@ -110,6 +113,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Countly": [
           "~> 2.0.0"
         ]
@@ -127,6 +133,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "CrittercismSDK": [
@@ -148,6 +157,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "FlurrySDK": [
           "~> 4.4.0"
         ]
@@ -165,6 +177,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "GoogleAnalytics-iOS-SDK": [
@@ -186,6 +201,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Localytics-iOS-Client": [
           "~> 2.23.0"
         ]
@@ -203,6 +221,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Mixpanel": [
@@ -224,6 +245,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "~> 0.5.51"
         ]
@@ -241,6 +265,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -262,6 +289,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -279,6 +309,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.5.3/Analytics.podspec.json
+++ b/Specs/Analytics/1.5.3/Analytics.podspec.json
@@ -31,9 +31,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -69,11 +66,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -89,6 +89,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Bugsnag": [
@@ -110,6 +113,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Countly": [
           "~> 2.0.0"
         ]
@@ -127,6 +133,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "CrittercismSDK": [
@@ -148,6 +157,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "FlurrySDK": [
           "~> 4.4.0"
         ]
@@ -165,6 +177,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "GoogleAnalytics-iOS-SDK": [
@@ -186,6 +201,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Localytics-iOS-Client": [
           "~> 2.23.0"
         ]
@@ -203,6 +221,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Mixpanel": [
@@ -224,6 +245,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "~> 0.6.52"
         ]
@@ -241,6 +265,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -262,6 +289,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -279,6 +309,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.5.4/Analytics.podspec.json
+++ b/Specs/Analytics/1.5.4/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -77,11 +74,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -97,6 +97,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Bugsnag": [
@@ -118,6 +121,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Countly": [
           "~> 2.0.0"
         ]
@@ -135,6 +141,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "CrittercismSDK": [
@@ -156,6 +165,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "FlurrySDK": [
           "~> 4.4.0"
         ]
@@ -173,6 +185,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "GoogleAnalytics-iOS-SDK": [
@@ -194,6 +209,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Localytics-iOS-Client": [
           "~> 2.23.0"
         ]
@@ -211,6 +229,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Mixpanel": [
@@ -232,6 +253,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "~> 0.6.52"
         ]
@@ -249,6 +273,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -270,6 +297,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -287,6 +317,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.5.6/Analytics.podspec.json
+++ b/Specs/Analytics/1.5.6/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -77,11 +74,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -97,6 +97,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Bugsnag": [
@@ -118,6 +121,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Countly": [
           "~> 2.0.0"
         ]
@@ -135,6 +141,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "CrittercismSDK": [
@@ -156,6 +165,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "FlurrySDK": [
           "~> 4.4.0"
         ]
@@ -173,6 +185,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "GoogleAnalytics-iOS-SDK": [
@@ -194,6 +209,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Localytics-iOS-Client": [
           "~> 2.23.0"
         ]
@@ -211,6 +229,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Mixpanel": [
@@ -232,6 +253,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "~> 0.6.52"
         ]
@@ -249,6 +273,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -270,6 +297,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -287,6 +317,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.5.7/Analytics.podspec.json
+++ b/Specs/Analytics/1.5.7/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -77,11 +74,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -97,6 +97,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Bugsnag": [
@@ -118,6 +121,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Countly": [
           "~> 1.0.0"
         ]
@@ -135,6 +141,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "CrittercismSDK": [
@@ -156,6 +165,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "FlurrySDK": [
           "~> 4.4.0"
         ]
@@ -173,6 +185,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "GoogleAnalytics-iOS-SDK": [
@@ -194,6 +209,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Localytics-iOS-Client": [
           "~> 2.23.0"
         ]
@@ -211,6 +229,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Mixpanel": [
@@ -232,6 +253,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "~> 0.6.52"
         ]
@@ -249,6 +273,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -270,6 +297,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -287,6 +317,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.5.8/Analytics.podspec.json
+++ b/Specs/Analytics/1.5.8/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -77,11 +74,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -97,6 +97,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Bugsnag": [
@@ -118,6 +121,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Countly": [
           "~> 1.0.0"
         ]
@@ -135,6 +141,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "CrittercismSDK": [
@@ -156,6 +165,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "FlurrySDK": [
           "~> 4.4.0"
         ]
@@ -173,6 +185,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "GoogleAnalytics-iOS-SDK": [
@@ -194,6 +209,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Localytics-iOS-Client": [
           "~> 2.23.0"
         ]
@@ -211,6 +229,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Mixpanel": [
@@ -232,6 +253,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "~> 0.6.52"
         ]
@@ -249,6 +273,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -270,6 +297,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -287,6 +317,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.5.9/Analytics.podspec.json
+++ b/Specs/Analytics/1.5.9/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -77,11 +74,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -97,6 +97,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Bugsnag": [
@@ -118,6 +121,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Countly": [
           "~> 1.0.0"
         ]
@@ -135,6 +141,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "CrittercismSDK": [
@@ -156,6 +165,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "FlurrySDK": [
           "~> 4.4.0"
         ]
@@ -173,6 +185,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "GoogleAnalytics-iOS-SDK": [
@@ -194,6 +209,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Localytics-iOS-Client": [
           "~> 2.23.0"
         ]
@@ -211,6 +229,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Mixpanel": [
@@ -232,6 +253,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "~> 0.6.52"
         ]
@@ -249,6 +273,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -270,6 +297,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -287,6 +317,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [

--- a/Specs/Analytics/1.6.0/Analytics.podspec.json
+++ b/Specs/Analytics/1.6.0/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -78,11 +75,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -98,6 +98,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Bugsnag": [
@@ -119,6 +122,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Countly": [
           "~> 1.0.0"
         ]
@@ -136,6 +142,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "CrittercismSDK": [
@@ -157,6 +166,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "FlurrySDK": [
           "~> 4.4.0"
         ]
@@ -174,6 +186,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "GoogleAnalytics-iOS-SDK": [
@@ -195,6 +210,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Localytics-iOS-Client": [
           "~> 2.23.0"
         ]
@@ -212,6 +230,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Mixpanel": [
@@ -233,6 +254,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "~> 0.6.52"
         ]
@@ -250,6 +274,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [
@@ -271,6 +298,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Taplytics": [
           "~> 1.3.0"
         ]
@@ -290,6 +320,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -307,6 +340,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.6.1/Analytics.podspec.json
+++ b/Specs/Analytics/1.6.1/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -78,11 +75,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -98,6 +98,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Bugsnag": [
@@ -119,6 +122,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Countly": [
           "~> 1.0.0"
         ]
@@ -136,6 +142,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "CrittercismSDK": [
@@ -157,6 +166,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "FlurrySDK": [
           "~> 4.4.0"
         ]
@@ -174,6 +186,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "GoogleAnalytics-iOS-SDK": [
@@ -195,6 +210,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Localytics-iOS-Client": [
           "~> 2.23.0"
         ]
@@ -212,6 +230,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Mixpanel": [
@@ -233,6 +254,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "~> 0.6.52"
         ]
@@ -250,6 +274,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [
@@ -271,6 +298,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Taplytics": [
           "~> 1.3.0"
         ]
@@ -290,6 +320,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -307,6 +340,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.6.2/Analytics.podspec.json
+++ b/Specs/Analytics/1.6.2/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -78,11 +75,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -98,6 +98,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Bugsnag": [
@@ -119,6 +122,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Countly": [
           "~> 1.0.0"
         ]
@@ -136,6 +142,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "CrittercismSDK": [
@@ -157,6 +166,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "FlurrySDK": [
           "~> 4.4.0"
         ]
@@ -174,6 +186,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "GoogleAnalytics-iOS-SDK": [
@@ -195,6 +210,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Localytics-iOS-Client": [
           "~> 2.23.0"
         ]
@@ -212,6 +230,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Mixpanel": [
@@ -233,6 +254,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "~> 0.6.52"
         ]
@@ -250,6 +274,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [
@@ -271,6 +298,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Taplytics": [
           "~> 1.3.0"
         ]
@@ -290,6 +320,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -307,6 +340,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.7.0/Analytics.podspec.json
+++ b/Specs/Analytics/1.7.0/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -78,11 +75,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -98,6 +98,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "AppsFlyer-SDK": [
@@ -119,6 +122,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "~> 3.1.2"
         ]
@@ -136,6 +142,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -157,6 +166,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "~> 4.3.3"
         ]
@@ -174,6 +186,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -195,6 +210,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "~> 3.0.7"
         ]
@@ -212,6 +230,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-iOS-Client": [
@@ -233,6 +254,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "~> 2.3.6"
         ]
@@ -250,6 +274,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Optimizely-iOS-SDK": [
@@ -271,6 +298,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Quantcast-Measure": [
           "~> 1.4.4"
         ]
@@ -288,6 +318,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -309,6 +342,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -326,6 +362,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.7.1/Analytics.podspec.json
+++ b/Specs/Analytics/1.7.1/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -78,11 +75,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -98,6 +98,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "AppsFlyer-SDK": [
@@ -119,6 +122,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "~> 3.1.2"
         ]
@@ -136,6 +142,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -157,6 +166,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "~> 4.3.3"
         ]
@@ -174,6 +186,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -195,6 +210,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "~> 3.0.7"
         ]
@@ -212,6 +230,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-iOS-Client": [
@@ -233,6 +254,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "~> 2.5.0"
         ]
@@ -250,6 +274,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Optimizely-iOS-SDK": [
@@ -271,6 +298,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Quantcast-Measure": [
           "~> 1.4.4"
         ]
@@ -288,6 +318,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -309,6 +342,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -326,6 +362,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.7.10/Analytics.podspec.json
+++ b/Specs/Analytics/1.7.10/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -62,11 +59,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "2.1.1"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "2.1.1"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -82,6 +82,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "AppsFlyer-SDK": [
@@ -103,6 +106,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "3.1.2"
         ]
@@ -120,6 +126,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -141,6 +150,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "4.3.4"
         ]
@@ -158,6 +170,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -179,6 +194,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "3.0.9"
         ]
@@ -196,6 +214,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-AMP": [
@@ -217,6 +238,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "2.5.4"
         ]
@@ -236,6 +260,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "0.6.52"
         ]
@@ -253,6 +280,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [
@@ -290,6 +320,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Taplytics": [
           "2.0.10"
         ]
@@ -309,6 +342,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "2.8.1"
         ]
@@ -326,6 +362,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.7.2/Analytics.podspec.json
+++ b/Specs/Analytics/1.7.2/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -78,11 +75,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -98,6 +98,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "AppsFlyer-SDK": [
@@ -119,6 +122,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "~> 3.1.2"
         ]
@@ -136,6 +142,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -157,6 +166,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "~> 4.3.3"
         ]
@@ -174,6 +186,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -195,6 +210,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "~> 3.0.7"
         ]
@@ -212,6 +230,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-AMP": [
@@ -233,6 +254,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "~> 2.5.0"
         ]
@@ -250,6 +274,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Optimizely-iOS-SDK": [
@@ -271,6 +298,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Quantcast-Measure": [
           "~> 1.4.4"
         ]
@@ -288,6 +318,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -309,6 +342,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -326,6 +362,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.7.3/Analytics.podspec.json
+++ b/Specs/Analytics/1.7.3/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -78,11 +75,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -98,6 +98,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "AppsFlyer-SDK": [
@@ -119,6 +122,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "~> 3.1.2"
         ]
@@ -136,6 +142,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -157,6 +166,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "~> 4.3.3"
         ]
@@ -174,6 +186,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -195,6 +210,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "~> 3.0.7"
         ]
@@ -212,6 +230,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-AMP": [
@@ -233,6 +254,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "~> 2.5.0"
         ]
@@ -250,6 +274,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Optimizely-iOS-SDK": [
@@ -271,6 +298,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Quantcast-Measure": [
           "~> 1.4.4"
         ]
@@ -288,6 +318,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -309,6 +342,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -326,6 +362,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.7.4/Analytics.podspec.json
+++ b/Specs/Analytics/1.7.4/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -78,11 +75,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -98,6 +98,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "AppsFlyer-SDK": [
@@ -119,6 +122,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "~> 3.1.2"
         ]
@@ -136,6 +142,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -157,6 +166,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "~> 4.3.3"
         ]
@@ -174,6 +186,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -195,6 +210,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "3.0.9"
         ]
@@ -212,6 +230,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-AMP": [
@@ -233,6 +254,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "2.5.1"
         ]
@@ -250,6 +274,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Optimizely-iOS-SDK": [
@@ -271,6 +298,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Quantcast-Measure": [
           "~> 1.4.4"
         ]
@@ -288,6 +318,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -309,6 +342,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -326,6 +362,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.7.5/Analytics.podspec.json
+++ b/Specs/Analytics/1.7.5/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -78,11 +75,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -98,6 +98,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "AppsFlyer-SDK": [
@@ -119,6 +122,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "~> 3.1.2"
         ]
@@ -136,6 +142,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -157,6 +166,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "~> 4.3.3"
         ]
@@ -174,6 +186,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -195,6 +210,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "3.0.9"
         ]
@@ -212,6 +230,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-AMP": [
@@ -233,6 +254,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "2.5.1"
         ]
@@ -250,6 +274,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Optimizely-iOS-SDK": [
@@ -271,6 +298,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Quantcast-Measure": [
           "~> 1.4.4"
         ]
@@ -288,6 +318,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -309,6 +342,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -326,6 +362,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.7.6/Analytics.podspec.json
+++ b/Specs/Analytics/1.7.6/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -78,11 +75,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -98,6 +98,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "AppsFlyer-SDK": [
@@ -119,6 +122,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "~> 3.1.2"
         ]
@@ -136,6 +142,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -157,6 +166,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "~> 4.3.3"
         ]
@@ -174,6 +186,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -195,6 +210,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "3.0.9"
         ]
@@ -212,6 +230,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-AMP": [
@@ -233,6 +254,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "2.5.1"
         ]
@@ -250,6 +274,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Optimizely-iOS-SDK": [
@@ -271,6 +298,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Quantcast-Measure": [
           "~> 1.4.4"
         ]
@@ -288,6 +318,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -309,6 +342,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -326,6 +362,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.7.7/Analytics.podspec.json
+++ b/Specs/Analytics/1.7.7/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -78,11 +75,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "~> 2.1.0"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "~> 2.1.0"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -98,6 +98,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "AppsFlyer-SDK": [
@@ -119,6 +122,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "~> 3.1.2"
         ]
@@ -136,6 +142,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -157,6 +166,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "~> 4.3.3"
         ]
@@ -174,6 +186,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -195,6 +210,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "3.0.9"
         ]
@@ -212,6 +230,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-AMP": [
@@ -233,6 +254,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "2.5.3"
         ]
@@ -250,6 +274,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Optimizely-iOS-SDK": [
@@ -271,6 +298,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Quantcast-Measure": [
           "~> 1.4.4"
         ]
@@ -288,6 +318,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Taplytics": [
@@ -309,6 +342,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "~> 2.7"
         ]
@@ -326,6 +362,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.7.8/Analytics.podspec.json
+++ b/Specs/Analytics/1.7.8/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -62,11 +59,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "2.1.1"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "2.1.1"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -82,6 +82,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "AppsFlyer-SDK": [
@@ -103,6 +106,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "3.1.2"
         ]
@@ -120,6 +126,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -141,6 +150,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "4.3.4"
         ]
@@ -158,6 +170,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -179,6 +194,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "3.0.9"
         ]
@@ -196,6 +214,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-AMP": [
@@ -217,6 +238,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "2.5.3"
         ]
@@ -236,6 +260,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "0.6.52"
         ]
@@ -253,6 +280,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [
@@ -290,6 +320,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Taplytics": [
           "2.0.10"
         ]
@@ -309,6 +342,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "2.8.1"
         ]
@@ -326,6 +362,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.7.9/Analytics.podspec.json
+++ b/Specs/Analytics/1.7.9/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -62,11 +59,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "2.1.1"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "2.1.1"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -82,6 +82,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "AppsFlyer-SDK": [
@@ -103,6 +106,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "3.1.2"
         ]
@@ -120,6 +126,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -141,6 +150,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "4.3.4"
         ]
@@ -158,6 +170,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -179,6 +194,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "3.0.9"
         ]
@@ -196,6 +214,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-AMP": [
@@ -217,6 +238,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "2.5.3"
         ]
@@ -236,6 +260,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "0.6.52"
         ]
@@ -253,6 +280,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [
@@ -290,6 +320,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Taplytics": [
           "2.0.10"
         ]
@@ -309,6 +342,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "2.8.1"
         ]
@@ -326,6 +362,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.8.0/Analytics.podspec.json
+++ b/Specs/Analytics/1.8.0/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -60,11 +57,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "2.1.1"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "2.1.1"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -80,6 +80,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "AppsFlyer-SDK": [
@@ -101,6 +104,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "3.1.2"
         ]
@@ -118,6 +124,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -139,6 +148,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "4.3.4"
         ]
@@ -156,6 +168,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -177,6 +192,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "3.0.9"
         ]
@@ -194,6 +212,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-AMP": [
@@ -215,6 +236,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "2.5.4"
         ]
@@ -234,6 +258,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "0.7.55"
         ]
@@ -251,6 +278,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [
@@ -288,6 +318,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Taplytics": [
           "2.0.10"
         ]
@@ -307,6 +340,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "2.8.1"
         ]
@@ -324,6 +360,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.8.1/Analytics.podspec.json
+++ b/Specs/Analytics/1.8.1/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -60,11 +57,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "2.1.1"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "2.1.1"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -80,6 +80,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "AppsFlyer-SDK": [
@@ -101,6 +104,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "3.1.2"
         ]
@@ -118,6 +124,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -139,6 +148,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "4.3.4"
         ]
@@ -156,6 +168,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -177,6 +192,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "3.0.9"
         ]
@@ -194,6 +212,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-AMP": [
@@ -215,6 +236,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "2.5.4"
         ]
@@ -234,6 +258,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "0.7.55"
         ]
@@ -251,6 +278,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [
@@ -288,6 +318,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Taplytics": [
           "2.0.10"
         ]
@@ -307,6 +340,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "2.8.3"
         ]
@@ -324,6 +360,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.8.2/Analytics.podspec.json
+++ b/Specs/Analytics/1.8.2/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -60,11 +57,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "2.1.1"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "2.1.1"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -80,6 +80,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "AppsFlyer-SDK": [
@@ -101,6 +104,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "3.1.2"
         ]
@@ -118,6 +124,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -139,6 +148,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "4.3.4"
         ]
@@ -156,6 +168,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -177,6 +192,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "3.0.9"
         ]
@@ -194,6 +212,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-AMP": [
@@ -215,6 +236,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "2.5.4"
         ]
@@ -234,6 +258,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "0.7.55"
         ]
@@ -251,6 +278,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [
@@ -288,6 +318,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Taplytics": [
           "2.0.10"
         ]
@@ -307,6 +340,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "2.8.3"
         ]
@@ -324,6 +360,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.8.3/Analytics.podspec.json
+++ b/Specs/Analytics/1.8.3/Analytics.podspec.json
@@ -34,9 +34,6 @@
         "ios"
       ],
       "dependencies": {
-        "Analytics/Segmentio": [
-
-        ],
         "TRVSDictionaryWithCaseInsensitivity": [
           "0.0.2"
         ]
@@ -60,11 +57,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "2.1.1"
+        ],
         "Analytics/Core-iOS": [
 
         ],
-        "Amplitude-iOS": [
-          "2.1.1"
+        "Analytics/Segmentio": [
+
         ]
       }
     },
@@ -80,6 +80,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "AppsFlyer-SDK": [
@@ -101,6 +104,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Bugsnag": [
           "3.1.2"
         ]
@@ -118,6 +124,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Countly": [
@@ -139,6 +148,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "CrittercismSDK": [
           "4.3.4"
         ]
@@ -156,6 +168,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "FlurrySDK": [
@@ -177,6 +192,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "GoogleAnalytics-iOS-SDK": [
           "3.0.9"
         ]
@@ -194,6 +212,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Localytics-AMP": [
@@ -215,6 +236,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Mixpanel": [
           "2.5.4"
         ]
@@ -234,6 +258,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Optimizely-iOS-SDK": [
           "0.7.55"
         ]
@@ -251,6 +278,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "Quantcast-Measure": [
@@ -288,6 +318,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Taplytics": [
           "2.0.10"
         ]
@@ -307,6 +340,9 @@
         "Analytics/Core-iOS": [
 
         ],
+        "Analytics/Segmentio": [
+
+        ],
         "Tapstream": [
           "2.8.3"
         ]
@@ -324,6 +360,9 @@
       ],
       "dependencies": {
         "Analytics/Core-iOS": [
+
+        ],
+        "Analytics/Segmentio": [
 
         ],
         "TestFlightSDK": [

--- a/Specs/Analytics/1.8.4/Analytics.podspec.json
+++ b/Specs/Analytics/1.8.4/Analytics.podspec.json
@@ -57,14 +57,14 @@
         "ios"
       ],
       "dependencies": {
+        "Amplitude-iOS": [
+          "2.1.1"
+        ],
         "Analytics/Core-iOS": [
 
         ],
         "Analytics/Segmentio": [
 
-        ],
-        "Amplitude-iOS": [
-          "2.1.1"
         ]
       }
     },

--- a/Specs/DZNPhotoPickerController/1.4.3/DZNPhotoPickerController.podspec.json
+++ b/Specs/DZNPhotoPickerController/1.4.3/DZNPhotoPickerController.podspec.json
@@ -35,9 +35,6 @@
   ],
   "header_mappings_dir": "Source",
   "dependencies": {
-    "DZNPhotoPickerController/UIImagePickerControllerExtended": [
-
-    ],
     "AFNetworking": [
       "~> 2.2"
     ],

--- a/Specs/DZNPhotoPickerController/1.4.4/DZNPhotoPickerController.podspec.json
+++ b/Specs/DZNPhotoPickerController/1.4.4/DZNPhotoPickerController.podspec.json
@@ -35,9 +35,6 @@
   ],
   "header_mappings_dir": "Source",
   "dependencies": {
-    "DZNPhotoPickerController/UIImagePickerControllerExtended": [
-
-    ],
     "AFNetworking": [
       "~> 2.2"
     ],

--- a/Specs/DZNPhotoPickerController/1.4.5/DZNPhotoPickerController.podspec.json
+++ b/Specs/DZNPhotoPickerController/1.4.5/DZNPhotoPickerController.podspec.json
@@ -35,9 +35,6 @@
   ],
   "header_mappings_dir": "Source",
   "dependencies": {
-    "DZNPhotoPickerController/UIImagePickerControllerExtended": [
-
-    ],
     "AFNetworking": [
       "~> 2.2"
     ],

--- a/Specs/DZNPhotoPickerController/1.5/DZNPhotoPickerController.podspec.json
+++ b/Specs/DZNPhotoPickerController/1.5/DZNPhotoPickerController.podspec.json
@@ -35,9 +35,6 @@
   ],
   "header_mappings_dir": "Source",
   "dependencies": {
-    "DZNPhotoPickerController/UIImagePickerControllerExtended": [
-
-    ],
     "AFNetworking": [
       "~> 2.3.1"
     ],

--- a/Specs/Fancy-iOS/0.7.1/Fancy-iOS.podspec.json
+++ b/Specs/Fancy-iOS/0.7.1/Fancy-iOS.podspec.json
@@ -39,9 +39,6 @@
       "dependencies": {
         "Fancy-iOS/Core": [
 
-        ],
-        "Fancy-iOS/UI/Core": [
-
         ]
       },
       "subspecs": [
@@ -56,7 +53,12 @@
         },
         {
           "name": "RangeSlider",
-          "source_files": "src/ui/range-slider/*.{h,m}"
+          "source_files": "src/ui/range-slider/*.{h,m}",
+          "dependencies": {
+            "Fancy-iOS/UI/Core": [
+
+            ]
+          }
         }
       ]
     }

--- a/Specs/Fancy-iOS/0.7.2/Fancy-iOS.podspec.json
+++ b/Specs/Fancy-iOS/0.7.2/Fancy-iOS.podspec.json
@@ -39,9 +39,6 @@
       "dependencies": {
         "Fancy-iOS/Core": [
 
-        ],
-        "Fancy-iOS/UI/Core": [
-
         ]
       },
       "subspecs": [
@@ -56,7 +53,12 @@
         },
         {
           "name": "RangeSlider",
-          "source_files": "src/ui/range-slider/*.{h,m}"
+          "source_files": "src/ui/range-slider/*.{h,m}",
+          "dependencies": {
+            "Fancy-iOS/UI/Core": [
+
+            ]
+          }
         }
       ]
     }

--- a/Specs/KFData/1.0.0-RC1/KFData.podspec.json
+++ b/Specs/KFData/1.0.0-RC1/KFData.podspec.json
@@ -16,7 +16,7 @@
     "osx": "10.7",
     "ios": "5.0"
   },
-  "default_subspec": "Essentials",
+  "default_subspecs": "Essentials",
   "subspecs": [
     {
       "name": "Core",
@@ -52,7 +52,10 @@
     {
       "name": "UI",
       "dependencies": {
-        "KFData/Essentials": [
+        "KFData/Core": [
+
+        ],
+        "KFData/Store": [
 
         ]
       },

--- a/Specs/KFData/1.0.0-RC2/KFData.podspec.json
+++ b/Specs/KFData/1.0.0-RC2/KFData.podspec.json
@@ -16,7 +16,7 @@
     "osx": "10.7",
     "ios": "5.0"
   },
-  "default_subspec": "Essentials",
+  "default_subspecs": "Essentials",
   "subspecs": [
     {
       "name": "Core",
@@ -52,7 +52,10 @@
     {
       "name": "UI",
       "dependencies": {
-        "KFData/Essentials": [
+        "KFData/Core": [
+
+        ],
+        "KFData/Store": [
 
         ]
       },

--- a/Specs/KFData/1.0.0/KFData.podspec.json
+++ b/Specs/KFData/1.0.0/KFData.podspec.json
@@ -16,7 +16,7 @@
     "osx": "10.7",
     "ios": "5.0"
   },
-  "default_subspec": "Essentials",
+  "default_subspecs": "Essentials",
   "subspecs": [
     {
       "name": "Core",
@@ -52,7 +52,10 @@
     {
       "name": "UI",
       "dependencies": {
-        "KFData/Essentials": [
+        "KFData/Core": [
+
+        ],
+        "KFData/Store": [
 
         ]
       },

--- a/Specs/KFData/1.0.1/KFData.podspec.json
+++ b/Specs/KFData/1.0.1/KFData.podspec.json
@@ -17,7 +17,7 @@
     "osx": "10.7",
     "ios": "5.0"
   },
-  "default_subspec": "Essentials",
+  "default_subspecs": "Essentials",
   "header_dir": "KFData",
   "subspecs": [
     {
@@ -61,7 +61,13 @@
     {
       "name": "UI",
       "dependencies": {
-        "KFData/Essentials": [
+        "KFData/Attribute": [
+
+        ],
+        "KFData/Core": [
+
+        ],
+        "KFData/Store": [
 
         ]
       },

--- a/Specs/KFData/1.0.2/KFData.podspec.json
+++ b/Specs/KFData/1.0.2/KFData.podspec.json
@@ -17,7 +17,7 @@
     "osx": "10.7",
     "ios": "5.0"
   },
-  "default_subspec": "Essentials",
+  "default_subspecs": "Essentials",
   "header_dir": "KFData",
   "subspecs": [
     {
@@ -70,7 +70,16 @@
     {
       "name": "UI",
       "dependencies": {
-        "KFData/Essentials": [
+        "KFData/Attribute": [
+
+        ],
+        "KFData/Core": [
+
+        ],
+        "KFData/Manager": [
+
+        ],
+        "KFData/Store": [
 
         ]
       },

--- a/Specs/KFData/1.0.3/KFData.podspec.json
+++ b/Specs/KFData/1.0.3/KFData.podspec.json
@@ -70,7 +70,16 @@
     {
       "name": "UI",
       "dependencies": {
-        "KFData/Essentials": [
+        "KFData/Attribute": [
+
+        ],
+        "KFData/Core": [
+
+        ],
+        "KFData/Manager": [
+
+        ],
+        "KFData/Store": [
 
         ]
       },

--- a/Specs/KFData/1.0.4/KFData.podspec.json
+++ b/Specs/KFData/1.0.4/KFData.podspec.json
@@ -80,6 +80,15 @@
     {
       "name": "UI",
       "dependencies": {
+        "KFData/Core": [
+
+        ],
+        "KFData/Store": [
+
+        ],
+        "KFData/Attribute": [
+
+        ],
         "KFData/Manager": [
 
         ]

--- a/Specs/LWFKit/0.1.0/LWFKit.podspec.json
+++ b/Specs/LWFKit/0.1.0/LWFKit.podspec.json
@@ -37,17 +37,6 @@
     "LWFKit/Externals/Ejecta/EJCanvas/2D/Shaders/*"
   ],
   "requires_arc": true,
-  "dependencies": {
-    "LWFKit/JavaScriptCore": [
-
-    ],
-    "LWFKit/Ejecta": [
-
-    ],
-    "LWFKit/Bindings": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "JavaScriptCore",

--- a/Specs/LumberjackConsole/1.0.0/LumberjackConsole.podspec.json
+++ b/Specs/LumberjackConsole/1.0.0/LumberjackConsole.podspec.json
@@ -33,9 +33,6 @@
     ],
     "CocoaLumberjack": [
       ">= 1.6.3"
-    ],
-    "LumberjackConsole/Base": [
-
     ]
   },
   "subspecs": [

--- a/Specs/LumberjackConsole/1.0.1/LumberjackConsole.podspec.json
+++ b/Specs/LumberjackConsole/1.0.1/LumberjackConsole.podspec.json
@@ -33,9 +33,6 @@
     ],
     "CocoaLumberjack": [
       ">= 1.6.4"
-    ],
-    "LumberjackConsole/Base": [
-
     ]
   },
   "subspecs": [

--- a/Specs/LumberjackConsole/1.0.2/LumberjackConsole.podspec.json
+++ b/Specs/LumberjackConsole/1.0.2/LumberjackConsole.podspec.json
@@ -33,9 +33,6 @@
     ],
     "CocoaLumberjack": [
       ">= 1.6.4"
-    ],
-    "LumberjackConsole/Base": [
-
     ]
   },
   "subspecs": [

--- a/Specs/LumberjackConsole/1.0.3/LumberjackConsole.podspec.json
+++ b/Specs/LumberjackConsole/1.0.3/LumberjackConsole.podspec.json
@@ -33,7 +33,7 @@
     ],
     "CocoaLumberjack": [
       ">= 1.6.4"
-    ],
+    ]
   },
   "subspecs": [
     {

--- a/Specs/LumberjackConsole/1.0.3/LumberjackConsole.podspec.json
+++ b/Specs/LumberjackConsole/1.0.3/LumberjackConsole.podspec.json
@@ -34,9 +34,6 @@
     "CocoaLumberjack": [
       ">= 1.6.4"
     ],
-    "LumberjackConsole/Base": [
-
-    ]
   },
   "subspecs": [
     {

--- a/Specs/MyiOSViewHelpers/0.1.0/MyiOSViewHelpers.podspec.json
+++ b/Specs/MyiOSViewHelpers/0.1.0/MyiOSViewHelpers.podspec.json
@@ -169,9 +169,6 @@
           "source_files": "MyiOSViewHelpers/Screens/PickerView/*.{h,m}",
           "ios": {
             "dependencies": {
-              "MyiOSViewHelpers/Screens/PickerView": [
-                "0.1.0"
-              ],
               "MyiOSHelpers/Logic/Blocks": [
                 "~>0.1.0"
               ],

--- a/Specs/MyiOSViewHelpers/1.0.0/MyiOSViewHelpers.podspec.json
+++ b/Specs/MyiOSViewHelpers/1.0.0/MyiOSViewHelpers.podspec.json
@@ -169,9 +169,6 @@
           "source_files": "MyiOSViewHelpers/Screens/PickerView/*.{h,m}",
           "ios": {
             "dependencies": {
-              "MyiOSViewHelpers/Screens/PickerView": [
-                "1.0.0"
-              ],
               "MyiOSHelpers/Logic/Blocks": [
                 "~>1.0.0"
               ],

--- a/Specs/MyiOSViewHelpers/1.0.1/MyiOSViewHelpers.podspec.json
+++ b/Specs/MyiOSViewHelpers/1.0.1/MyiOSViewHelpers.podspec.json
@@ -169,9 +169,6 @@
           "source_files": "MyiOSViewHelpers/Screens/PickerView/*.{h,m}",
           "ios": {
             "dependencies": {
-              "MyiOSViewHelpers/Screens/PickerView": [
-                "1.0.1"
-              ],
               "MyiOSHelpers/Logic/Blocks": [
                 "~> 1.0.3"
               ],

--- a/Specs/OMGHTTPURLRQ/1.1.4/OMGHTTPURLRQ.podspec.json
+++ b/Specs/OMGHTTPURLRQ/1.1.4/OMGHTTPURLRQ.podspec.json
@@ -20,18 +20,18 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "source_files": "OMGHTTPURLRQ.{h,m}",
-  "dependencies": {
-    "ChuzzleKit": [
-
-    ],
-    "OMGHTTPURLRQ/UserAgent": [
-
-    ]
-  },
   "subspecs": [
     {
-      "name": "RQ"
+      "name": "RQ",
+      "source_files": "OMGHTTPURLRQ.{h,m}",
+      "dependencies": {
+        "ChuzzleKit": [
+
+        ],
+        "OMGHTTPURLRQ/UserAgent": [
+
+        ]
+      }
     },
     {
       "name": "UserAgent",

--- a/Specs/OMGHTTPURLRQ/1.1.5/OMGHTTPURLRQ.podspec.json
+++ b/Specs/OMGHTTPURLRQ/1.1.5/OMGHTTPURLRQ.podspec.json
@@ -20,15 +20,15 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "source_files": "OMGHTTPURLRQ.{h,m}",
-  "dependencies": {
-    "OMGHTTPURLRQ/UserAgent": [
-
-    ]
-  },
   "subspecs": [
     {
-      "name": "RQ"
+      "name": "RQ",
+      "source_files": "OMGHTTPURLRQ.{h,m}",
+      "dependencies": {
+        "OMGHTTPURLRQ/UserAgent": [
+
+        ]
+      }
     },
     {
       "name": "UserAgent",

--- a/Specs/OMGHTTPURLRQ/1.1.6/OMGHTTPURLRQ.podspec.json
+++ b/Specs/OMGHTTPURLRQ/1.1.6/OMGHTTPURLRQ.podspec.json
@@ -20,15 +20,15 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "source_files": "OMGHTTPURLRQ.{h,m}",
-  "dependencies": {
-    "OMGHTTPURLRQ/UserAgent": [
-
-    ]
-  },
   "subspecs": [
     {
-      "name": "RQ"
+      "name": "RQ",
+      "source_files": "OMGHTTPURLRQ.{h,m}",
+      "dependencies": {
+        "OMGHTTPURLRQ/UserAgent": [
+
+        ]
+      }
     },
     {
       "name": "UserAgent",

--- a/Specs/OMGHTTPURLRQ/2.0.1/OMGHTTPURLRQ.podspec.json
+++ b/Specs/OMGHTTPURLRQ/2.0.1/OMGHTTPURLRQ.podspec.json
@@ -20,15 +20,15 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "source_files": "OMGHTTPURLRQ.{h,m}",
-  "dependencies": {
-    "OMGHTTPURLRQ/UserAgent": [
-
-    ]
-  },
   "subspecs": [
     {
-      "name": "RQ"
+      "name": "RQ",
+      "source_files": "OMGHTTPURLRQ.{h,m}",
+      "dependencies": {
+        "OMGHTTPURLRQ/UserAgent": [
+
+        ]
+      }
     },
     {
       "name": "UserAgent",

--- a/Specs/OMGHTTPURLRQ/2.0/OMGHTTPURLRQ.podspec.json
+++ b/Specs/OMGHTTPURLRQ/2.0/OMGHTTPURLRQ.podspec.json
@@ -20,15 +20,15 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "source_files": "OMGHTTPURLRQ.{h,m}",
-  "dependencies": {
-    "OMGHTTPURLRQ/UserAgent": [
-
-    ]
-  },
   "subspecs": [
     {
-      "name": "RQ"
+      "name": "RQ",
+      "source_files": "OMGHTTPURLRQ.{h,m}",
+      "dependencies": {
+        "OMGHTTPURLRQ/UserAgent": [
+
+        ]
+      }
     },
     {
       "name": "UserAgent",

--- a/Specs/OMGHTTPURLRQ/2.1/OMGHTTPURLRQ.podspec.json
+++ b/Specs/OMGHTTPURLRQ/2.1/OMGHTTPURLRQ.podspec.json
@@ -21,18 +21,18 @@
     "osx": "10.7"
   },
   "default_subspecs": "RQ",
-  "source_files": "OMGHTTPURLRQ.{h,m}",
-  "dependencies": {
-    "OMGHTTPURLRQ/UserAgent": [
-
-    ],
-    "OMGHTTPURLRQ/FormURLEncode": [
-
-    ]
-  },
   "subspecs": [
     {
-      "name": "RQ"
+      "name": "RQ",
+      "source_files": "OMGHTTPURLRQ.{h,m}",
+      "dependencies": {
+        "OMGHTTPURLRQ/UserAgent": [
+
+        ],
+        "OMGHTTPURLRQ/FormURLEncode": [
+
+        ]
+      }
     },
     {
       "name": "UserAgent",

--- a/Specs/Objective-LevelDB/2.0.0/Objective-LevelDB.podspec.json
+++ b/Specs/Objective-LevelDB/2.0.0/Objective-LevelDB.podspec.json
@@ -19,11 +19,6 @@
     "submodules": true
   },
   "source_files": "Classes/*.{h,m,mm}",
-  "dependencies": {
-    "Objective-LevelDB/leveldb": [
-
-    ]
-  },
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Objective-LevelDB/2.0.1/Objective-LevelDB.podspec.json
+++ b/Specs/Objective-LevelDB/2.0.1/Objective-LevelDB.podspec.json
@@ -19,11 +19,6 @@
     "submodules": true
   },
   "source_files": "Classes/*.{h,m,mm}",
-  "dependencies": {
-    "Objective-LevelDB/leveldb": [
-
-    ]
-  },
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Objective-LevelDB/2.0.2/Objective-LevelDB.podspec.json
+++ b/Specs/Objective-LevelDB/2.0.2/Objective-LevelDB.podspec.json
@@ -19,11 +19,6 @@
     "submodules": true
   },
   "source_files": "Classes/*.{h,m,mm}",
-  "dependencies": {
-    "Objective-LevelDB/leveldb": [
-
-    ]
-  },
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Objective-LevelDB/2.0.3/Objective-LevelDB.podspec.json
+++ b/Specs/Objective-LevelDB/2.0.3/Objective-LevelDB.podspec.json
@@ -19,11 +19,6 @@
     "submodules": true
   },
   "source_files": "Classes/*.{h,m,mm}",
-  "dependencies": {
-    "Objective-LevelDB/leveldb": [
-
-    ]
-  },
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Objective-LevelDB/2.0.4/Objective-LevelDB.podspec.json
+++ b/Specs/Objective-LevelDB/2.0.4/Objective-LevelDB.podspec.json
@@ -19,11 +19,6 @@
     "submodules": true
   },
   "source_files": "Classes/*.{h,m,mm}",
-  "dependencies": {
-    "Objective-LevelDB/leveldb": [
-
-    ]
-  },
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Objective-LevelDB/2.0.5/Objective-LevelDB.podspec.json
+++ b/Specs/Objective-LevelDB/2.0.5/Objective-LevelDB.podspec.json
@@ -19,11 +19,6 @@
     "submodules": true
   },
   "source_files": "Classes/*.{h,m,mm}",
-  "dependencies": {
-    "Objective-LevelDB/leveldb": [
-
-    ]
-  },
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Objective-LevelDB/2.0.6/Objective-LevelDB.podspec.json
+++ b/Specs/Objective-LevelDB/2.0.6/Objective-LevelDB.podspec.json
@@ -19,11 +19,6 @@
     "submodules": true
   },
   "source_files": "Classes/*.{h,m,mm}",
-  "dependencies": {
-    "Objective-LevelDB/leveldb": [
-
-    ]
-  },
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Objective-LevelDB/2.0.7/Objective-LevelDB.podspec.json
+++ b/Specs/Objective-LevelDB/2.0.7/Objective-LevelDB.podspec.json
@@ -19,11 +19,6 @@
     "submodules": true
   },
   "source_files": "Classes/*.{h,m,mm}",
-  "dependencies": {
-    "Objective-LevelDB/leveldb": [
-
-    ]
-  },
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Objective-LevelDB/2.0.8/Objective-LevelDB.podspec.json
+++ b/Specs/Objective-LevelDB/2.0.8/Objective-LevelDB.podspec.json
@@ -19,11 +19,6 @@
     "submodules": true
   },
   "source_files": "Classes/*.{h,m,mm}",
-  "dependencies": {
-    "Objective-LevelDB/leveldb": [
-
-    ]
-  },
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Objective-LevelDB/2.1.0/Objective-LevelDB.podspec.json
+++ b/Specs/Objective-LevelDB/2.1.0/Objective-LevelDB.podspec.json
@@ -19,11 +19,6 @@
     "submodules": true
   },
   "source_files": "Classes/*.{h,m,mm}",
-  "dependencies": {
-    "Objective-LevelDB/leveldb": [
-
-    ]
-  },
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/RZUtils/2.0.0/RZUtils.podspec.json
+++ b/Specs/RZUtils/2.0.0/RZUtils.podspec.json
@@ -33,47 +33,6 @@
   "subspecs": [
     {
       "name": "Categories",
-      "dependencies": {
-        "RZUtils/Categories/CoreAnimation": [
-
-        ],
-        "RZUtils/Categories/KVO": [
-
-        ],
-        "RZUtils/Categories/NSDate": [
-
-        ],
-        "RZUtils/Categories/NSDictionary": [
-
-        ],
-        "RZUtils/Categories/NSString": [
-
-        ],
-        "RZUtils/Categories/NSUndoManager": [
-
-        ],
-        "RZUtils/Categories/UIAlertView": [
-
-        ],
-        "RZUtils/Categories/UIColor": [
-
-        ],
-        "RZUtils/Categories/UIFont": [
-
-        ],
-        "RZUtils/Categories/UIImage": [
-
-        ],
-        "RZUtils/Categories/UIImageView": [
-
-        ],
-        "RZUtils/Categories/UIView": [
-
-        ],
-        "RZUtils/Categories/UIViewController": [
-
-        ]
-      },
       "subspecs": [
         {
           "name": "CoreAnimation",
@@ -132,53 +91,6 @@
     },
     {
       "name": "Components",
-      "dependencies": {
-        "RZUtils/Components/RZAnimatedCountingLabel": [
-
-        ],
-        "RZUtils/Components/RZAnimatedImageView": [
-
-        ],
-        "RZUtils/Components/RZButtonView": [
-
-        ],
-        "RZUtils/Components/RZCollectionTableView": [
-
-        ],
-        "RZUtils/Components/RZCollectionViewAnimationAssistant": [
-
-        ],
-        "RZUtils/Components/RZDelayedOperation": [
-
-        ],
-        "RZUtils/Components/RZLocationService": [
-
-        ],
-        "RZUtils/Components/RZProgressView": [
-
-        ],
-        "RZUtils/Components/RZRevealViewController": [
-
-        ],
-        "RZUtils/Components/RZSegmentedViewController": [
-
-        ],
-        "RZUtils/Components/RZSingleChildContainerViewController": [
-
-        ],
-        "RZUtils/Components/RZSplitViewController": [
-
-        ],
-        "RZUtils/Components/RZTelprompt": [
-
-        ],
-        "RZUtils/Components/RZViewFactory": [
-
-        ],
-        "RZUtils/Components/RZWebViewController": [
-
-        ]
-      },
       "subspecs": [
         {
           "name": "RZAnimatedCountingLabel",
@@ -248,11 +160,6 @@
     },
     {
       "name": "TestUtilities",
-      "dependencies": {
-        "RZUtils/TestUtilities/RZWaiter": [
-
-        ]
-      },
       "subspecs": [
         {
           "name": "RZWaiter",
@@ -262,14 +169,6 @@
     },
     {
       "name": "Utilities",
-      "dependencies": {
-        "RZUtils/Utilities/RZCommonUtils": [
-
-        ],
-        "RZUtils/Utilities/RZDispatch": [
-
-        ]
-      },
       "subspecs": [
         {
           "name": "RZCommonUtils",

--- a/Specs/SlackTextViewController/1.0/SlackTextViewController.podspec.json
+++ b/Specs/SlackTextViewController/1.0/SlackTextViewController.podspec.json
@@ -25,11 +25,6 @@
     "Source/Classes/*.{h,m}"
   ],
   "frameworks": "UIKit",
-  "dependencies": {
-    "SlackTextViewController/Additions": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Additions",

--- a/Specs/SlackTextViewController/1.1.1/SlackTextViewController.podspec.json
+++ b/Specs/SlackTextViewController/1.1.1/SlackTextViewController.podspec.json
@@ -26,11 +26,6 @@
     "Source/Classes/*.{h,m}"
   ],
   "frameworks": "UIKit",
-  "dependencies": {
-    "SlackTextViewController/Additions": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Additions",

--- a/Specs/SlackTextViewController/1.1/SlackTextViewController.podspec.json
+++ b/Specs/SlackTextViewController/1.1/SlackTextViewController.podspec.json
@@ -26,11 +26,6 @@
     "Source/Classes/*.{h,m}"
   ],
   "frameworks": "UIKit",
-  "dependencies": {
-    "SlackTextViewController/Additions": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Additions",

--- a/Specs/SlackTextViewController/1.2.1/SlackTextViewController.podspec.json
+++ b/Specs/SlackTextViewController/1.2.1/SlackTextViewController.podspec.json
@@ -26,11 +26,6 @@
     "Source/Classes/*.{h,m}"
   ],
   "frameworks": "UIKit",
-  "dependencies": {
-    "SlackTextViewController/Additions": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Additions",

--- a/Specs/SlackTextViewController/1.2.10/SlackTextViewController.podspec.json
+++ b/Specs/SlackTextViewController/1.2.10/SlackTextViewController.podspec.json
@@ -26,11 +26,6 @@
     "Source/Classes/*.{h,m}"
   ],
   "frameworks": "UIKit",
-  "dependencies": {
-    "SlackTextViewController/Additions": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Additions",

--- a/Specs/SlackTextViewController/1.2.2/SlackTextViewController.podspec.json
+++ b/Specs/SlackTextViewController/1.2.2/SlackTextViewController.podspec.json
@@ -26,11 +26,6 @@
     "Source/Classes/*.{h,m}"
   ],
   "frameworks": "UIKit",
-  "dependencies": {
-    "SlackTextViewController/Additions": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Additions",

--- a/Specs/SlackTextViewController/1.2.3/SlackTextViewController.podspec.json
+++ b/Specs/SlackTextViewController/1.2.3/SlackTextViewController.podspec.json
@@ -26,11 +26,6 @@
     "Source/Classes/*.{h,m}"
   ],
   "frameworks": "UIKit",
-  "dependencies": {
-    "SlackTextViewController/Additions": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Additions",

--- a/Specs/SlackTextViewController/1.2.4/SlackTextViewController.podspec.json
+++ b/Specs/SlackTextViewController/1.2.4/SlackTextViewController.podspec.json
@@ -26,11 +26,6 @@
     "Source/Classes/*.{h,m}"
   ],
   "frameworks": "UIKit",
-  "dependencies": {
-    "SlackTextViewController/Additions": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Additions",

--- a/Specs/SlackTextViewController/1.2.5/SlackTextViewController.podspec.json
+++ b/Specs/SlackTextViewController/1.2.5/SlackTextViewController.podspec.json
@@ -26,11 +26,6 @@
     "Source/Classes/*.{h,m}"
   ],
   "frameworks": "UIKit",
-  "dependencies": {
-    "SlackTextViewController/Additions": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Additions",

--- a/Specs/SlackTextViewController/1.2.6/SlackTextViewController.podspec.json
+++ b/Specs/SlackTextViewController/1.2.6/SlackTextViewController.podspec.json
@@ -26,11 +26,6 @@
     "Source/Classes/*.{h,m}"
   ],
   "frameworks": "UIKit",
-  "dependencies": {
-    "SlackTextViewController/Additions": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Additions",

--- a/Specs/SlackTextViewController/1.2.7/SlackTextViewController.podspec.json
+++ b/Specs/SlackTextViewController/1.2.7/SlackTextViewController.podspec.json
@@ -26,11 +26,6 @@
     "Source/Classes/*.{h,m}"
   ],
   "frameworks": "UIKit",
-  "dependencies": {
-    "SlackTextViewController/Additions": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Additions",

--- a/Specs/SlackTextViewController/1.2.8/SlackTextViewController.podspec.json
+++ b/Specs/SlackTextViewController/1.2.8/SlackTextViewController.podspec.json
@@ -26,11 +26,6 @@
     "Source/Classes/*.{h,m}"
   ],
   "frameworks": "UIKit",
-  "dependencies": {
-    "SlackTextViewController/Additions": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Additions",

--- a/Specs/SlackTextViewController/1.2.9/SlackTextViewController.podspec.json
+++ b/Specs/SlackTextViewController/1.2.9/SlackTextViewController.podspec.json
@@ -26,11 +26,6 @@
     "Source/Classes/*.{h,m}"
   ],
   "frameworks": "UIKit",
-  "dependencies": {
-    "SlackTextViewController/Additions": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Additions",

--- a/Specs/SlackTextViewController/1.2/SlackTextViewController.podspec.json
+++ b/Specs/SlackTextViewController/1.2/SlackTextViewController.podspec.json
@@ -26,11 +26,6 @@
     "Source/Classes/*.{h,m}"
   ],
   "frameworks": "UIKit",
-  "dependencies": {
-    "SlackTextViewController/Additions": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Additions",

--- a/Specs/SlackTextViewController/1.3/SlackTextViewController.podspec.json
+++ b/Specs/SlackTextViewController/1.3/SlackTextViewController.podspec.json
@@ -26,11 +26,6 @@
     "Source/Classes/*.{h,m}"
   ],
   "frameworks": "UIKit",
-  "dependencies": {
-    "SlackTextViewController/Additions": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Additions",

--- a/Specs/TAKKit/1.0.0/TAKKit.podspec.json
+++ b/Specs/TAKKit/1.0.0/TAKKit.podspec.json
@@ -18,11 +18,6 @@
   "source_files": "Classes",
   "header_mappings_dir": "Classes",
   "social_media_url": "https://twitter.com/taka0125",
-  "dependencies": {
-    "TAKKit/Core": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/TAKKit/1.0.1/TAKKit.podspec.json
+++ b/Specs/TAKKit/1.0.1/TAKKit.podspec.json
@@ -18,11 +18,6 @@
   "source_files": "Classes",
   "header_mappings_dir": "Classes",
   "social_media_url": "https://twitter.com/taka0125",
-  "dependencies": {
-    "TAKKit/Core": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/TAKKit/1.1.0/TAKKit.podspec.json
+++ b/Specs/TAKKit/1.1.0/TAKKit.podspec.json
@@ -18,11 +18,6 @@
   "source_files": "Classes",
   "header_mappings_dir": "Classes",
   "social_media_url": "https://twitter.com/taka0125",
-  "dependencies": {
-    "TAKKit/Core": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/Typhoon/2.1.2/Typhoon.podspec.json
+++ b/Specs/Typhoon/2.1.2/Typhoon.podspec.json
@@ -19,11 +19,6 @@
   "documentation_url": "http://www.typhoonframework.org/docs/latest/api/",
   "requires_arc": true,
   "source_files": "Source/*.{h,m}",
-  "dependencies": {
-    "Typhoon/Factory": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Definition",

--- a/Specs/Typhoon/2.1.3/Typhoon.podspec.json
+++ b/Specs/Typhoon/2.1.3/Typhoon.podspec.json
@@ -19,11 +19,6 @@
   "documentation_url": "http://www.typhoonframework.org/docs/latest/api/",
   "requires_arc": true,
   "source_files": "Source/*.{h,m}",
-  "dependencies": {
-    "Typhoon/Factory": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Definition",

--- a/Specs/Typhoon/2.1.4/Typhoon.podspec.json
+++ b/Specs/Typhoon/2.1.4/Typhoon.podspec.json
@@ -19,11 +19,6 @@
   "documentation_url": "http://www.typhoonframework.org/docs/latest/api/",
   "requires_arc": true,
   "source_files": "Source/*.{h,m}",
-  "dependencies": {
-    "Typhoon/Factory": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Definition",

--- a/Specs/Typhoon/2.1.5/Typhoon.podspec.json
+++ b/Specs/Typhoon/2.1.5/Typhoon.podspec.json
@@ -19,11 +19,6 @@
   "documentation_url": "http://www.typhoonframework.org/docs/latest/api/",
   "requires_arc": true,
   "source_files": "Source/*.{h,m}",
-  "dependencies": {
-    "Typhoon/Factory": [
-
-    ]
-  },
   "subspecs": [
     {
       "name": "Definition",


### PR DESCRIPTION
- [x] Analytics
- [x] DZNPhotoPickerController
- [x] Fancy-iOS
- [x] KFData (upstream)
- [x] LumberjackConsole
- [x] LWFKit
- [x] MyiOSViewHelpers
- [x] MyMeteor
- [x] Objective-LevelDB
- [x] OMGHTTPURLRQ (upstream)
- [x] Overcoat (dependency)
- [x] PromiseKit (dependency)
- [x] RZUtils
- [x] SlackTextViewController (upstream)
- [x] TAKKit (upstream)
- [x] teemov2
- [x] Typhoon

---
- SDWebImage (caused by dependant libwebp)
- NBUImagePicker (caused by dependant NBUKit)
#### non-arc and arc subspecs
- [ ] FastElegantDelegation
- [ ] ShareKit
#### Code-base dependency
- [ ] DTModelStorage
- [ ] Rest2Mobile
- [ ] libwebp
- [ ] INSpriterKit
- [ ] NBUKit
- [ ] mopub-ios-sdk
- [ ] XMPPFramework
#### Pod depending pod depending pod
- [ ] AFRESTfulCoreDataBackgroundQueue / SLRESTfulCoreData
#### Other
- [ ] MIHCrypto depends on OpenSSL-Universal, but due to OpenSSL doesn't use semantic versioning. Their versioning system results in us marking it as a pre-release.
#### Unrelated problems
- [ ] AWSiOSSDK -- linting this proves it doesn't work anyway (AWSiOSSDK/src/Amazon.S3/Model/S3ListPartsRequest.m:22:13: error: type of property 'partNumberMarker' ('int') does not match type of instance variable 'partNumberMarker' ('long'))
- [ ] AnalyticsKit (Unable to find a specification for `Localytics` depended upon by `AnalyticsKit/Localytics`)
- [ ] iOS-FakeWeb (Unable to find a specification for `ASIHTTPConnection` depended upon by `iOS-FakeWeb/ASIHTTPConnection`)
- [ ] GBAnalytics (`Tapstream (~> 3.0)` required by `GBAnalytics (2.4.0)`)
- [ ] ErrorKit (Unable to find a specification for `AdMob (< 6.6)` depended upon by `ErrorKit/AdMob`)
- [ ] spatialite (prepare command hook + depends on non-existant freexl)

Part of https://github.com/CocoaPods/Molinillo/issues/6
