### PR TITLE
Fixed missing framework

### DIFF
--- a/Specs/FyberSDK/7.1.0/FyberSDK.podspec.json
+++ b/Specs/FyberSDK/7.1.0/FyberSDK.podspec.json
@@ -27,7 +27,8 @@
     "MediaPlayer",
     "QuartzCore",
     "SystemConfiguration",
-    "UIKit"
+    "UIKit",
+    "CoreLocation"
   ],
   "weak_frameworks": [
     "AdSupport",


### PR DESCRIPTION
Our SKD requires the `CoreLocation` to be linked but it was missing in the podspec.

cheers
