### PR TITLE
Deprecated old Nimble spec

### DIFF
--- a/Specs/Nimble/0.0.1/Nimble.podspec.json
+++ b/Specs/Nimble/0.0.1/Nimble.podspec.json
@@ -20,5 +20,6 @@
   ],
   "frameworks": "CoreData",
   "requires_arc": true,
-  "prefix_header_contents": "#ifdef __OBJC__\n    #import <CoreData/CoreData.h>\n#endif\n"
+  "prefix_header_contents": "#ifdef __OBJC__\n    #import <CoreData/CoreData.h>\n#endif\n",
+  "deprecated_in_favor_of": "Nimble-CoreData"
 }


### PR DESCRIPTION
This is related to the renaming of the old "Nimble" pod to be "Nimble-CoreData", so that [Nimble](http://github.com/Quick/Nimble) may use that name. See [here](https://github.com/MarcoSero/Nimble/pull/23#issuecomment-71164105) for discussion. 
