### PR TITLE
CustomBadge Version 2.0 fixed and set to deprecated

### DIFF
--- a/Specs/CustomBadge/2.0/CustomBadge.podspec.json
+++ b/Specs/CustomBadge/2.0/CustomBadge.podspec.json
@@ -1,19 +1,23 @@
 {
   "name": "CustomBadge",
   "version": "2.0",
-  "license": "(custom, see https://github.com/ckteebe/CustomBadge/blob/master/README)",
-  "summary": "Draws a typical iOS badge indicator with a custom text on any view.",
-  "homepage": "http://www.spaulus.com/2011/04/custombadge-2-0-retina-ready-scalable-light-reflex/?lang=en",
+  "summary": "CustomBadge is an Objective-C based component to create customized Badges for any given View.",
+  "homepage": "http://www.saschapaulus.de",
+  "license": "MIT",
   "authors": {
     "Sascha Paulus": "open@spaulus.com"
   },
+  "platforms": {
+    "ios": "6.0"
+  },
   "source": {
     "git": "https://github.com/ckteebe/CustomBadge.git",
-    "commit": "3e6eed7bdb3e5faa02f79a9d81b0b11316d44a2e"
+    "tag": "2.0"
   },
-  "platforms": {
-    "ios": null
-  },
-  "source_files": "Classes/CustomBadge.{h,m}",
-  "requires_arc": false
+  "source_files": [
+    "Classes/CustomBadge.{h,m}"
+  ],
+  "frameworks": "QuartzCore",
+  "requires_arc": true
+  "deprecated" : true
 }


### PR DESCRIPTION
After I was told it's not possible/wished to delete versions from CocoaPods I made a clean version 2.0 on Github and updated the Specfile. Hope now everything is fine and clean. Thanks, Sascha
