### PR TITLE
Fixed license type

### DIFF
--- a/Specs/AppsFlyer-SDK/2.5.3.14/AppsFlyer-SDK.podspec.json
+++ b/Specs/AppsFlyer-SDK/2.5.3.14/AppsFlyer-SDK.podspec.json
@@ -5,8 +5,8 @@
   "description": "                       AppsFlyer's NativeTrack allows you to find what attracts new users to your app, measure all your app marketing activities on one dashboard, and add new traffic sources in minutes, all without having to update SDK's.\n\n                       * Markdown format.\n                       * Don't worry about the indent, we strip it!\n",
   "homepage": "http://appsflyer.com",
   "license": {
-    "type": "MIT",
-    "file": "LICENSE"
+    "type": "Proprietary",
+    "text": "    Copyright 2014 AppsFlyer Ltd. All rights reserved.\n"
   },
   "authors": {
     "Gil Meroz": "gil@appsflyer.com"


### PR DESCRIPTION
`pod install` is showing an error:

```
pod install says
[!] Unable to read the license file `[...]/Pods/AppsFlyer-SDK/LICENSE` for the spec `AppsFlyer-SDK (2.5.3.14)
```

It was already fixed in https://github.com/CocoaPods/Specs/pull/13001 for 2.5.3.11 but the fix disappeared on the next version
