### PR TITLE
libwebp - remove circular references between subspecs

### DIFF
--- a/Specs/libwebp/0.4.0/libwebp.podspec.json
+++ b/Specs/libwebp/0.4.0/libwebp.podspec.json
@@ -16,33 +16,68 @@
   "requires_arc": false,
   "subspecs": [
     {
-      "name": "dec",
-      "source_files": "src/dec/*.{h,c}"
-    },
-    {
-      "name": "demux",
-      "source_files": "src/demux/*.{h,c}"
-    },
-    {
-      "name": "dsp",
-      "source_files": "src/dsp/*.{h,c}"
-    },
-    {
-      "name": "enc",
-      "source_files": "src/enc/*.{h,c}"
-    },
-    {
-      "name": "mux",
-      "source_files": "src/mux/*.{h,c}"
-    },
-    {
-      "name": "utils",
-      "source_files": "src/utils/*.{h,c}"
-    },
-    {
       "name": "webp",
       "header_dir": "webp",
       "source_files": "src/webp/*.h"
+    },
+    {
+      "name": "core",
+      "source_files": [
+        "src/utils/*.{h,c}", 
+        "src/dsp/*.{h,c}", 
+        "src/enc/*.{h,c}", 
+        "src/dec/*.{h,c}"
+      ],
+      "dependencies": {
+        "libwebp/webp": [
+        ]
+      }
+    },
+    {
+      "name": "utils",
+      "dependencies": {
+        "libwebp/core": [
+        ]
+      }
+    },
+    {
+      "name": "dsp",
+      "dependencies": {
+        "libwebp/core": [
+        ]
+      }
+    },
+    {
+      "name": "enc",
+      "dependencies": {
+        "libwebp/core": [
+
+        ]
+      }
+    },
+    {
+      "name": "dec",
+      "dependencies": {
+        "libwebp/core": [
+        ]
+      }
+    },
+    {
+      "name": "demux",
+      "source_files": "src/demux/*.{h,c}",
+      "dependencies": {
+        "libwebp/core": [
+
+        ]
+      }
+    },
+    {
+      "name": "mux",
+      "source_files": "src/mux/*.{h,c}",
+      "dependencies": {
+        "libwebp/core": [
+        ]
+      }
     }
   ]
 }

--- a/Specs/libwebp/0.4.0/libwebp.podspec.json
+++ b/Specs/libwebp/0.4.0/libwebp.podspec.json
@@ -16,68 +16,33 @@
   "requires_arc": false,
   "subspecs": [
     {
-      "name": "webp",
-      "header_dir": "webp",
-      "source_files": "src/webp/*.h"
-    },
-    {
-      "name": "core",
-      "source_files": [
-        "src/utils/*.{h,c}", 
-        "src/dsp/*.{h,c}", 
-        "src/enc/*.{h,c}", 
-        "src/dec/*.{h,c}"
-      ],
-      "dependencies": {
-        "libwebp/webp": [
-        ]
-      }
-    },
-    {
-      "name": "utils",
-      "dependencies": {
-        "libwebp/core": [
-        ]
-      }
-    },
-    {
-      "name": "dsp",
-      "dependencies": {
-        "libwebp/core": [
-        ]
-      }
-    },
-    {
-      "name": "enc",
-      "dependencies": {
-        "libwebp/core": [
-
-        ]
-      }
-    },
-    {
       "name": "dec",
-      "dependencies": {
-        "libwebp/core": [
-        ]
-      }
+      "source_files": "src/dec/*.{h,c}"
     },
     {
       "name": "demux",
-      "source_files": "src/demux/*.{h,c}",
-      "dependencies": {
-        "libwebp/core": [
-
-        ]
-      }
+      "source_files": "src/demux/*.{h,c}"
+    },
+    {
+      "name": "dsp",
+      "source_files": "src/dsp/*.{h,c}"
+    },
+    {
+      "name": "enc",
+      "source_files": "src/enc/*.{h,c}"
     },
     {
       "name": "mux",
-      "source_files": "src/mux/*.{h,c}",
-      "dependencies": {
-        "libwebp/core": [
-        ]
-      }
+      "source_files": "src/mux/*.{h,c}"
+    },
+    {
+      "name": "utils",
+      "source_files": "src/utils/*.{h,c}"
+    },
+    {
+      "name": "webp",
+      "header_dir": "webp",
+      "source_files": "src/webp/*.h"
     }
   ]
 }

--- a/Specs/libwebp/0.4.1/libwebp.podspec.json
+++ b/Specs/libwebp/0.4.1/libwebp.podspec.json
@@ -16,14 +16,49 @@
   "requires_arc": false,
   "subspecs": [
     {
-      "name": "dec",
-      "source_files": "src/dec/*.{h,c}",
+      "name": "webp",
+      "header_dir": "webp",
+      "source_files": "src/webp/*.h"
+    },
+    {
+      "name": "core",
+      "source_files": [
+        "src/utils/*.{h,c}", 
+        "src/dsp/*.{h,c}", 
+        "src/enc/*.{h,c}", 
+        "src/dec/*.{h,c}"
+      ],
       "dependencies": {
-        "libwebp/utils": [
+        "libwebp/webp": [
+        ]
+      }
+    },
+    {
+      "name": "utils",
+      "dependencies": {
+        "libwebp/core": [
+        ]
+      }
+    },
+    {
+      "name": "dsp",
+      "dependencies": {
+        "libwebp/core": [
+        ]
+      }
+    },
+    {
+      "name": "enc",
+      "dependencies": {
+        "libwebp/core": [
 
-        ],
-        "libwebp/enc": [
-
+        ]
+      }
+    },
+    {
+      "name": "dec",
+      "dependencies": {
+        "libwebp/core": [
         ]
       }
     },
@@ -31,31 +66,7 @@
       "name": "demux",
       "source_files": "src/demux/*.{h,c}",
       "dependencies": {
-        "libwebp/utils": [
-
-        ]
-      }
-    },
-    {
-      "name": "dsp",
-      "source_files": "src/dsp/*.{h,c}",
-      "dependencies": {
-        "libwebp/utils": [
-
-        ],
-        "libwebp/enc": [
-
-        ],
-        "libwebp/dec": [
-
-        ]
-      }
-    },
-    {
-      "name": "enc",
-      "source_files": "src/enc/*.{h,c}",
-      "dependencies": {
-        "libwebp/utils": [
+        "libwebp/core": [
 
         ]
       }
@@ -64,27 +75,9 @@
       "name": "mux",
       "source_files": "src/mux/*.{h,c}",
       "dependencies": {
-        "libwebp/utils": [
-
+        "libwebp/core": [
         ]
       }
-    },
-    {
-      "name": "utils",
-      "source_files": "src/utils/*.{h,c}",
-      "dependencies": {
-        "libwebp/webp": [
-
-        ],
-        "libwebp/dsp": [
-
-        ]
-      }
-    },
-    {
-      "name": "webp",
-      "header_dir": "webp",
-      "source_files": "src/webp/*.h"
     }
   ]
 }

--- a/Specs/libwebp/0.4.2/libwebp.podspec.json
+++ b/Specs/libwebp/0.4.2/libwebp.podspec.json
@@ -16,14 +16,49 @@
   "requires_arc": false,
   "subspecs": [
     {
-      "name": "dec",
-      "source_files": "src/dec/*.{h,c}",
+      "name": "webp",
+      "header_dir": "webp",
+      "source_files": "src/webp/*.h"
+    },
+    {
+      "name": "core",
+      "source_files": [
+        "src/utils/*.{h,c}", 
+        "src/dsp/*.{h,c}", 
+        "src/enc/*.{h,c}", 
+        "src/dec/*.{h,c}"
+      ],
       "dependencies": {
-        "libwebp/utils": [
+        "libwebp/webp": [
+        ]
+      }
+    },
+    {
+      "name": "utils",
+      "dependencies": {
+        "libwebp/core": [
+        ]
+      }
+    },
+    {
+      "name": "dsp",
+      "dependencies": {
+        "libwebp/core": [
+        ]
+      }
+    },
+    {
+      "name": "enc",
+      "dependencies": {
+        "libwebp/core": [
 
-        ],
-        "libwebp/enc": [
-
+        ]
+      }
+    },
+    {
+      "name": "dec",
+      "dependencies": {
+        "libwebp/core": [
         ]
       }
     },
@@ -31,31 +66,7 @@
       "name": "demux",
       "source_files": "src/demux/*.{h,c}",
       "dependencies": {
-        "libwebp/utils": [
-
-        ]
-      }
-    },
-    {
-      "name": "dsp",
-      "source_files": "src/dsp/*.{h,c}",
-      "dependencies": {
-        "libwebp/utils": [
-
-        ],
-        "libwebp/enc": [
-
-        ],
-        "libwebp/dec": [
-
-        ]
-      }
-    },
-    {
-      "name": "enc",
-      "source_files": "src/enc/*.{h,c}",
-      "dependencies": {
-        "libwebp/utils": [
+        "libwebp/core": [
 
         ]
       }
@@ -64,27 +75,9 @@
       "name": "mux",
       "source_files": "src/mux/*.{h,c}",
       "dependencies": {
-        "libwebp/utils": [
-
+        "libwebp/core": [
         ]
       }
-    },
-    {
-      "name": "utils",
-      "source_files": "src/utils/*.{h,c}",
-      "dependencies": {
-        "libwebp/webp": [
-
-        ],
-        "libwebp/dsp": [
-
-        ]
-      }
-    },
-    {
-      "name": "webp",
-      "header_dir": "webp",
-      "source_files": "src/webp/*.h"
     }
   ]
 }


### PR DESCRIPTION
In order to remove circular references between subspecs of `libwebp`, had to restructure the subspecs (created `core` subspec with all the files from `dsp`, `utils`, `enc` and `dec`. Kept those for backwards compatibility). For details, see https://github.com/CocoaPods/Specs/issues/12819.

@kylef There are some older pod specs in `libwebp`: `0.3.0-rc7`, `0.3.1` and `0.4.0` that don't compile for arm64 which breaks the Travis CI. Since those tags from libwebp are not to be used by CocoaPods users, we should delete them or mark them as deprecated in some way. How can we do that? I thought about deleting them, but I'm not sure about the impact on users that have them. Could we use the `s.deprecated` setting? Would it work if we'd change the older specs to have no source files and `s.deprecated = true`, so they compile fine and show the user the version is deprecated?

Note: since I am only the person to push specs to CocoaPods and not the maintainer of this library, I cannot make changes inside their code, so I'm stuck with updating the specs.
