### PR TITLE
Making the deprecation of this pod obvious.

### DIFF
--- a/Specs/Google-Maps-iOS-SDK/1.9.2/Google-Maps-iOS-SDK.podspec.json
+++ b/Specs/Google-Maps-iOS-SDK/1.9.2/Google-Maps-iOS-SDK.podspec.json
@@ -3,7 +3,7 @@
   "version": "1.9.2",
   "deprecated_in_favor_of": "GoogleMaps",
   "summary": "Google Maps SDK for iOS.",
-  "description": "Use the Google Maps SDK for iOS to add interactive maps, and immersive Street View panoramas to your app.",
+  "description": "This podspec has been deprecated. Please use the GoogleMaps pod instead.",
   "homepage": "https://developers.google.com/maps/documentation/ios/",
   "license": {
     "type": "Copyright",

--- a/Specs/Google-Maps-iOS-SDK/1.9.2/Google-Maps-iOS-SDK.podspec.json
+++ b/Specs/Google-Maps-iOS-SDK/1.9.2/Google-Maps-iOS-SDK.podspec.json
@@ -2,8 +2,8 @@
   "name": "Google-Maps-iOS-SDK",
   "version": "1.9.2",
   "deprecated_in_favor_of": "GoogleMaps",
-  "summary": "Google Maps SDK for iOS.",
-  "description": "This podspec has been deprecated. Please use the GoogleMaps pod instead.",
+  "summary": "Google-Maps-iOS-SDK (deprecated)",
+  "description": "Note: This podspec is deprecated. Please use the GoogleMaps pod instead, to get the Google Maps SDK for iOS and the Google Places API for iOS.",
   "homepage": "https://developers.google.com/maps/documentation/ios/",
   "license": {
     "type": "Copyright",


### PR DESCRIPTION
On https://cocoapods.org/pods/Google-Maps-iOS-SDK there is nothing
obvious that this pod has been deprecated in favour of GoogleMaps. We'd
like to direct our developers across to the correct Podfile. Thanks!
