### PR TITLE
Deprecated TKAlamofire

### DIFF
--- a/Specs/TKAlamofire/1.0.2/TKAlamofire.podspec.json
+++ b/Specs/TKAlamofire/1.0.2/TKAlamofire.podspec.json
@@ -13,5 +13,6 @@
     "tag": "1.0.2"
   },
   "source_files": "TKAlamofire/*.swift",
-  "requires_arc": true
+  "requires_arc": true,
+  "deprecated_in_favor_of": "Alamofire"
 }

--- a/Specs/TKAlamofire/1.1.4/TKAlamofire.podspec.json
+++ b/Specs/TKAlamofire/1.1.4/TKAlamofire.podspec.json
@@ -17,5 +17,6 @@
     "tag": "1.1.4"
   },
   "source_files": "Source/*.swift",
-  "requires_arc": true
+  "requires_arc": true,
+  "deprecated_in_favor_of": "Alamofire"
 }


### PR DESCRIPTION
Hello CocoaPods!

I have been working with the author of TKAlamofire to remove a couple libraries that were published to CocoaPods when private specs would have been more applicable. They have already pulled down the TKAlamofire repository and are working on others. This PR adds the deprecation flag to the two TKAlamofire releases that have been published.

I will also attempt to get the @nicolastinkl (the author) to comment on this ticket with his approval if I can.

Thanks!
