### PR TITLE
Updates Moya remote.

### DIFF
--- a/Specs/Moya/0.6.1/Moya.podspec.json
+++ b/Specs/Moya/0.6.1/Moya.podspec.json
@@ -3,7 +3,7 @@
   "version": "0.6.1",
   "summary": "Network abstraction layer written in Swift",
   "description": "  Moya abstracts network commands using Swift Generics to provide developers \n  with more compile-time confidence. \n\n  A ReactiveCocoa extension exists as well. Instructions for its installation\n  are in [the README](https://github.com/ashfurrow/Moya).\n",
-  "homepage": "https://github.com/AshFurrow/Moya",
+  "homepage": "https://github.com/Moya/Moya",
   "license": {
     "type": "MIT",
     "file": "LICENSE"
@@ -16,7 +16,7 @@
     "ios": "8.0"
   },
   "source": {
-    "git": "https://github.com/ashfurrow/Moya.git",
+    "git": "https://github.com/Moya/Moya.git",
     "tag": "0.6.1"
   },
   "default_subspecs": "Core",

--- a/Specs/Moya/0.6/Moya.podspec.json
+++ b/Specs/Moya/0.6/Moya.podspec.json
@@ -3,7 +3,7 @@
   "version": "0.6",
   "summary": "Network abstraction layer written in Swift",
   "description": "  Moya abstracts network commands using Swift Generics to provide developers \n  with more compile-time confidence. \n\n  A ReactiveCocoa extension exists as well. Instructions for its installation\n  are in [the README](https://github.com/ashfurrow/Moya).\n",
-  "homepage": "https://github.com/AshFurrow/Moya",
+  "homepage": "https://github.com/Moya/Moya",
   "license": {
     "type": "MIT",
     "file": "LICENSE"
@@ -16,7 +16,7 @@
     "ios": "8.0"
   },
   "source": {
-    "git": "https://github.com/ashfurrow/Moya.git",
+    "git": "https://github.com/Moya/Moya.git",
     "tag": "0.6"
   },
   "default_subspecs": "Core",

--- a/Specs/Moya/0.7.0/Moya.podspec.json
+++ b/Specs/Moya/0.7.0/Moya.podspec.json
@@ -3,7 +3,7 @@
   "version": "0.7.0",
   "summary": "Network abstraction layer written in Swift",
   "description": "  Moya abstracts network commands using Swift Generics to provide developers \n  with more compile-time confidence. \n\n  A ReactiveCocoa extension exists as well. Instructions for its installation\n  are in [the README](https://github.com/ashfurrow/Moya).\n",
-  "homepage": "https://github.com/AshFurrow/Moya",
+  "homepage": "https://github.com/Moya/Moya",
   "license": {
     "type": "MIT",
     "file": "LICENSE"
@@ -16,7 +16,7 @@
     "ios": "8.0"
   },
   "source": {
-    "git": "https://github.com/ashfurrow/Moya.git",
+    "git": "https://github.com/Moya/Moya.git",
     "tag": "0.7.0"
   },
   "default_subspecs": "Core",

--- a/Specs/Moya/0.7.1/Moya.podspec.json
+++ b/Specs/Moya/0.7.1/Moya.podspec.json
@@ -3,7 +3,7 @@
   "version": "0.7.1",
   "summary": "Network abstraction layer written in Swift",
   "description": "  Moya abstracts network commands using Swift Generics to provide developers \n  with more compile-time confidence. \n\n  A ReactiveCocoa extension exists as well. Instructions for its installation\n  are in [the README](https://github.com/ashfurrow/Moya).\n",
-  "homepage": "https://github.com/AshFurrow/Moya",
+  "homepage": "https://github.com/Moya/Moya",
   "license": {
     "type": "MIT",
     "file": "LICENSE"
@@ -16,7 +16,7 @@
     "ios": "8.0"
   },
   "source": {
-    "git": "https://github.com/ashfurrow/Moya.git",
+    "git": "https://github.com/Moya/Moya.git",
     "tag": "0.7.1"
   },
   "default_subspecs": "Core",

--- a/Specs/Moya/0.8.0/Moya.podspec.json
+++ b/Specs/Moya/0.8.0/Moya.podspec.json
@@ -3,7 +3,7 @@
   "version": "0.8.0",
   "summary": "Network abstraction layer written in Swift",
   "description": "  Moya abstracts network commands using Swift Generics to provide developers \n  with more compile-time confidence. \n\n  A ReactiveCocoa extension exists as well. Instructions for its installation\n  are in [the README](https://github.com/ashfurrow/Moya).\n",
-  "homepage": "https://github.com/AshFurrow/Moya",
+  "homepage": "https://github.com/Moya/Moya",
   "license": {
     "type": "MIT",
     "file": "LICENSE"
@@ -16,7 +16,7 @@
     "ios": "8.0"
   },
   "source": {
-    "git": "https://github.com/ashfurrow/Moya.git",
+    "git": "https://github.com/Moya/Moya.git",
     "tag": "0.8.0"
   },
   "default_subspecs": "Core",

--- a/Specs/Moya/1.0.0/Moya.podspec.json
+++ b/Specs/Moya/1.0.0/Moya.podspec.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "summary": "Network abstraction layer written in Swift",
   "description": "  Moya abstracts network commands using Swift Generics to provide developers \n  with more compile-time confidence. \n\n  A ReactiveCocoa extension exists as well. Instructions for its installation\n  are in [the README](https://github.com/ashfurrow/Moya).\n",
-  "homepage": "https://github.com/AshFurrow/Moya",
+  "homepage": "https://github.com/Moya/Moya",
   "license": {
     "type": "MIT",
     "file": "LICENSE"
@@ -16,7 +16,7 @@
     "ios": "8.0"
   },
   "source": {
-    "git": "https://github.com/ashfurrow/Moya.git",
+    "git": "https://github.com/Moya/Moya.git",
     "tag": "1.0.0"
   },
   "default_subspecs": "Core",

--- a/Specs/Moya/1.1.0/Moya.podspec.json
+++ b/Specs/Moya/1.1.0/Moya.podspec.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "summary": "Network abstraction layer written in Swift",
   "description": "  Moya abstracts network commands using Swift Generics to provide developers\n  with more compile-time confidence.\n\n  A ReactiveCocoa extension exists as well. Instructions for its installation\n  are in [the README](https://github.com/ashfurrow/Moya).\n",
-  "homepage": "https://github.com/AshFurrow/Moya",
+  "homepage": "https://github.com/Moya/Moya",
   "license": {
     "type": "MIT",
     "file": "LICENSE"
@@ -16,7 +16,7 @@
     "ios": "8.0"
   },
   "source": {
-    "git": "https://github.com/ashfurrow/Moya.git",
+    "git": "https://github.com/Moya/Moya.git",
     "tag": "1.1.0"
   },
   "default_subspecs": "Core",

--- a/Specs/Moya/1.1.1/Moya.podspec.json
+++ b/Specs/Moya/1.1.1/Moya.podspec.json
@@ -3,7 +3,7 @@
   "version": "1.1.1",
   "summary": "Network abstraction layer written in Swift",
   "description": "  Moya abstracts network commands using Swift Generics to provide developers\n  with more compile-time confidence.\n\n  A ReactiveCocoa extension exists as well. Instructions for its installation\n  are in [the README](https://github.com/ashfurrow/Moya).\n",
-  "homepage": "https://github.com/AshFurrow/Moya",
+  "homepage": "https://github.com/Moya/Moya",
   "license": {
     "type": "MIT",
     "file": "LICENSE"
@@ -16,7 +16,7 @@
     "ios": "8.0"
   },
   "source": {
-    "git": "https://github.com/ashfurrow/Moya.git",
+    "git": "https://github.com/Moya/Moya.git",
     "tag": "1.1.1"
   },
   "default_subspecs": "Core",

--- a/Specs/Moya/2.0.0/Moya.podspec.json
+++ b/Specs/Moya/2.0.0/Moya.podspec.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "summary": "Network abstraction layer written in Swift",
   "description": "  Moya abstracts network commands using Swift Generics to provide developers\n  with more compile-time confidence.\n\n  ReactiveCocoa and RxSwift extensions exist as well. Instructions for installation\n  are in [the README](https://github.com/ashfurrow/Moya).\n",
-  "homepage": "https://github.com/ashfurrow/Moya",
+  "homepage": "https://github.com/Moya/Moya",
   "license": {
     "type": "MIT",
     "file": "LICENSE"
@@ -16,7 +16,7 @@
     "ios": "8.0"
   },
   "source": {
-    "git": "https://github.com/ashfurrow/Moya.git",
+    "git": "https://github.com/Moya/Moya.git",
     "tag": "2.0.0"
   },
   "default_subspecs": "Core",


### PR DESCRIPTION
Maya moved to an organization; GitHub redirects will only work for a month or so, so this fixes it permanently. 
