### PR TITLE
updated ios-version and added ios.frameworks and libraries

### DIFF
--- a/Specs/IndoorsSDK-iOS/2.5.0/IndoorsSDK-iOS.podspec.json
+++ b/Specs/IndoorsSDK-iOS/2.5.0/IndoorsSDK-iOS.podspec.json
@@ -2,7 +2,7 @@
   "name": "IndoorsSDK-iOS",
   "version": "2.5.0",
   "platforms": {
-    "ios": "8.1"
+    "ios": "7.0"
   },
   "summary": "iOS SDK for performing indoors mapping and localisation provided by indoo.rs",
   "authors": {
@@ -22,5 +22,19 @@
       "Indoors.framework",
       "IndoorsSurface.framework"
     ]
-  }
+  },
+  "frameworks": ["QuartzCore", 
+	  			 "SystemConfiguration", 
+				 "CoreMotion", 
+				 "CFNetwork", 
+				 "UIKit", 
+				 "Foundation", 
+				 "CoreBluetooth", 
+				 "CoreGraphics", 
+				 "CoreLocation"],
+				 
+  "libraries": ["z", "sqlite3.0", "c++"],
+  
+  "requires_arc": true
+  
 }


### PR DESCRIPTION
i just changed the iOS-version and added a few frameworks to IndoorsSDK-iOS.podspec.
i know that i should just bump the version of the podspec file to add changes. but i can't change the version of the sdk the pod incudes, and they definitely have to match. so is this possible?
