### PR TITLE
Fixing broken links in OpenCV version > 2.4.9

### DIFF
--- a/Specs/OpenCV/2.4.10/OpenCV.podspec.json
+++ b/Specs/OpenCV/2.4.10/OpenCV.podspec.json
@@ -10,7 +10,7 @@
   },
   "authors": "opencv.org",
   "source": {
-    "http": "http://skylink.dl.sourceforge.net/project/opencvlibrary/opencv-ios/2.4.10/opencv2.framework.zip"
+    "http": "http://hivelocity.dl.sourceforge.net/project/opencvlibrary/opencv-ios/2.4.10/opencv2.framework.zip"
   },
   "platforms": {
     "ios": "4.0"

--- a/Specs/OpenCV/2.4.9.1/OpenCV.podspec.json
+++ b/Specs/OpenCV/2.4.9.1/OpenCV.podspec.json
@@ -10,7 +10,7 @@
   },
   "authors": "opencv.org",
   "source": {
-    "http": "http://skylink.dl.sourceforge.net/project/opencvlibrary/opencv-ios/2.4.9/opencv2.framework.zip"
+    "http": "http://hivelocity.dl.sourceforge.net/project/opencvlibrary/opencv-ios/2.4.9/opencv2.framework.zip"
   },
   "platforms": {
     "ios": "4.0"

--- a/Specs/OpenCV/2.4.9/OpenCV.podspec.json
+++ b/Specs/OpenCV/2.4.9/OpenCV.podspec.json
@@ -10,7 +10,7 @@
   },
   "authors": "opencv.org",
   "source": {
-    "http": "http://skylink.dl.sourceforge.net/project/opencvlibrary/opencv-ios/2.4.9/opencv2.framework.zip"
+    "http": "http://hivelocity.dl.sourceforge.net/project/opencvlibrary/opencv-ios/2.4.9/opencv2.framework.zip"
   },
   "platforms": {
     "ios": "4.0"


### PR DESCRIPTION
The Skylink Sourceforge mirror is no longer available for OpenCV version > 2.4.9. Switching source URL to use HIVELOCITY mirror.
