### PR TITLE
Update an existing podspec for Helpshift 4.10.2

### DIFF
--- a/Helpshift/4.10.0/Helpshift.podspec
+++ b/Helpshift/4.10.0/Helpshift.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name                = 'Helpshift'
+  s.version             = '4.10.0'
+  s.summary             = 'Customer service helpdesk for mobile applications.'
+  s.license             = { :type => 'Commercial', :text => 'See http://www.helpshift.com/terms/' }
+  s.homepage            = 'http://www.helpshift.com/'
+  s.author              = { 'Helpshift' => 'support@helpshift.com' }
+  s.source              = { :http => 'https://d3e51fp79zp4el.cloudfront.net/library/ios/v4.9/helpshift-sdk-ios-v4.10.0.zip' }
+  s.platform            = :ios, '6.0'
+  s.source_files        = 'helpshift-sdk-ios-v4.10.0/Helpshift.h'
+  s.resources           = 'helpshift-sdk-ios-v4.10.0/HSResources/*.png'
+  s.preserve_paths      = 'helpshift-sdk-ios-v4.10.0/libHelpshift.a', 'helpshift-sdk-ios-v4.10.0/HSLocalization/*.lproj', 'helpshift-sdk-ios-v4.10.0/HSThemes/*.plist'
+  s.frameworks          = 'CoreGraphics', 'QuartzCore', 'CoreText', 'SystemConfiguration', 'CoreTelephony', 'Foundation', 'UIKit', 'Security', 'QuickLook'
+  s.libraries           = 'sqlite3.0', 'z', 'Helpshift'
+  s.xcconfig            = {'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Helpshift/helpshift-sdk-ios-v4.10.0"'}
+  s.documentation_url   = 'http://developers.helpshift.com/ios/'
+  s.requires_arc        = false
+end

--- a/Helpshift/4.10.0/Helpshift.podspec
+++ b/Helpshift/4.10.0/Helpshift.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.license             = { :type => 'Commercial', :text => 'See http://www.helpshift.com/terms/' }
   s.homepage            = 'http://www.helpshift.com/'
   s.author              = { 'Helpshift' => 'support@helpshift.com' }
-  s.source              = { :http => 'https://d3e51fp79zp4el.cloudfront.net/library/ios/v4.9/helpshift-sdk-ios-v4.10.0.zip' }
+  s.source              = { :http => 'https://d3e51fp79zp4el.cloudfront.net/library/ios/v4.10/helpshift-sdk-ios-v4.10.0.zip' }
   s.platform            = :ios, '6.0'
   s.source_files        = 'helpshift-sdk-ios-v4.10.0/Helpshift.h'
   s.resources           = 'helpshift-sdk-ios-v4.10.0/HSResources/*.png'

--- a/Helpshift/4.10.1/Helpshift.podspec
+++ b/Helpshift/4.10.1/Helpshift.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name                = 'Helpshift'
+  s.version             = '4.10.1'
+  s.summary             = 'Customer service helpdesk for mobile applications.'
+  s.license             = { :type => 'Commercial', :text => 'See http://www.helpshift.com/terms/' }
+  s.homepage            = 'http://www.helpshift.com/'
+  s.author              = { 'Helpshift' => 'support@helpshift.com' }
+  s.source              = { :http => 'https://d3e51fp79zp4el.cloudfront.net/library/ios/v4.10/helpshift-sdk-ios-v4.10.1.zip' }
+  s.platform            = :ios, '6.0'
+  s.source_files        = 'helpshift-sdk-ios-v4.10.1/Helpshift.h'
+  s.resources           = 'helpshift-sdk-ios-v4.10.1/HSResources/*.png'
+  s.preserve_paths      = 'helpshift-sdk-ios-v4.10.1/libHelpshift.a', 'helpshift-sdk-ios-v4.10.1/HSLocalization/*.lproj', 'helpshift-sdk-ios-v4.10.1/HSThemes/*.plist'
+  s.frameworks          = 'CoreGraphics', 'QuartzCore', 'CoreText', 'SystemConfiguration', 'CoreTelephony', 'Foundation', 'UIKit', 'Security', 'QuickLook'
+  s.libraries           = 'sqlite3.0', 'z', 'Helpshift'
+  s.xcconfig            = {'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Helpshift/helpshift-sdk-ios-v4.10.1"'}
+  s.documentation_url   = 'http://developers.helpshift.com/ios/'
+  s.requires_arc        = false
+end

--- a/Helpshift/4.10.2/Helpshift.podspec
+++ b/Helpshift/4.10.2/Helpshift.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source              = { :http => 'https://d3e51fp79zp4el.cloudfront.net/library/ios/v4.10/helpshift-sdk-ios-v4.10.2.zip' }
   s.platform            = :ios, '6.0'
   s.source_files        = 'helpshift-sdk-ios-v4.10.2/Helpshift.h'
-  s.resources           = 'helpshift-sdk-ios-v4.10.2/HSResources/*.png'
+  s.resources           = ["helpshift-sdk-ios-v4.10.2/HSResources/*.png", "helpshift-sdk-ios-v4.10.2/HSLocalization/*.lproj"]
   s.preserve_paths      = 'helpshift-sdk-ios-v4.10.2/libHelpshift.a', 'helpshift-sdk-ios-v4.10.2/HSLocalization/*.lproj', 'helpshift-sdk-ios-v4.10.2/HSThemes/*.plist'
   s.frameworks          = 'CoreGraphics', 'QuartzCore', 'CoreText', 'SystemConfiguration', 'CoreTelephony', 'Foundation', 'UIKit', 'Security', 'QuickLook'
   s.libraries           = 'sqlite3.0', 'z', 'Helpshift'

--- a/Helpshift/4.10.2/Helpshift.podspec
+++ b/Helpshift/4.10.2/Helpshift.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name                = 'Helpshift'
+  s.version             = '4.10.2'
+  s.summary             = 'Customer service helpdesk for mobile applications.'
+  s.license             = { :type => 'Commercial', :text => 'See http://www.helpshift.com/terms/' }
+  s.homepage            = 'http://www.helpshift.com/'
+  s.author              = { 'Helpshift' => 'support@helpshift.com' }
+  s.source              = { :http => 'https://d3e51fp79zp4el.cloudfront.net/library/ios/v4.10/helpshift-sdk-ios-v4.10.2.zip' }
+  s.platform            = :ios, '6.0'
+  s.source_files        = 'helpshift-sdk-ios-v4.10.2/Helpshift.h'
+  s.resources           = 'helpshift-sdk-ios-v4.10.2/HSResources/*.png'
+  s.preserve_paths      = 'helpshift-sdk-ios-v4.10.2/libHelpshift.a', 'helpshift-sdk-ios-v4.10.2/HSLocalization/*.lproj', 'helpshift-sdk-ios-v4.10.2/HSThemes/*.plist'
+  s.frameworks          = 'CoreGraphics', 'QuartzCore', 'CoreText', 'SystemConfiguration', 'CoreTelephony', 'Foundation', 'UIKit', 'Security', 'QuickLook'
+  s.libraries           = 'sqlite3.0', 'z', 'Helpshift'
+  s.xcconfig            = {'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Helpshift/helpshift-sdk-ios-v4.10.2"'}
+  s.documentation_url   = 'http://developers.helpshift.com/ios/'
+  s.requires_arc        = false
+end

--- a/Helpshift/4.5.0/Helpshift.podspec
+++ b/Helpshift/4.5.0/Helpshift.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name                = 'Helpshift'
+  s.version             = '4.5.0'
+  s.summary             = 'Customer service helpdesk for mobile applications.'
+  s.license             = { :type => 'Commercial', :text => 'See http://www.helpshift.com/terms/' }
+  s.homepage            = 'http://www.helpshift.com/'
+  s.author              = { 'Helpshift' => 'support@helpshift.com' }
+  s.source              = { :http => 'https://d3e51fp79zp4el.cloudfront.net/library/ios/v4.5/helpshift-sdk-ios-v4.5.0.zip' }
+  s.platform            = :ios, '5.0'
+  s.source_files        = 'helpshift-sdk-ios-v4.5.0/Helpshift.h'
+  s.resources           = 'helpshift-sdk-ios-v4.5.0/HSResources/*.png'
+  s.preserve_paths      = 'helpshift-sdk-ios-v4.5.0/libHelpshift.a', 'helpshift-sdk-ios-v4.5.0/HSLocalization/*.lproj', 'helpshift-sdk-ios-v4.5.0/HSThemes/*.plist'
+  s.frameworks          = 'CoreGraphics', 'QuartzCore', 'CoreText', 'SystemConfiguration', 'CoreTelephony', 'Foundation', 'UIKit'
+  s.libraries           = 'sqlite3.0', 'z', 'Helpshift'
+  s.xcconfig            = {'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Helpshift/helpshift-sdk-ios-v4.5.0"'}
+  s.documentation_url   = 'http://developers.helpshift.com/ios/'
+  s.requires_arc        = false
+end

--- a/Helpshift/4.6.0/Helpshift.podspec
+++ b/Helpshift/4.6.0/Helpshift.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name                = 'Helpshift'
+  s.version             = '4.6.0'
+  s.summary             = 'Customer service helpdesk for mobile applications.'
+  s.license             = { :type => 'Commercial', :text => 'See http://www.helpshift.com/terms/' }
+  s.homepage            = 'http://www.helpshift.com/'
+  s.author              = { 'Helpshift' => 'support@helpshift.com' }
+  s.source              = { :http => 'https://d3e51fp79zp4el.cloudfront.net/library/ios/v4.6/helpshift-sdk-ios-v4.6.0.zip' }
+  s.platform            = :ios, '5.0'
+  s.source_files        = 'helpshift-sdk-ios-v4.6.0/Helpshift.h'
+  s.resources           = 'helpshift-sdk-ios-v4.6.0/HSResources/*.png'
+  s.preserve_paths      = 'helpshift-sdk-ios-v4.6.0/libHelpshift.a', 'helpshift-sdk-ios-v4.6.0/HSLocalization/*.lproj', 'helpshift-sdk-ios-v4.6.0/HSThemes/*.plist'
+  s.frameworks          = 'CoreGraphics', 'QuartzCore', 'CoreText', 'SystemConfiguration', 'CoreTelephony', 'Foundation', 'UIKit'
+  s.libraries           = 'sqlite3.0', 'z', 'Helpshift'
+  s.xcconfig            = {'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Helpshift/helpshift-sdk-ios-v4.6.0"'}
+  s.documentation_url   = 'http://developers.helpshift.com/ios/'
+  s.requires_arc        = false
+end

--- a/Helpshift/4.7.0/Helpshift.podspec
+++ b/Helpshift/4.7.0/Helpshift.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name                = 'Helpshift'
+  s.version             = '4.7.0'
+  s.summary             = 'Customer service helpdesk for mobile applications.'
+  s.license             = { :type => 'Commercial', :text => 'See http://www.helpshift.com/terms/' }
+  s.homepage            = 'http://www.helpshift.com/'
+  s.author              = { 'Helpshift' => 'support@helpshift.com' }
+  s.source              = { :http => 'https://d3e51fp79zp4el.cloudfront.net/library/ios/v4.7/helpshift-sdk-ios-v4.7.0.zip' }
+  s.platform            = :ios, '5.0'
+  s.source_files        = 'helpshift-sdk-ios-v4.7.0/Helpshift.h'
+  s.resources           = 'helpshift-sdk-ios-v4.7.0/HSResources/*.png'
+  s.preserve_paths      = 'helpshift-sdk-ios-v4.7.0/libHelpshift.a', 'helpshift-sdk-ios-v4.7.0/HSLocalization/*.lproj', 'helpshift-sdk-ios-v4.7.0/HSThemes/*.plist'
+  s.frameworks          = 'CoreGraphics', 'QuartzCore', 'CoreText', 'SystemConfiguration', 'CoreTelephony', 'Foundation', 'UIKit'
+  s.libraries           = 'sqlite3.0', 'z', 'Helpshift'
+  s.xcconfig            = {'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Helpshift/helpshift-sdk-ios-v4.7.0"'}
+  s.documentation_url   = 'http://developers.helpshift.com/ios/'
+  s.requires_arc        = false
+end

--- a/Helpshift/4.8.0/Helpshift.podspec
+++ b/Helpshift/4.8.0/Helpshift.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name                = 'Helpshift'
+  s.version             = '4.8.0'
+  s.summary             = 'Customer service helpdesk for mobile applications.'
+  s.license             = { :type => 'Commercial', :text => 'See http://www.helpshift.com/terms/' }
+  s.homepage            = 'http://www.helpshift.com/'
+  s.author              = { 'Helpshift' => 'support@helpshift.com' }
+  s.source              = { :http => 'https://d3e51fp79zp4el.cloudfront.net/library/ios/v4.8/helpshift-sdk-ios-v4.8.0.zip' }
+  s.platform            = :ios, '5.0'
+  s.source_files        = 'helpshift-sdk-ios-v4.8.0/Helpshift.h'
+  s.resources           = 'helpshift-sdk-ios-v4.8.0/HSResources/*.png'
+  s.preserve_paths      = 'helpshift-sdk-ios-v4.8.0/libHelpshift.a', 'helpshift-sdk-ios-v4.8.0/HSLocalization/*.lproj', 'helpshift-sdk-ios-v4.8.0/HSThemes/*.plist'
+  s.frameworks          = 'CoreGraphics', 'QuartzCore', 'CoreText', 'SystemConfiguration', 'CoreTelephony', 'Foundation', 'UIKit'
+  s.libraries           = 'sqlite3.0', 'z', 'Helpshift'
+  s.xcconfig            = {'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Helpshift/helpshift-sdk-ios-v4.8.0"'}
+  s.documentation_url   = 'http://developers.helpshift.com/ios/'
+  s.requires_arc        = false
+end

--- a/Helpshift/4.9.0/Helpshift.podspec
+++ b/Helpshift/4.9.0/Helpshift.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name                = 'Helpshift'
+  s.version             = '4.9.0'
+  s.summary             = 'Customer service helpdesk for mobile applications.'
+  s.license             = { :type => 'Commercial', :text => 'See http://www.helpshift.com/terms/' }
+  s.homepage            = 'http://www.helpshift.com/'
+  s.author              = { 'Helpshift' => 'support@helpshift.com' }
+  s.source              = { :http => 'https://d3e51fp79zp4el.cloudfront.net/library/ios/v4.9/helpshift-sdk-ios-v4.9.0.zip' }
+  s.platform            = :ios, '5.0'
+  s.source_files        = 'helpshift-sdk-ios-v4.9.0/Helpshift.h'
+  s.resources           = 'helpshift-sdk-ios-v4.9.0/HSResources/*.png'
+  s.preserve_paths      = 'helpshift-sdk-ios-v4.9.0/libHelpshift.a', 'helpshift-sdk-ios-v4.9.0/HSLocalization/*.lproj', 'helpshift-sdk-ios-v4.9.0/HSThemes/*.plist'
+  s.frameworks          = 'CoreGraphics', 'QuartzCore', 'CoreText', 'SystemConfiguration', 'CoreTelephony', 'Foundation', 'UIKit'
+  s.libraries           = 'sqlite3.0', 'z', 'Helpshift'
+  s.xcconfig            = {'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Helpshift/helpshift-sdk-ios-v4.9.0"'}
+  s.documentation_url   = 'http://developers.helpshift.com/ios/'
+  s.requires_arc        = false
+end

--- a/Helpshift/4.9.1/Helpshift.podspec
+++ b/Helpshift/4.9.1/Helpshift.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name                = 'Helpshift'
+  s.version             = '4.9.1'
+  s.summary             = 'Customer service helpdesk for mobile applications.'
+  s.license             = { :type => 'Commercial', :text => 'See http://www.helpshift.com/terms/' }
+  s.homepage            = 'http://www.helpshift.com/'
+  s.author              = { 'Helpshift' => 'support@helpshift.com' }
+  s.source              = { :http => 'https://d3e51fp79zp4el.cloudfront.net/library/ios/v4.9/helpshift-sdk-ios-v4.9.1.zip' }
+  s.platform            = :ios, '5.0'
+  s.source_files        = 'helpshift-sdk-ios-v4.9.1/Helpshift.h'
+  s.resources           = 'helpshift-sdk-ios-v4.9.1/HSResources/*.png'
+  s.preserve_paths      = 'helpshift-sdk-ios-v4.9.1/libHelpshift.a', 'helpshift-sdk-ios-v4.9.1/HSLocalization/*.lproj', 'helpshift-sdk-ios-v4.9.1/HSThemes/*.plist'
+  s.frameworks          = 'CoreGraphics', 'QuartzCore', 'CoreText', 'SystemConfiguration', 'CoreTelephony', 'Foundation', 'UIKit'
+  s.libraries           = 'sqlite3.0', 'z', 'Helpshift'
+  s.xcconfig            = {'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Helpshift/helpshift-sdk-ios-v4.9.1"'}
+  s.documentation_url   = 'http://developers.helpshift.com/ios/'
+  s.requires_arc        = false
+end


### PR DESCRIPTION
We have moved to using trunk for pushing pod versions but we need to update an existing podspec version.
Our versions depend upon the native SDK version that we are releasing so it doesnt make sense for us to add a new version.
Also, the high number of changes that you see are due to the fact that the upstream Specs repository does not have the podspec files but instead the podspec.json files since we started using Trunk.
