### PR TITLE
Update spec to point to the current library binary

### DIFF
--- a/Specs/Ooyala/1.5.1/Ooyala.podspec.json
+++ b/Specs/Ooyala/1.5.1/Ooyala.podspec.json
@@ -11,7 +11,7 @@
     "Ooyala": "support@ooyala.com"
   },
   "source": {
-    "http": "https://ooyala.box.com/shared/static/yor6jmfris8zdfr5m3y3.zip"
+    "http": "https://ooyala.box.com/shared/static/trtptb6942ikglrdeq5e.zip"
   },
   "platforms": {
     "ios": null


### PR DESCRIPTION
I've updated the spec to point to the current URL where Ooyala keeps their binary-only library. I can't find who is the owner of this podspec so I'm submitting this PR instead.
I guess this pod is not widely used, because it has been broken for some time and no one has complained (apart from my coworkers, since our build is broken because of this). I have been running locally with a patched spec but I thought in the long run it would be easier if the master repo was fixed.
