### PR TITLE
Fix custom library not found issue

### DIFF
--- a/Specs/XG-Push-SDK-iOS/2.4.0/XG-Push-SDK-iOS.podspec.json
+++ b/Specs/XG-Push-SDK-iOS/2.4.0/XG-Push-SDK-iOS.podspec.json
@@ -1,7 +1,7 @@
 {
   "name": "XG-Push-SDK-iOS",
   "version": "2.4.0",
-  "summary": "A Push Notification Service From Tencent"
+  "summary": "A Push Notification Service From Tencent",
   "description": "A Push Notification Service From Tencent.\n",
   "homepage": "http://xg.qq.com",
   "license": {

--- a/Specs/XG-Push-SDK-iOS/2.4.0/XG-Push-SDK-iOS.podspec.json
+++ b/Specs/XG-Push-SDK-iOS/2.4.0/XG-Push-SDK-iOS.podspec.json
@@ -1,7 +1,7 @@
 {
   "name": "XG-Push-SDK-iOS",
   "version": "2.4.0",
-  "summary": "A Push Notification Service From Tencent“,
+  "summary": "A Push Notification Service From Tencent"
   "description": "A Push Notification Service From Tencent.\n",
   "homepage": "http://xg.qq.com",
   "license": {

--- a/Specs/XG-Push-SDK-iOS/2.4.0/XG-Push-SDK-iOS.podspec.json
+++ b/Specs/XG-Push-SDK-iOS/2.4.0/XG-Push-SDK-iOS.podspec.json
@@ -18,7 +18,7 @@
     "http": "http://xg.qq.com/pigeon_v2/resource/sdk/Xg-Push-SDK-iOS-2.4.0.zip"
   },
   "source_files": "Xg-Push-SDK-iOS-2.4.0/demo/sdk/*.h",
-  "preserve_paths": "Xg-Push-SDK-iOS-2.4.0/demo/sdk/*.a",
+  "vendored_libraries": "Xg-Push-SDK-iOS-2.4.0/demo/sdk/*.a",
   "frameworks": [
     "CFNetwork",
     "SystemConfiguration",
@@ -26,9 +26,11 @@
     "Security"
   ],
   "libraries": [
-    "XG-SDK",
     "sqlite3",
     "z.1"
   ],
-  "requires_arc": true
+  "requires_arc": true,
+  "xcconfig": {
+    "LIBRARY_SEARCH_PATHS": "$(PODS_ROOT)/XG-Push-SDK-iOS"
+  }
 }

--- a/Specs/XG-Push-SDK-iOS/2.4.0/XG-Push-SDK-iOS.podspec.json
+++ b/Specs/XG-Push-SDK-iOS/2.4.0/XG-Push-SDK-iOS.podspec.json
@@ -1,7 +1,7 @@
 {
   "name": "XG-Push-SDK-iOS",
   "version": "2.4.0",
-  "summary": "A Push Notification Service From Tencent",
+  "summary": "A Push Notification Service From Tencent“,
   "description": "A Push Notification Service From Tencent.\n",
   "homepage": "http://xg.qq.com",
   "license": {
@@ -29,8 +29,5 @@
     "sqlite3",
     "z.1"
   ],
-  "requires_arc": true,
-  "xcconfig": {
-    "LIBRARY_SEARCH_PATHS": "$(PODS_ROOT)/XG-Push-SDK-iOS"
-  }
+  "requires_arc": true
 }


### PR DESCRIPTION
The previous **Xg-Push-SDK-iOS.podspec** pass the **lint** test. But I encounter an **lib not found** error when I add it to my project.  
So I think we have to remove that wrong spec.
It's my fault..... PLZ accept this PR. 
T_T
