### PR TITLE
GoogleAnalytics - Correct source URLs

### DIFF
--- a/Specs/GoogleAnalytics/3.12.0/GoogleAnalytics.podspec.json
+++ b/Specs/GoogleAnalytics/3.12.0/GoogleAnalytics.podspec.json
@@ -26,6 +26,6 @@
     "z"
   ],
   "source": {
-    "http": "https://static.corp.google.com/cpdc/e2d01de47dc68c9e-GoogleAnalytics-3.12.0.tar.gz"
+    "http": "https://www.gstatic.com/cpdc/e2d01de47dc68c9e-GoogleAnalytics-3.12.0.tar.gz"
   }
 }

--- a/Specs/GoogleIDFASupport/3.12.0/GoogleIDFASupport.podspec.json
+++ b/Specs/GoogleIDFASupport/3.12.0/GoogleIDFASupport.podspec.json
@@ -19,6 +19,6 @@
     "AdSupport"
   ],
   "source": {
-    "http": "https://static.corp.google.com/cpdc/d1b9837b3d4a0fd2-GoogleIDFASupport-3.12.0.tar.gz"
+    "http": "https://www.gstatic.com/cpdc/d1b9837b3d4a0fd2-GoogleIDFASupport-3.12.0.tar.gz"
   }
 }


### PR DESCRIPTION
URLs listed in 3.12.0 were not publicly facing URLs which results in a
broken spec file.
