### PR TITLE
Add the headers to 3.0.11 also

### DIFF
--- a/Specs/Crashlytics-OSX/3.0.11/Crashlytics-OSX.podspec.json
+++ b/Specs/Crashlytics-OSX/3.0.11/Crashlytics-OSX.podspec.json
@@ -11,6 +11,7 @@
     "http": "https://kit-downloads.fabric.io/mac/com.twitter.crashlytics.mac/3.0.11/com.twitter.crashlytics.mac-default.zip"
   },
   "vendored_frameworks": "Crashlytics.framework",
+  "public_header_files": "Crashlytics.framework/Headers/*.h",
   "license": {
     "type": "Commercial",
     "text": "Fabric: Copyright 2015 Twitter, Inc. All Rights Reserved. Use of this software is subject to the terms and conditions of the Fabric Software and Services Agreement located at https://fabric.io/terms.  Crashlytics Kit: Copyright 2015 Crashlytics, Inc. All Rights Reserved. Use of this software is subject to the terms and conditions of the Crashlytics Terms of Service located at http://try.crashlytics.com/terms/terms-of-service.pdf and the Crashlytics Privacy Policy located at http://try.crashlytics.com/terms/privacy-policy.pdf. OSS: http://get.fabric.io/terms/opensource.txt"


### PR DESCRIPTION
This is really the last one! So sorry! We just decided to make sure that these were all working for anyone that is pinned to an older version and this one fell through the cracks. Now they should be all set and up-to-date with the public headers defined.

Thank you so much! 
