### PR TITLE
Deprecate EWaySDK

### DIFF
--- a/Specs/EWaySDK/1.0.0/EWaySDK.podspec.json
+++ b/Specs/EWaySDK/1.0.0/EWaySDK.podspec.json
@@ -19,5 +19,6 @@
     "ios": "7.0"
   },
   "requires_arc": true,
+  "deprecated_in_favor_of": "eWAYPaymentsSDK",
   "source_files": "EWaySDK/*.{h,m}"
 }


### PR DESCRIPTION
This was created by one of our devs for testing and the underlying GitHub repo has since been removed.
