### PR TITLE
Use vendored frameworks instead of using PODS_ROOT

### DIFF
--- a/Specs/libspotify/12.1.64/libspotify.podspec.json
+++ b/Specs/libspotify/12.1.64/libspotify.podspec.json
@@ -17,12 +17,8 @@
   "source": {
     "http": "https://developer.spotify.com/download/libspotify/libspotify-12.1.64-iOS-universal.zip"
   },
-  "source_files": "libspotify-12.1.64-iOS-universal/libspotify.framework/Versions/12.1.64/Headers/*.h",
-  "preserve_paths": "libspotify-12.1.64-iOS-universal/libspotify.framework/*",
-  "xcconfig": {
-    "FRAMEWORK_SEARCH_PATHS": "\"$(PODS_ROOT)/Libspotify/libspotify-12.1.64-iOS-universal\""
-  },
-  "frameworks": "libspotify",
+  "public_header_files": "libspotify-12.1.64-iOS-universal/libspotify.framework/Versions/12.1.64/Headers/*.h",
+  "vendored_frameworks": ["libspotify-12.1.64-iOS-universal/libspotify.framework"],
   "libraries": "stdc++",
   "requires_arc": true
 }


### PR DESCRIPTION
This also fixes mis-capitalized path which causes build failures on
case-sensitive file systems.

I'm not an employee of Spotify, but this has been causing build failures on my machine since I use a case-sensitive disk image for development work. Using `vendored_frameworks` worked for my project, but if I made any mistake, please let me know.
