### PR TITLE
use vendored_frameworks for Parse.framework, fixes for 0.38 cocoapods

### DIFF
--- a/Specs/Parse/1.7.5/Parse.podspec.json
+++ b/Specs/Parse/1.7.5/Parse.podspec.json
@@ -14,15 +14,8 @@
   "platforms": {
     "ios": "6.0"
   },
-  "requires_arc": false,
-  "public_header_files": "Parse.framework/**/*.h",
-  "source_files": [
-    "Parse.framework/**/*.h",
-    "Empty.m"
-  ],
-  "preserve_paths": "Parse.framework/Parse",
-  "vendored_libraries": "libParse.a",
-  "prepare_command": "touch Empty.m && cp Parse.framework/Parse libParse.a",
+  "requires_arc": true,
+  "vendored_frameworks": "Parse.framework",
   "frameworks": [
     "AudioToolbox",
     "CFNetwork",


### PR DESCRIPTION
Fixes the problem missing header in cocoapods 0.38
