### PR TITLE
Switch to working mirrors for OpenCV

### DIFF
--- a/Specs/OpenCV/2.4.10/OpenCV.podspec.json
+++ b/Specs/OpenCV/2.4.10/OpenCV.podspec.json
@@ -10,7 +10,7 @@
   },
   "authors": "opencv.org",
   "source": {
-    "http": "http://garr.dl.sourceforge.net/project/opencvlibrary/opencv-ios/2.4.10/opencv2.framework.zip"
+    "http": "http://download.sourceforge.net/project/opencvlibrary/opencv-ios/2.4.10/opencv2.framework.zip"
   },
   "platforms": {
     "ios": "4.0"

--- a/Specs/OpenCV/2.4.10/OpenCV.podspec.json
+++ b/Specs/OpenCV/2.4.10/OpenCV.podspec.json
@@ -10,7 +10,7 @@
   },
   "authors": "opencv.org",
   "source": {
-    "http": "http://hivelocity.dl.sourceforge.net/project/opencvlibrary/opencv-ios/2.4.10/opencv2.framework.zip"
+    "http": "http://garr.dl.sourceforge.net/project/opencvlibrary/opencv-ios/2.4.10/opencv2.framework.zip"
   },
   "platforms": {
     "ios": "4.0"

--- a/Specs/OpenCV/2.4.9/OpenCV.podspec.json
+++ b/Specs/OpenCV/2.4.9/OpenCV.podspec.json
@@ -10,7 +10,7 @@
   },
   "authors": "opencv.org",
   "source": {
-    "http": "http://garr.dl.sourceforge.net/project/opencvlibrary/opencv-ios/2.4.9/opencv2.framework.zip"
+    "http": "http://downloads.sourceforge.net/project/opencvlibrary/opencv-ios/2.4.9/opencv2.framework.zip"
   },
   "platforms": {
     "ios": "4.0"

--- a/Specs/OpenCV/2.4.9/OpenCV.podspec.json
+++ b/Specs/OpenCV/2.4.9/OpenCV.podspec.json
@@ -10,7 +10,7 @@
   },
   "authors": "opencv.org",
   "source": {
-    "http": "http://hivelocity.dl.sourceforge.net/project/opencvlibrary/opencv-ios/2.4.9/opencv2.framework.zip"
+    "http": "http://garr.dl.sourceforge.net/project/opencvlibrary/opencv-ios/2.4.9/opencv2.framework.zip"
   },
   "platforms": {
     "ios": "4.0"


### PR DESCRIPTION
It looks like the current URLs for OpenCV [have been broken for over a month now](http://stackoverflow.com/questions/31005022/cant-install-opencv-with-cocoapods-could-not-resolve-host-hivelocity-dl-sourc). I updated the Podspec to a different SourceForge mirror for versions 2.4.9 and 2.4.10.

I also have a Podspec for OpenCV 3.0.0, but I assume I need to leave that up to the owner.

Thanks!
