### PR TITLE
Fix to 2.4.13 and 2.4.14 ArtisanSDK CocoaPod.

### DIFF
--- a/Specs/ArtisanSDK/2.4.13/ArtisanSDK.podspec.json
+++ b/Specs/ArtisanSDK/2.4.13/ArtisanSDK.podspec.json
@@ -14,7 +14,7 @@
     "git": "https://github.com/ArtisanMobile/ArtisanSDK.git",
     "tag": "2.4.13"
   },
-  "source_files": "ArtisanSDK.framework/Headers/*.h",
+  "source_files": "ArtisanSDK.framework/Versions/A/Headers/*.h",
   "platforms": {
     "ios": "6.0"
   },

--- a/Specs/ArtisanSDK/2.4.14/ArtisanSDK.podspec.json
+++ b/Specs/ArtisanSDK/2.4.14/ArtisanSDK.podspec.json
@@ -14,7 +14,7 @@
     "git": "https://github.com/ArtisanMobile/ArtisanSDK.git",
     "tag": "2.4.14"
   },
-  "source_files": "ArtisanSDK.framework/Headers/*.h",
+  "source_files": "ArtisanSDK.framework/Versions/A/Headers/*.h",
   "platforms": {
     "ios": "6.0"
   },


### PR DESCRIPTION
We tweaked our Framework packaging, so we need to make a small tweak to our 2.4.13 and 2.4.14 release specs to get them properly downloading the Framework file again.

Thanks!
