### PR TITLE
Deprecated IDmeVerify

### DIFF
--- a/Specs/IDmeVerify/2.2.1/IDmeVerify.podspec.json
+++ b/Specs/IDmeVerify/2.2.1/IDmeVerify.podspec.json
@@ -23,6 +23,7 @@
   },
   "public_header_files": "ID.me Verify SDK/include/IDmeVerify/*.h",
   "source_files": "ID.me Verify SDK/include/IDmeVerify/*.{h,m}",
+  "deprecated": "true",
   "resources": "ID.me Verify SDK/IDmeVerify.bundle",
   "vendored_libraries": "ID.me Verify SDK/*",
   "requires_arc": true,
@@ -32,7 +33,7 @@
     ]
   },
   "authors": {
-    "Arthur Ariel Sabintsev": "arthur@id.me"
+    "Arthur Ariel Sabintsev": "arthur@sabintsev.com"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Deprecated this library, as the repo is gone. No one was using it, as we stopped issuing production keys for it awhile ago and deprecated the functionality internally.
