### PR TITLE
OpenCV 2.4.10 - Update URL Broken

### DIFF
--- a/Specs/OpenCV/2.4.10/OpenCV.podspec.json
+++ b/Specs/OpenCV/2.4.10/OpenCV.podspec.json
@@ -10,7 +10,7 @@
   },
   "authors": "opencv.org",
   "source": {
-    "http": "http://skylink.dl.sourceforge.net/project/opencvlibrary/opencv-ios/2.4.10/opencv2.framework.zip"
+    "http": "http://iweb.dl.sourceforge.net/project/opencvlibrary/opencv-ios/2.4.10/opencv2.framework.zip"
   },
   "platforms": {
     "ios": "4.0"


### PR DESCRIPTION
The http download URL hasn't been working the last couple days, wondering if we can substitute it with this alternative URL from the same site.
