### PR TITLE
GoogleAnalytics-iOS-SDK subspecs+IDFA

### DIFF
--- a/Specs/GoogleAnalytics-iOS-SDK/3.10/GoogleAnalytics-iOS-SDK.podspec.json
+++ b/Specs/GoogleAnalytics-iOS-SDK/3.10/GoogleAnalytics-iOS-SDK.podspec.json
@@ -16,26 +16,46 @@
   "platforms": {
     "ios": "5.0"
   },
-  "source_files": [
-    "GoogleAnalytics/Library/*.h",
-    "GoogleTagManager/Library/*.h"
-  ],
-  "preserve_paths": "libGoogleAnalyticsServices.a",
-  "frameworks": [
-    "Foundation",
-    "UIKit",
-    "CFNetwork",
-    "CoreData",
-    "SystemConfiguration"
-  ],
-  "libraries": [
-    "GoogleAnalyticsServices",
-    "z",
-    "sqlite3"
-  ],
-  "xcconfig": {
-    "LIBRARY_SEARCH_PATHS": "\"$(PODS_ROOT)/GoogleAnalytics-iOS-SDK\"",
-    "HEADER_SEARCH_PATHS": "$(SDKROOT)/usr/include/libz"
-  },
-  "requires_arc": true
+  "requires_arc": true,
+  "default_subspecs": "Core",
+  "subspecs": [
+    {
+      "name": "Core",
+      "source_files": [
+        "GoogleAnalytics/Library/*.h",
+        "GoogleTagManager/Library/*.h"
+      ],
+      "preserve_paths": "libGoogleAnalyticsServices.a",
+      "frameworks": [
+        "Foundation",
+        "UIKit",
+        "CFNetwork",
+        "CoreData",
+        "SystemConfiguration"
+      ],
+      "libraries": [
+        "GoogleAnalyticsServices",
+        "z",
+        "sqlite3"
+      ],
+      "xcconfig": {
+        "LIBRARY_SEARCH_PATHS": "\"$(PODS_ROOT)/GoogleAnalytics-iOS-SDK\"",
+        "HEADER_SEARCH_PATHS": "$(SDKROOT)/usr/include/libz"
+      }
+    },
+    {
+      "name": "IDFA",
+      "preserve_paths": "libAdIdAccess.a",
+      "frameworks": [
+        "AdSupport"
+      ],
+      "libraries": [
+        "AdIdAccess"
+      ],
+      "dependencies": {
+        "GoogleAnalytics-iOS-SDK/Core": [
+        ]
+      }
+    }
+  ]
 }

--- a/Specs/GoogleAnalytics-iOS-SDK/3.10/GoogleAnalytics-iOS-SDK.podspec.json
+++ b/Specs/GoogleAnalytics-iOS-SDK/3.10/GoogleAnalytics-iOS-SDK.podspec.json
@@ -46,7 +46,7 @@
     {
       "name": "IDFA",
       "preserve_paths": "libAdIdAccess.a",
-      "frameworks": [
+      "weak_frameworks": [
         "AdSupport"
       ],
       "libraries": [


### PR DESCRIPTION
@alloy @x2on, please look at this first, as you have pushed all the previous specs. If this sounds like a legit fix, we can apply it to previous specs as well.
#### The change

Fixed an issue with **GoogleAnalytics-iOS-SDK**. For users that want to enable `IDFA` collecting, they can't because `libAdIdAccess.a` cannot be retrieved via the spec.

The fix involves creating a `Core` default podspec with all the files and configs we used to have. The `IDFA` subspec depends on the `Core` subspec and only adds the `libAdIdAccess.a lib` along with a dependency to the `AdSupport` framework.
