### PR TITLE
[Add] LibComponentLogging-pods 0.0.2

### DIFF
--- a/Specs/LibComponentLogging-pods/0.0.2/LibComponentLogging-pods.podspec.json
+++ b/Specs/LibComponentLogging-pods/0.0.2/LibComponentLogging-pods.podspec.json
@@ -1,0 +1,26 @@
+{
+  "name": "LibComponentLogging-pods",
+  "version": "0.0.2",
+  "source": {
+    "git": "https://github.com/aharren/LibComponentLogging-pods.git",
+    "tag": "0.0.2",
+    "submodules" : true
+  },
+  "homepage": "http://0xc0.de/LibComponentLogging",
+  "authors": {
+    "Arne Harren": "ah@0xc0.de"
+  },
+  "license": "MIT",
+  "summary": "LibComponentLogging configuration for CocoaPods.",
+  "description": "LibComponentLogging-pods provides a configuration mechanism for LibComponentLogging and CocoaPods which configures logging back-ends and extensions based on your project's CocoaPods Podfile file.",
+  "source_files": [
+  ],
+  "preserve_paths": [
+    "*"
+  ],
+  "requires_arc": false,
+  "dependencies": {
+    "LibComponentLogging-Core": [
+    ]
+  }
+}


### PR DESCRIPTION
adapt lcl_configure to new location of build headers in CocoaPods 0.34.x and 0.35.x
