### PR TITLE
Add deprecated_in_favor_of line to MZRPresentationKit

### DIFF
--- a/Specs/MZRPresentationKit/1.0.0/MZRPresentationKit.podspec.json
+++ b/Specs/MZRPresentationKit/1.0.0/MZRPresentationKit.podspec.json
@@ -17,5 +17,6 @@
     "ios": "8.0"
   },
   "requires_arc": true,
-  "source_files": "Pod/Classes/**/*.swift"
+  "source_files": "Pod/Classes/**/*.swift",
+  "deprecated_in_favor_of": "TouchVisualizer"
 }

--- a/Specs/MZRPresentationKit/1.0.1/MZRPresentationKit.podspec.json
+++ b/Specs/MZRPresentationKit/1.0.1/MZRPresentationKit.podspec.json
@@ -17,5 +17,6 @@
     "ios": "8.0"
   },
   "requires_arc": true,
-  "source_files": "Pod/Classes/**/*.swift"
+  "source_files": "Pod/Classes/**/*.swift",
+  "deprecated_in_favor_of": "TouchVisualizer"
 }

--- a/Specs/MZRPresentationKit/1.0.2/MZRPresentationKit.podspec.json
+++ b/Specs/MZRPresentationKit/1.0.2/MZRPresentationKit.podspec.json
@@ -17,5 +17,6 @@
     "ios": "8.0"
   },
   "requires_arc": true,
-  "source_files": "Pod/Classes/**/*.swift"
+  "source_files": "Pod/Classes/**/*.swift",
+  "deprecated_in_favor_of": "TouchVisualizer"
 }

--- a/Specs/MZRPresentationKit/1.0.3/MZRPresentationKit.podspec.json
+++ b/Specs/MZRPresentationKit/1.0.3/MZRPresentationKit.podspec.json
@@ -17,5 +17,6 @@
     "ios": "8.1"
   },
   "requires_arc": true,
-  "source_files": "Pod/Classes/**/*.swift"
+  "source_files": "Pod/Classes/**/*.swift",
+  "deprecated_in_favor_of": "TouchVisualizer"
 }


### PR DESCRIPTION
Advise with https://github.com/CocoaPods/Specs/pull/13100 , added "deprecated_in_favor_of" to MZRPresentationKit podspecs.
