### PR TITLE
Deprecate podspec

### DIFF
--- a/Specs/GoogleAnalytics-iOS-SDK/3.12/GoogleAnalytics-iOS-SDK.podspec.json
+++ b/Specs/GoogleAnalytics-iOS-SDK/3.12/GoogleAnalytics-iOS-SDK.podspec.json
@@ -17,6 +17,8 @@
     "ios": "5.0"
   },
   "requires_arc": true,
+  "deprecated": true,
+  "deprecated_in_favor_of": "GoogleAnalytics",
   "default_subspecs": "Core",
   "subspecs": [
     {

--- a/Specs/GoogleAnalytics-iOS-SDK/3.12/GoogleAnalytics-iOS-SDK.podspec.json
+++ b/Specs/GoogleAnalytics-iOS-SDK/3.12/GoogleAnalytics-iOS-SDK.podspec.json
@@ -17,7 +17,6 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "deprecated": true,
   "deprecated_in_favor_of": "GoogleAnalytics",
   "default_subspecs": "Core",
   "subspecs": [


### PR DESCRIPTION
Mark `GoogleAnalytics-iOS-SDK` deprecated as Google now provide their own Specs.
