### PR TITLE
Deprecated all versions of of Bazaarvoice podspec in favor of BVSDK

### DIFF
--- a/Specs/Bazaarvoice/2.1.2/Bazaarvoice.podspec.json
+++ b/Specs/Bazaarvoice/2.1.2/Bazaarvoice.podspec.json
@@ -24,5 +24,7 @@
   "frameworks": "BVSDK",
   "xcconfig": {
     "FRAMEWORK_SEARCH_PATHS": "\"$(PODS_ROOT)/Bazaarvoice\""
-  }
+  },
+  "deprecated": true,
+  "deprecated_in_favor_of": "BVSDK"
 }

--- a/Specs/Bazaarvoice/2.1.5/Bazaarvoice.podspec.json
+++ b/Specs/Bazaarvoice/2.1.5/Bazaarvoice.podspec.json
@@ -24,5 +24,7 @@
   "frameworks": "BVSDK",
   "xcconfig": {
     "FRAMEWORK_SEARCH_PATHS": "\"$(PODS_ROOT)/Bazaarvoice\""
-  }
+  },
+  "deprecated": true,
+  "deprecated_in_favor_of": "BVSDK"
 }


### PR DESCRIPTION
Deprecated all versions of of Bazaarvoice podspec in favor of BVSDK podspec, as they reference the same library. 
