### PR TITLE
Add BWMCoverView podspec file

### DIFF
--- a/Specs/BWMCoverView/BWMCoverView.podspec
+++ b/Specs/BWMCoverView/BWMCoverView.podspec
@@ -1,0 +1,132 @@
+#
+#  Be sure to run `pod spec lint BWMCoverView.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  These will help people to find your library, and whilst it
+  #  can feel like a chore to fill in it's definitely to your advantage. The
+  #  summary should be tweet-length, and the description more in depth.
+  #
+
+  s.name         = "BWMCoverView"
+  s.version      = "0.0.1"
+  s.summary      = "BWMCoverView is an easy to use recyclable advertisement player. Extends to UIView class and UIPageControl class. By Bi Weiming."
+
+  s.description  = <<-DESC
+                   BWMCoverView is an easy to use recyclable advertisement player. Extends to UIView class and UIPageControl class, you will nike it. By Bi Weiming, made in China Guangzhou.
+                   It is a advertisement player view used on iOS, which implement by Objective-C.
+                   DESC
+
+  s.homepage     = "https://github.com/Nihility-Ming/BWMCoverView"
+  s.screenshots  = "https://raw.githubusercontent.com/Nihility-Ming/BWMCoverView/gh-pages/AppScreenShotCase.gif"
+
+
+  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Licensing your code is important. See http://choosealicense.com for more info.
+  #  CocoaPods will detect a license file if there is a named LICENSE*
+  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
+  #
+
+  s.license      = "MIT"
+  # s.license      = { :type => "MIT", :file => "LICENSE.md" }
+
+
+  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the authors of the library, with email addresses. Email addresses
+  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
+  #  accepts just a name if you'd rather not provide an email address.
+  #
+  #  Specify a social_media_url where others can refer to, for example a twitter
+  #  profile URL.
+  #
+
+  s.author             = { "Bi Weiming" => "tvlogin@qq.com" }
+  # Or just: s.author    = "weiming.bi"
+  # s.authors            = { "weiming.bi" => "weiming.bi@yahoo.com" }
+  # s.social_media_url   = "http://twitter.com/weiming.bi"
+
+  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If this Pod runs only on iOS or OS X, then specify the platform and
+  #  the deployment target. You can optionally include the target after the platform.
+  #
+
+  # s.platform     = :ios
+    s.platform     = :ios, "6.0"
+
+  #  When using multiple platforms
+    s.ios.deployment_target = "6.0"
+  # s.osx.deployment_target = "10.7"
+
+
+  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the location from where the source should be retrieved.
+  #  Supports git, hg, bzr, svn and HTTP.
+  #
+
+  s.source       = { :git => "https://github.com/Nihility-Ming/BWMCoverView.git", :tag => "0.0.1" }
+
+
+  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  CocoaPods is smart about how it includes source code. For source files
+  #  giving a folder will include any h, m, mm, c & cpp files. For header
+  #  files it will include any header in the folder.
+  #  Not including the public_header_files will make all headers public.
+  #
+
+  s.source_files  = "BWMCoverView/BWMCoverView/*"
+  # s.exclude_files = "SDWebImage/*"
+
+  # s.public_header_files = "BWMCoverView/SDWebImage/*"
+
+
+  # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  A list of resources included with the Pod. These are copied into the
+  #  target bundle with a build phase script. Anything else will be cleaned.
+  #  You can preserve files from being cleaned, please don't preserve
+  #  non-essential files like tests, examples and documentation.
+  #
+
+  # s.resource  = "icon.png"
+  # s.resources = "Resources/*.png"
+
+  # s.preserve_paths = "FilesToSave", "MoreFilesToSave"
+
+
+  # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Link your library with frameworks, or libraries. Libraries do not include
+  #  the lib prefix of their name.
+  #
+
+  # s.framework  = "SomeFramework"
+    s.frameworks = "Foundation", "CoreGraphics", "UIKit"
+
+  # s.library   = "iconv"
+  # s.libraries = "iconv", "xml2"
+
+
+  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If your library depends on compiler flags you can set them in the xcconfig hash
+  #  where they will only apply to your library. If you depend on other Podspecs
+  #  you can include multiple dependencies to ensure it works.
+
+    s.requires_arc = true
+
+  # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
+    s.dependency "SDWebImage", "~> 3.7.2"
+
+end


### PR DESCRIPTION
Add BWMCoverView of new library to Cocoapods.
BWMCoverView is an easy to use recyclable advertisement player. Extends to UIView class and UIPageControl class. By Bi Weiming.
