### PR TITLE
Create Google-AdMob-Ads-SDK.podspec.json

### DIFF
--- a/Specs/Google-AdMob-Ads-SDK/6.12.2/Google-AdMob-Ads-SDK.podspec.json
+++ b/Specs/Google-AdMob-Ads-SDK/6.12.2/Google-AdMob-Ads-SDK.podspec.json
@@ -1,0 +1,40 @@
+{
+  "name": "Google-AdMob-Ads-SDK",
+  "version": "6.12.2",
+  "summary": "Google AdMob Ads SDK.",
+  "description": "The Google AdMob Ads SDK allows developers to easily incorporate mobile-friendly text and image banners as well as rich, full-screen web apps known as interstitials.",
+  "homepage": "https://developers.google.com/mobile-ads-sdk/",
+  "license": {
+    "type": "Copyright",
+    "text": "Copyright 2009 - 2012 Google, Inc. All rights reserved.\n"
+  },
+  "authors": "Google Inc.",
+  "source": {
+    "http": "http://dl.google.com/googleadmobadssdk/googlemobileadssdkios.zip"
+  },
+  "platforms": {
+    "ios": "5.0"
+  },
+  "source_files": [
+    "GoogleMobileAdsSdkiOS-6.12.2/*.h",
+    "GoogleMobileAdsSdkiOS-6.12.2/Add-ons/DoubleClick/*.h"
+  ],
+  "preserve_paths": "GoogleMobileAdsSdkiOS-6.12.2",
+  "frameworks": [
+    "AdSupport",
+    "AudioToolbox",
+    "AVFoundation",
+    "CoreGraphics",
+    "CoreTelephony",
+    "EventKit",
+    "EventKitUI",
+    "MessageUI",
+    "StoreKit",
+    "SystemConfiguration"
+  ],
+  "libraries": "GoogleAdMobAds",
+  "xcconfig": {
+    "LIBRARY_SEARCH_PATHS": "\"$(PODS_ROOT)/Google-AdMob-Ads-SDK/GoogleMobileAdsSdkiOS-6.12.2\""
+  },
+  "requires_arc": false
+}


### PR DESCRIPTION
I can't install this pod because version number is invalid.

https://github.com/CocoaPods/Specs/raw/master/Specs/Google-AdMob-Ads-SDK/6.12.0/Google-AdMob-Ads-SDK.podspec.json

googlemobileadssdkios.zip include source code version 6.12.2, but above podspec file specify version 6.12.0.
