### PR TITLE
Update Rdio spec with the latest version

### DIFF
--- a/Specs/Rdio/2.1.4/Rdio.podspec.json
+++ b/Specs/Rdio/2.1.4/Rdio.podspec.json
@@ -1,0 +1,36 @@
+{
+  "name": "Rdio",
+  "version": "2.1.4",
+  "summary": "The Rdio Framework",
+  "homepage": "http://www.rdio.com/developers/",
+  "license": {
+    "type": "Commercial",
+    "text": "Copyright © 2009-2013 Rdio, Inc. All rights reserved.\n"
+  },
+  "description": "The Rdio iOS SDK combines our Web Services API and a native playback implementation, allowing developers to make API calls, authenticate users, and stream music. The SDK handles providing full tracks to Rdio Unlimited subscribers, and 30 second samples to everyone else.\n",
+  "authors": {
+    "Rdio": "developersupport@rd.io"
+  },
+  "platforms": {
+    "ios": null
+  },
+  "source": {
+    "http": "http://www.rdio.com/media/static/developer/ios/releases/rdio-ios-2.1.4.tar.gz"
+  },
+  "public_header_files": "Rdio.frameworks/Headers/*.h",
+  "vendored_frameworks": ["Rdio.framework"],
+  "frameworks": [
+    "CoreGraphics",
+    "CFNetwork",
+    "CoreMedia",
+    "SystemConfiguration",
+    "AudioToolbox",
+    "Security",
+    "Rdio"
+  ],
+  "compiler_flags": [
+    "-ObjC",
+    "-all_load"
+  ],
+  "requires_arc": true
+}


### PR DESCRIPTION
The old version is very out of date and uses PODS_ROOT.
