### PR TITLE
Rename APIModel to ApiModel

### DIFF
--- a/Specs/ApiModel/0.1.0/ApiModel.podspec.json
+++ b/Specs/ApiModel/0.1.0/ApiModel.podspec.json
@@ -1,9 +1,9 @@
 {
-  "name": "APIModel",
+  "name": "ApiModel",
   "version": "0.1.0",
   "summary": "Easy API integrations using Realm and Swift",
   "description": "                   Easy get up and running with any API, with maximum flexibility,\n                   intuitive boilerplate and a very declarative aproach to API integrations.\n",
-  "homepage": "https://github.com/erkie/APIModel",
+  "homepage": "https://github.com/erkie/ApiModel",
   "license": "MIT",
   "authors": {
     "Erik Rothoff Andersson": "erik.rothoff@gmail.com"
@@ -12,7 +12,7 @@
     "ios": "8.0"
   },
   "source": {
-    "git": "https://github.com/erkie/APIModel.git",
+    "git": "https://github.com/erkie/ApiModel.git",
     "tag": "0.1.0"
   },
   "source_files": "Source/*",

--- a/Specs/ApiModel/0.2.0/ApiModel.podspec.json
+++ b/Specs/ApiModel/0.2.0/ApiModel.podspec.json
@@ -1,9 +1,9 @@
 {
-  "name": "APIModel",
-  "version": "0.3.0",
+  "name": "ApiModel",
+  "version": "0.2.0",
   "summary": "Easy API integrations using Realm and Swift",
   "description": "                   Easy get up and running with any API, with maximum flexibility,\n                   intuitive boilerplate and a very declarative aproach to API integrations.\n",
-  "homepage": "https://github.com/erkie/APIModel",
+  "homepage": "https://github.com/erkie/ApiModel",
   "license": "MIT",
   "authors": {
     "Erik Rothoff Andersson": "erik.rothoff@gmail.com"
@@ -12,17 +12,17 @@
     "ios": "8.0"
   },
   "source": {
-    "git": "https://github.com/erkie/APIModel.git",
-    "tag": "0.3.0"
+    "git": "https://github.com/erkie/ApiModel.git",
+    "tag": "0.2.0"
   },
-  "source_files": "Source/**/*",
+  "source_files": "Source/*",
   "requires_arc": true,
   "dependencies": {
     "Alamofire": [
       "~> 1.2"
     ],
-    "RealmSwift": [
-      "~> 0.92.0"
+    "Realm": [
+      "~> 0.91.0"
     ]
   }
 }

--- a/Specs/ApiModel/0.3.0/ApiModel.podspec.json
+++ b/Specs/ApiModel/0.3.0/ApiModel.podspec.json
@@ -1,9 +1,9 @@
 {
-  "name": "APIModel",
-  "version": "0.2.0",
+  "name": "ApiModel",
+  "version": "0.3.0",
   "summary": "Easy API integrations using Realm and Swift",
   "description": "                   Easy get up and running with any API, with maximum flexibility,\n                   intuitive boilerplate and a very declarative aproach to API integrations.\n",
-  "homepage": "https://github.com/erkie/APIModel",
+  "homepage": "https://github.com/erkie/ApiModel",
   "license": "MIT",
   "authors": {
     "Erik Rothoff Andersson": "erik.rothoff@gmail.com"
@@ -12,17 +12,17 @@
     "ios": "8.0"
   },
   "source": {
-    "git": "https://github.com/erkie/APIModel.git",
-    "tag": "0.2.0"
+    "git": "https://github.com/erkie/ApiModel.git",
+    "tag": "0.3.0"
   },
-  "source_files": "Source/*",
+  "source_files": "Source/**/*",
   "requires_arc": true,
   "dependencies": {
     "Alamofire": [
       "~> 1.2"
     ],
-    "Realm": [
-      "~> 0.91.0"
+    "RealmSwift": [
+      "~> 0.92.0"
     ]
   }
 }

--- a/Specs/ApiModel/0.4.0/ApiModel.podspec.json
+++ b/Specs/ApiModel/0.4.0/ApiModel.podspec.json
@@ -1,9 +1,9 @@
 {
-  "name": "APIModel",
+  "name": "ApiModel",
   "version": "0.4.0",
   "summary": "Easy API integrations using Realm and Swift",
   "description": "                   Easy get up and running with any API, with maximum flexibility,\n                   intuitive boilerplate and a very declarative aproach to API integrations.\n",
-  "homepage": "https://github.com/erkie/APIModel",
+  "homepage": "https://github.com/erkie/ApiModel",
   "license": "MIT",
   "authors": {
     "Erik Rothoff Andersson": "erik.rothoff@gmail.com"
@@ -12,7 +12,7 @@
     "ios": "8.0"
   },
   "source": {
-    "git": "https://github.com/erkie/APIModel.git",
+    "git": "https://github.com/erkie/ApiModel.git",
     "tag": "0.4.0"
   },
   "source_files": "Source/**/*",


### PR DESCRIPTION
For consistency within the project I needed to change the case of the project name, including the cocoapod itself.

However, `pod trunk push` gave the `Name already taken` error. Googling seemed to suggest either "Don't change name", "Pull request Specs" or "deprecate_in_favor_of". Now it's impossible to `deprecate_in_favor_of` where the old name is the same but with a difference case. So I decided to attempt a pull request.

I personally know the only other user of this library so it felt OK to just rename it like this. Hopefully it's OK with everyone else.
