### PR TITLE
Mark libextobjc headers as private in Mantle podspec

### DIFF
--- a/Specs/Mantle/2.0/Mantle.podspec.json
+++ b/Specs/Mantle/2.0/Mantle.podspec.json
@@ -21,7 +21,8 @@
   "subspecs": [
     {
       "name": "extobjc",
-      "source_files": "Mantle/extobjc"
+      "source_files": "Mantle/extobjc",
+      "private_header_files": "Mantle/extobjc/*.h"
     }
   ]
 }


### PR DESCRIPTION
I can't version bump Mantle – this resolves an issue with what should be a private dependency
