### PR TITLE
Deprecating all versions of Bazaarvoice pod in favor of BVSDK

### DIFF
--- a/Specs/Bazaarvoice/2.1.2/Bazaarvoice.podspec.json
+++ b/Specs/Bazaarvoice/2.1.2/Bazaarvoice.podspec.json
@@ -24,5 +24,6 @@
   "frameworks": "BVSDK",
   "xcconfig": {
     "FRAMEWORK_SEARCH_PATHS": "\"$(PODS_ROOT)/Bazaarvoice\""
-  }
+  },
+  "deprecated_in_favor_of": "BVSDK"
 }

--- a/Specs/Bazaarvoice/2.1.5/Bazaarvoice.podspec.json
+++ b/Specs/Bazaarvoice/2.1.5/Bazaarvoice.podspec.json
@@ -24,5 +24,6 @@
   "frameworks": "BVSDK",
   "xcconfig": {
     "FRAMEWORK_SEARCH_PATHS": "\"$(PODS_ROOT)/Bazaarvoice\""
-  }
+  },
+  "deprecated_in_favor_of": "BVSDK"
 }

--- a/Specs/Bazaarvoice/2.1.6/Bazaarvoice.podspec.json
+++ b/Specs/Bazaarvoice/2.1.6/Bazaarvoice.podspec.json
@@ -25,6 +25,5 @@
   "xcconfig": {
     "FRAMEWORK_SEARCH_PATHS": "\"$(PODS_ROOT)/Bazaarvoice\""
   },
-  "deprecated": true,
   "deprecated_in_favor_of": "BVSDK"
 }


### PR DESCRIPTION
Deprecating all versions of Bazaarvoice pod in favor of BVSDK pod. `pod spec lint` passed with no warnings or errors on all 3 versions. Thanks for your patience!
