### PR TITLE
Add public_header_files path to 3.1.0 version of Crashlytics podspec

### DIFF
--- a/Specs/Crashlytics/3.1.0/Crashlytics.podspec.json
+++ b/Specs/Crashlytics/3.1.0/Crashlytics.podspec.json
@@ -11,6 +11,7 @@
     "http": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.1.0/com.twitter.crashlytics.ios-default.zip"
   },
   "vendored_frameworks": "Crashlytics.framework",
+  "public_header_files": "Crashlytics.framework/Headers/*.h",
   "license": {
     "type": "Commercial",
     "text": "Fabric: Copyright 2015 Twitter, Inc. All Rights Reserved. Use of this software is subject to the terms and conditions of the Fabric Software and Services Agreement located at https://fabric.io/terms. Crashlytics Kit: Copyright 2015 Crashlytics, Inc. All Rights Reserved. Use of this software is subject to the terms and conditions of the Crashlytics Terms of Service located at http://try.crashlytics.com/terms/terms-of-service.pdf and the Crashlytics Privacy Policy located at http://try.crashlytics.com/terms/privacy-policy.pdf. OSS: http://get.fabric.io/terms/opensource.txt"


### PR DESCRIPTION
The patch is exactly the same as the one in #13315 (discussed in https://github.com/CocoaPods/CocoaPods/issues/3828). Twitter recently published a new version so the same patch needs to be applied to it as well.
