### PR TITLE
Seems to be missing the AFNetworking dependency

### DIFF
--- a/Specs/SGImageCache/1.2.0/SGImageCache.podspec.json
+++ b/Specs/SGImageCache/1.2.0/SGImageCache.podspec.json
@@ -22,6 +22,9 @@
     ],
     "MGEvents": [
 
+    ],
+    "AFNetworking" :[
+      
     ]
   },
   "default_subspecs": "base",


### PR DESCRIPTION
I tried installing in my swift project using Alamofire instead of AFNetworking and had to manually modify the dependency to the AfNetworking.framework in the pod project file. Will this fix it?
