### PR TITLE
Removed old path

### DIFF
--- a/Specs/ChartboostSDK/5.0.3/ChartboostSDK.podspec.json
+++ b/Specs/ChartboostSDK/5.0.3/ChartboostSDK.podspec.json
@@ -19,9 +19,6 @@
   },
   "source_files": "Chartboost.framework/Versions/A/Headers/*.h",
   "preserve_paths": "Chartboost.framework/*",
-  "xcconfig": {
-    "FRAMEWORK_SEARCH_PATHS": "\"$(PODS_ROOT)/Chartboost\""
-  },
   "weak_frameworks": "AdSupport",
   "frameworks": [
     "QuartzCore",


### PR DESCRIPTION
We started using vendored_framework with the latest release, so there is no need to use xconfig anymore. In fact, that path was non existent and was throwing an annoying warning on Xcode.
