### PR TITLE
Ups the LlamaKit 0.6 version to require Swift 1.2

### DIFF
--- a/Specs/LlamaKit/0.6.0/LlamaKit.podspec.json
+++ b/Specs/LlamaKit/0.6.0/LlamaKit.podspec.json
@@ -10,7 +10,7 @@
   },
   "social_media_url": "https://twitter.com/cocoaphony",
   "platforms": {
-    "ios": "8.0",
+    "ios": "8.3",
     "osx": "10.10"
   },
   "source": {


### PR DESCRIPTION
My apologies for not getting this when I pushed. 
