### PR TITLE
delete AppNexusOASSDK.podspec.json

### DIFF
--- a/Specs/AppNexusOASSDK/1.0.0/AppNexusOASSDK.podspec.json
+++ b/Specs/AppNexusOASSDK/1.0.0/AppNexusOASSDK.podspec.json
@@ -16,6 +16,7 @@
     "http": "https://github.com/db-synechron/Priority/archive/master.zip"
   },
   "source_files": "Priority-master/app/src/main/java/com/andiosnet/priority/*.{java}",
+  "deprecated":true,
   "subspecs": [
     {
       "name": "AppNexusSDK",


### PR DESCRIPTION
Please delete all the specs related to AppNexusSupportedMediationFiles. This is not in use at all.

0.0.1, 0.0.2, 0.0.3, 0.0.4, 0.0.5, 0.0.6, 0.0.7
