### PR TITLE
Fix for error "Permission denied (publickey)."

### DIFF
--- a/Specs/BrightcenterSDK-2.0/0.9.14/BrightcenterSDK-2.0.podspec.json
+++ b/Specs/BrightcenterSDK-2.0/0.9.14/BrightcenterSDK-2.0.podspec.json
@@ -14,7 +14,7 @@
     "ios": "5.0"
   },
   "source": {
-    "git": "git@github.com:triforkamsterdam/BrightcenterSDK-iOS-2.0.git",
+    "git": "https://github.com/triforkamsterdam/BrightcenterSDK-iOS-2.0.git",
     "tag": "0.9.14"
   },
   "ios": {


### PR DESCRIPTION
Getting the following error by "pod install":
Cloning into '/Users/renswijnmalen/Projects/0026-brutaal/brutaal2.0/brutaal.spritebuilder/Pods/BrightcenterSDK-2.0'...
Permission denied (publickey).

This change will fix this error.
