### PR TITLE
Lowered requirement for iOS to 8.0

### DIFF
--- a/Specs/LlamaKit/0.6.0/LlamaKit.podspec.json
+++ b/Specs/LlamaKit/0.6.0/LlamaKit.podspec.json
@@ -10,7 +10,7 @@
   },
   "social_media_url": "https://twitter.com/cocoaphony",
   "platforms": {
-    "ios": "8.3",
+    "ios": "8.0",
     "osx": "10.10"
   },
   "source": {


### PR DESCRIPTION
I initially made this to prevent people from using the pod with pre-Xcode 6.3, but what if they _are_ using 6.3 but want to support lower versions of iOS? 
