### PR TITLE
Fixed documentation URL

### DIFF
--- a/Specs/FyberSDK/7.1.0/FyberSDK.podspec.json
+++ b/Specs/FyberSDK/7.1.0/FyberSDK.podspec.json
@@ -16,7 +16,7 @@
   "source": {
     "http": "https://bintray.com/artifact/download/fyber/mobile-sdk/Fyber_iOS_SDK_v.7.1.0.zip"
   },
-  "documentation_url": "http://developer.fyber.com/content/ref/ios/7.1.0/",
+  "documentation_url": "http://developer.fyber.com/ref/ios/7.1.0/",
   "public_header_files": "Fyber_iOS_SDK_v.7.1.0/sponsorpay-sdk-lib/*.h",
   "vendored_libraries": "Fyber_iOS_SDK_v.7.1.0/sponsorpay-sdk-lib/libSponsorPaySDK-*.a",
   "resources": "Fyber_iOS_SDK_v.7.1.0/sponsorpay-sdk-lib/Resources/**/*.{png,json}",


### PR DESCRIPTION
Hi,
there was a typo in our documentation URL.
