### PR TITLE
Point older JXHTTP versions to the Tumblr repository since Justin's is no longer available

### DIFF
--- a/Specs/JXHTTP/1.0.0/JXHTTP.podspec.json
+++ b/Specs/JXHTTP/1.0.0/JXHTTP.podspec.json
@@ -8,7 +8,7 @@
     "Justin Ouellette": "jstn@jxhttp.com"
   },
   "source": {
-    "git": "https://github.com/jstn/JXHTTP.git",
+    "git": "https://github.com/tumblr/JXHTTP.git",
     "tag": "1.0.0"
   },
   "license": {

--- a/Specs/JXHTTP/1.0.1/JXHTTP.podspec.json
+++ b/Specs/JXHTTP/1.0.1/JXHTTP.podspec.json
@@ -8,7 +8,7 @@
     "Justin Ouellette": "jstn@jxhttp.com"
   },
   "source": {
-    "git": "https://github.com/jstn/JXHTTP.git",
+    "git": "https://github.com/tumblr/JXHTTP.git",
     "tag": "1.0.1"
   },
   "license": {

--- a/Specs/JXHTTP/1.0.2/JXHTTP.podspec.json
+++ b/Specs/JXHTTP/1.0.2/JXHTTP.podspec.json
@@ -8,7 +8,7 @@
     "Justin Ouellette": "jstn@jxhttp.com"
   },
   "source": {
-    "git": "https://github.com/jstn/JXHTTP.git",
+    "git": "https://github.com/tumblr/JXHTTP.git",
     "tag": "1.0.2"
   },
   "license": {

--- a/Specs/JXHTTP/1.0.3/JXHTTP.podspec.json
+++ b/Specs/JXHTTP/1.0.3/JXHTTP.podspec.json
@@ -8,7 +8,7 @@
     "Justin Ouellette": "jstn@jxhttp.com"
   },
   "source": {
-    "git": "https://github.com/jstn/JXHTTP.git",
+    "git": "https://github.com/tumblr/JXHTTP.git",
     "tag": "1.0.3"
   },
   "license": {

--- a/Specs/JXHTTP/1.0.4/JXHTTP.podspec.json
+++ b/Specs/JXHTTP/1.0.4/JXHTTP.podspec.json
@@ -9,7 +9,7 @@
     "Bryan Irace": "bryan.irace@gmail.com"
   },
   "source": {
-    "git": "https://github.com/jstn/JXHTTP.git",
+    "git": "https://github.com/tumblr/JXHTTP.git",
     "tag": "1.0.4"
   },
   "license": {

--- a/Specs/JXHTTP/1.0.5/JXHTTP.podspec.json
+++ b/Specs/JXHTTP/1.0.5/JXHTTP.podspec.json
@@ -9,7 +9,7 @@
     "Bryan Irace": "bryan.irace@gmail.com"
   },
   "source": {
-    "git": "https://github.com/jstn/JXHTTP.git",
+    "git": "https://github.com/tumblr/JXHTTP.git",
     "tag": "1.0.5"
   },
   "license": {

--- a/Specs/JXHTTP/1.0.6/JXHTTP.podspec.json
+++ b/Specs/JXHTTP/1.0.6/JXHTTP.podspec.json
@@ -9,7 +9,7 @@
     "Bryan Irace": "bryan.irace@gmail.com"
   },
   "source": {
-    "git": "https://github.com/jstn/JXHTTP.git",
+    "git": "https://github.com/tumblr/JXHTTP.git",
     "tag": "1.0.6"
   },
   "license": {

--- a/Specs/JXHTTP/1.0.7/JXHTTP.podspec.json
+++ b/Specs/JXHTTP/1.0.7/JXHTTP.podspec.json
@@ -9,7 +9,7 @@
     "Bryan Irace": "bryan.irace@gmail.com"
   },
   "source": {
-    "git": "https://github.com/jstn/JXHTTP.git",
+    "git": "https://github.com/tumblr/JXHTTP.git",
     "tag": "1.0.7"
   },
   "license": {

--- a/Specs/JXHTTP/2.0.0/JXHTTP.podspec.json
+++ b/Specs/JXHTTP/2.0.0/JXHTTP.podspec.json
@@ -12,7 +12,7 @@
     "ios": "5.0"
   },
   "source": {
-    "git": "https://github.com/jstn/JXHTTP.git",
+    "git": "https://github.com/tumblr/JXHTTP.git",
     "tag": "2.0.0"
   },
   "license": {

--- a/Specs/JXHTTP/2.0.1/JXHTTP.podspec.json
+++ b/Specs/JXHTTP/2.0.1/JXHTTP.podspec.json
@@ -9,7 +9,7 @@
     "Bryan Irace": "bryan.irace@gmail.com"
   },
   "source": {
-    "git": "https://github.com/jstn/JXHTTP.git",
+    "git": "https://github.com/tumblr/JXHTTP.git",
     "tag": "2.0.1"
   },
   "license": {


### PR DESCRIPTION
In order to support [folks who are using an older version of TMTumblrSDK](https://github.com/tumblr/JXHTTP/pull/1#issuecomment-106297303), I’m updating these older versions of JXHTTP to point to the Tumblr repository (Justin yanked the original from his public GitHub account).
