### PR TITLE
Update gtm-http-fetcher.podspec.json

### DIFF
--- a/Specs/gtm-http-fetcher/1.0.141/gtm-http-fetcher.podspec.json
+++ b/Specs/gtm-http-fetcher/1.0.141/gtm-http-fetcher.podspec.json
@@ -13,7 +13,6 @@
   },
   "summary": "Google Toolbox for Mac - HTTP Fetcher",
   "description": "                    GTM HTTP Fetcher makes it easy for Cocoa applications to perform http\n                    operations. The fetcher is implemented as a wrapper on NSURLConnection,\n                    so its behavior is asynchronous and uses operating-system settings on\n                    iOS and Mac OS X.\n\n                    This version can be used with iOS ≥ 5.0 or OS X ≥ 10.7.\n                    To target earlier versions of iOS or OS X, use\n\n                    pod 'gtm-http-fetcher', '~> 1.0.141'\n                  \n                    podspec version based on source SVN revision\n",
-  "deprecated_in_favor_of": "gtm-http-fetcher",
   "platforms": {
     "ios": "5.0",
     "osx": "10.7"


### PR DESCRIPTION
gtm-http-fetcher being deprecated in favor of itself does not make much sense to me
