### PR TITLE
libopus: Exclude demo file that should not be built

### DIFF
--- a/Specs/libopus/1.0.3/libopus.podspec.json
+++ b/Specs/libopus/1.0.3/libopus.podspec.json
@@ -24,7 +24,7 @@
     "tag": "v1.0.3"
   },
   "requires_arc": false,
-  "default_subspec": "float",
+  "default_subspecs": "float",
   "xcconfig": {
     "HEADER_SEARCH_PATHS": "\"${PODS_ROOT}/libopus/silk\""
   },
@@ -58,6 +58,7 @@
       "public_header_files": [
         "include/*.h"
       ],
+      "exclude_files": "celt/opus_custom_demo.c",
       "compiler_flags": [
         "-w",
         "-Xanalyzer",
@@ -94,6 +95,7 @@
       "public_header_files": [
         "include/*.h"
       ],
+      "exclude_files": "celt/opus_custom_demo.c",
       "compiler_flags": [
         "-w",
         "-Xanalyzer",

--- a/Specs/libopus/1.1/libopus.podspec.json
+++ b/Specs/libopus/1.1/libopus.podspec.json
@@ -57,6 +57,7 @@
       "public_header_files": [
         "include/*.h"
       ],
+      "exclude_files": "celt/opus_custom_demo.c",
       "compiler_flags": [
         "-w",
         "-Xanalyzer",
@@ -95,6 +96,7 @@
       "public_header_files": [
         "include/*.h"
       ],
+      "exclude_files": "celt/opus_custom_demo.c",
       "compiler_flags": [
         "-w",
         "-Xanalyzer",


### PR DESCRIPTION
`celt/opus_custom_demo.c` should not be build in the library since it includes a `main()` function and causes [linker errors](https://gist.github.com/Chuongv/3e5b53b5fd0727bb2afa)
