### PR TITLE
fix license warning for GoogleSignInSDK 1.0.0

### DIFF
--- a/Specs/GoogleSignInSDK/1.0.0/GoogleSignInSDK.podspec.json
+++ b/Specs/GoogleSignInSDK/1.0.0/GoogleSignInSDK.podspec.json
@@ -5,7 +5,7 @@
   "homepage": "https://developers.google.com/identity/sign-in/ios/getting-started",
   "license": {
     "type": "Apache 2.0 License",
-    "file": "LICENSE"
+    "text": "Copyright 2015 Google Inc."
   },
   "authors": "Google",
   "source": {


### PR DESCRIPTION
There is no license file in the directory, so we use text instead.
