### PR TITLE
[Update] ReactiveCocoa 3.0-beta.9

### DIFF
--- a/Specs/ReactiveCocoa/3.0-beta.9/ReactiveCocoa.podspec.json
+++ b/Specs/ReactiveCocoa/3.0-beta.9/ReactiveCocoa.podspec.json
@@ -9,6 +9,7 @@
     "Josh Abernathy": "josh@github.com"
   },
   "platforms": {
+    "ios": "8.0",
     "osx": "10.10"
   },
   "source": {
@@ -58,7 +59,7 @@
 
         ]
       },
-      "frameworks": "AppKit",
+      "frameworks": "Foundation",
       "ios": {
         "source_files": [
           "**/ReactiveCocoa.h",
@@ -70,7 +71,8 @@
         "source_files": [
           "**/ReactiveCocoa.h",
           "ReactiveCocoa/**/*{AppKit,NSControl,NSText,NSTable}*"
-        ]
+        ],
+        "frameworks": "AppKit"
       }
     }
   ]


### PR DESCRIPTION
Hi,
I've uploaded (via @ashfurrow, who was so nice to do it for me) a podspec file for ReactiveCocoa 3.0-beta.9

Too bad I made a mistake and left out the ios platform...
This PR fixes it.

Releasing a new version is not really an option here, since I'm not the author of the library.
