### PR TITLE
Updating pod for Google Mobile Ads SDK version 7.2.1

### DIFF
--- a/Specs/Google-Mobile-Ads-SDK/7.2.1/Google-Mobile-Ads-SDK.podspec.json
+++ b/Specs/Google-Mobile-Ads-SDK/7.2.1/Google-Mobile-Ads-SDK.podspec.json
@@ -22,6 +22,7 @@
     "AudioToolbox",
     "AVFoundation",
     "CoreGraphics",
+    "CoreMedia",
     "CoreTelephony",
     "EventKit",
     "EventKitUI",


### PR DESCRIPTION
Fix for pod spec. Won't be able to bump the version number as SDK release is still on 7.2.1.
