### PR TITLE
Google Maps SDK for iOS 1.10 changed Pod name.

### DIFF
--- a/Specs/Google-Maps-iOS-SDK/1.9.2/Google-Maps-iOS-SDK.podspec.json
+++ b/Specs/Google-Maps-iOS-SDK/1.9.2/Google-Maps-iOS-SDK.podspec.json
@@ -1,7 +1,7 @@
 {
   "name": "Google-Maps-iOS-SDK",
   "version": "1.9.2",
-  "deprecated_in_favour_of": "GoogleMaps",
+  "deprecated_in_favor_of": "GoogleMaps",
   "summary": "Google Maps SDK for iOS.",
   "description": "Use the Google Maps SDK for iOS to add interactive maps, and immersive Street View panoramas to your app.",
   "homepage": "https://developers.google.com/maps/documentation/ios/",

--- a/Specs/Google-Maps-iOS-SDK/1.9.2/Google-Maps-iOS-SDK.podspec.json
+++ b/Specs/Google-Maps-iOS-SDK/1.9.2/Google-Maps-iOS-SDK.podspec.json
@@ -1,6 +1,7 @@
 {
   "name": "Google-Maps-iOS-SDK",
   "version": "1.9.2",
+  "deprecated_in_favour_of": "GoogleMaps",
   "summary": "Google Maps SDK for iOS.",
   "description": "Use the Google Maps SDK for iOS to add interactive maps, and immersive Street View panoramas to your app.",
   "homepage": "https://developers.google.com/maps/documentation/ios/",


### PR DESCRIPTION
Hi CocoaPods folks,

Now that [Google Maps SDK for iOS](https://developers.google.com/maps/documentation/ios/start) is officially using CocoaPods as it's official distribution mechanism, it picked up a new pod name. I'm hoping this is the correct syntax to implement [deprecated_in_favor_of](https://guides.cocoapods.org/syntax/podspec.html#deprecated_in_favor_of).

tia,

brett
