### PR TITLE
deprecate FlurrySDK pod in favor of Flurry-iOS-SDK pod

### DIFF
--- a/Specs/FlurrySDK/3.0.9/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/3.0.9/FlurrySDK.podspec.json
@@ -22,6 +22,5 @@
     "LIBRARY_SEARCH_PATHS": "\"$(PODS_ROOT)/FlurrySDK/FlurryAnalytics\""
   },
   "requires_arc": false,
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/3.0.9/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/3.0.9/FlurrySDK.podspec.json
@@ -21,5 +21,7 @@
   "xcconfig": {
     "LIBRARY_SEARCH_PATHS": "\"$(PODS_ROOT)/FlurrySDK/FlurryAnalytics\""
   },
-  "requires_arc": false
+  "requires_arc": false,
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.0.1/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.0.1/FlurrySDK.podspec.json
@@ -23,6 +23,5 @@
   },
   "frameworks": "SystemConfiguration",
   "requires_arc": false,
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.0.1/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.0.1/FlurrySDK.podspec.json
@@ -22,5 +22,7 @@
     "LIBRARY_SEARCH_PATHS": "\"$(PODS_ROOT)/FlurrySDK/Flurry\""
   },
   "frameworks": "SystemConfiguration",
-  "requires_arc": false
+  "requires_arc": false,
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.0.4/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.0.4/FlurrySDK.podspec.json
@@ -23,6 +23,5 @@
   },
   "frameworks": "SystemConfiguration",
   "requires_arc": false,
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.0.4/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.0.4/FlurrySDK.podspec.json
@@ -22,5 +22,7 @@
     "LIBRARY_SEARCH_PATHS": "\"$(PODS_ROOT)/FlurrySDK/Flurry\""
   },
   "frameworks": "SystemConfiguration",
-  "requires_arc": false
+  "requires_arc": false,
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.0.5/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.0.5/FlurrySDK.podspec.json
@@ -23,6 +23,5 @@
   },
   "frameworks": "SystemConfiguration",
   "requires_arc": false,
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.0.5/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.0.5/FlurrySDK.podspec.json
@@ -22,5 +22,7 @@
     "LIBRARY_SEARCH_PATHS": "\"$(PODS_ROOT)/FlurrySDK/Flurry\""
   },
   "frameworks": "SystemConfiguration",
-  "requires_arc": false
+  "requires_arc": false,
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.1.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.1.0/FlurrySDK.podspec.json
@@ -23,6 +23,5 @@
   },
   "frameworks": "SystemConfiguration",
   "requires_arc": false,
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.1.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.1.0/FlurrySDK.podspec.json
@@ -22,5 +22,7 @@
     "LIBRARY_SEARCH_PATHS": "\"$(PODS_ROOT)/FlurrySDK/Flurry\""
   },
   "frameworks": "SystemConfiguration",
-  "requires_arc": false
+  "requires_arc": false,
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.2.1/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.2.1/FlurrySDK.podspec.json
@@ -25,5 +25,7 @@
     "SystemConfiguration",
     "UIKit"
   ],
-  "requires_arc": false
+  "requires_arc": false,
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.2.1/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.2.1/FlurrySDK.podspec.json
@@ -26,6 +26,5 @@
     "UIKit"
   ],
   "requires_arc": false,
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.2.2/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.2.2/FlurrySDK.podspec.json
@@ -29,6 +29,5 @@
     "UIKit"
   ],
   "requires_arc": false,
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.2.2/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.2.2/FlurrySDK.podspec.json
@@ -28,5 +28,7 @@
     "SystemConfiguration",
     "UIKit"
   ],
-  "requires_arc": false
+  "requires_arc": false,
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.2.3/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.2.3/FlurrySDK.podspec.json
@@ -31,6 +31,5 @@
     "CoreGraphics"
   ],
   "requires_arc": false,
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.2.3/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.2.3/FlurrySDK.podspec.json
@@ -30,5 +30,7 @@
     "Security",
     "CoreGraphics"
   ],
-  "requires_arc": false
+  "requires_arc": false,
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.2.4/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.2.4/FlurrySDK.podspec.json
@@ -31,6 +31,5 @@
     "CoreGraphics"
   ],
   "requires_arc": false,
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.2.4/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.2.4/FlurrySDK.podspec.json
@@ -30,5 +30,7 @@
     "Security",
     "CoreGraphics"
   ],
-  "requires_arc": false
+  "requires_arc": false,
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.3.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.3.0/FlurrySDK.podspec.json
@@ -31,6 +31,5 @@
     "CoreGraphics"
   ],
   "requires_arc": false,
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.3.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.3.0/FlurrySDK.podspec.json
@@ -30,5 +30,7 @@
     "Security",
     "CoreGraphics"
   ],
-  "requires_arc": false
+  "requires_arc": false,
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.3.1/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.3.1/FlurrySDK.podspec.json
@@ -31,6 +31,5 @@
     "CoreGraphics"
   ],
   "requires_arc": false,
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.3.1/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.3.1/FlurrySDK.podspec.json
@@ -30,5 +30,7 @@
     "Security",
     "CoreGraphics"
   ],
-  "requires_arc": false
+  "requires_arc": false,
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.3.2/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.3.2/FlurrySDK.podspec.json
@@ -51,6 +51,5 @@
       }
     }
   ],
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.3.2/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.3.2/FlurrySDK.podspec.json
@@ -50,5 +50,7 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.4.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.4.0/FlurrySDK.podspec.json
@@ -51,6 +51,5 @@
       }
     }
   ],
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/4.4.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.4.0/FlurrySDK.podspec.json
@@ -50,5 +50,7 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/5.0.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/5.0.0/FlurrySDK.podspec.json
@@ -61,6 +61,5 @@
       }
     }
   ],
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/5.0.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/5.0.0/FlurrySDK.podspec.json
@@ -60,5 +60,7 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/5.1.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/5.1.0/FlurrySDK.podspec.json
@@ -59,5 +59,7 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/5.1.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/5.1.0/FlurrySDK.podspec.json
@@ -60,6 +60,5 @@
       }
     }
   ],
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/5.2.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/5.2.0/FlurrySDK.podspec.json
@@ -59,5 +59,7 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/5.2.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/5.2.0/FlurrySDK.podspec.json
@@ -60,6 +60,5 @@
       }
     }
   ],
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/5.3.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/5.3.0/FlurrySDK.podspec.json
@@ -59,5 +59,7 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/5.3.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/5.3.0/FlurrySDK.podspec.json
@@ -60,6 +60,5 @@
       }
     }
   ],
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/5.4.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/5.4.0/FlurrySDK.podspec.json
@@ -49,5 +49,7 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/5.4.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/5.4.0/FlurrySDK.podspec.json
@@ -50,6 +50,5 @@
       }
     }
   ],
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/6.0.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/6.0.0/FlurrySDK.podspec.json
@@ -49,5 +49,7 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/6.0.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/6.0.0/FlurrySDK.podspec.json
@@ -50,6 +50,5 @@
       }
     }
   ],
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/6.2.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/6.2.0/FlurrySDK.podspec.json
@@ -51,5 +51,7 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/6.2.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/6.2.0/FlurrySDK.podspec.json
@@ -52,6 +52,5 @@
       }
     }
   ],
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/6.4.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/6.4.0/FlurrySDK.podspec.json
@@ -61,5 +61,7 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/6.4.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/6.4.0/FlurrySDK.podspec.json
@@ -62,6 +62,5 @@
       }
     }
   ],
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/6.5.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/6.5.0/FlurrySDK.podspec.json
@@ -61,5 +61,7 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/6.5.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/6.5.0/FlurrySDK.podspec.json
@@ -62,6 +62,5 @@
       }
     }
   ],
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/6.6.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/6.6.0/FlurrySDK.podspec.json
@@ -61,5 +61,7 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/6.6.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/6.6.0/FlurrySDK.podspec.json
@@ -62,6 +62,5 @@
       }
     }
   ],
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/6.7.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/6.7.0/FlurrySDK.podspec.json
@@ -70,5 +70,7 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/6.7.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/6.7.0/FlurrySDK.podspec.json
@@ -71,6 +71,5 @@
       }
     }
   ],
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/6.7.1-beta1/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/6.7.1-beta1/FlurrySDK.podspec.json
@@ -70,5 +70,7 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated": true,
+  "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }

--- a/Specs/FlurrySDK/6.7.1-beta1/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/6.7.1-beta1/FlurrySDK.podspec.json
@@ -71,6 +71,5 @@
       }
     }
   ],
-  "deprecated": true,
   "deprecated_in_favor_of": "Flurry-iOS-SDK"
 }


### PR DESCRIPTION
This deprecates the unofficial [FlurrySDK](https://github.com/dbgrandi/Flurry) pod in favor of the new official [Flurry-iOS-SDK](https://github.com/Flurry/Flurry-iOS-SDK).

I tested that the JSON parsed by loading/parsing it all with ruby's `JSON.load(File.read(<file>))`

I also tried to lint all the specs. **Some of the older specs did not lint.** One was missing a `LICENSE` file and a few others were using `default_subspec` instead of `default_subspecs`.
