### PR TITLE
Lowers OS X requirement for pre-release ReactiveCocoa 3 

### DIFF
--- a/Specs/ReactiveCocoa/3.0.0-alpha.1/ReactiveCocoa.podspec.json
+++ b/Specs/ReactiveCocoa/3.0.0-alpha.1/ReactiveCocoa.podspec.json
@@ -10,7 +10,7 @@
   },
   "platforms": {
     "ios": "8.0",
-    "osx": "10.10"
+    "osx": "10.9"
   },
   "source": {
     "git": "https://github.com/ashfurrow/ReactiveCocoa.git",


### PR DESCRIPTION
No reason to have it at 10.10. 

Related to https://github.com/ashfurrow/Swift-RAC-Macros/pull/2
