### PR TITLE
Fix missing upnpx public header files

### DIFF
--- a/Specs/upnpx/1.3.2/upnpx.podspec.json
+++ b/Specs/upnpx/1.3.2/upnpx.podspec.json
@@ -18,12 +18,20 @@
     "source_files": [
       "src/{api,common,eventserver,ssdp,upnp}/*.{h,m,mm,c,cpp}",
       "src/port/ios/*.{h,m}"
+    ],
+    "public_header_files": [
+      "src/api/*.h",
+      "src/port/ios/*.h"
     ]
   },
   "osx": {
     "source_files": [
       "src/{api,common,eventserver,ssdp,upnp}/*.{h,m,mm,c,cpp}",
       "src/port/macos/*.{h,m}"
+    ],
+    "public_header_files": [
+      "src/api/*.h",
+      "src/port/macos/*.h"
     ]
   },
   "libraries": "stdc++",


### PR DESCRIPTION
Submitting/merging a PR for the following reason:

> I pushed an update to this Pod yesterday, but didn't see a [PR](https://github.com/fkuehne/upnpx/pull/54/files) on the project which claims better compatibility with CocoaPods 0.36. I agree with the change, but I've already pushed the spec missing this change.
