### PR TITLE
AlamofireImage 1.0.0 podspec update

### DIFF
--- a/Specs/AlamofireImage/1.0.0/AlamofireImage.podspec.json
+++ b/Specs/AlamofireImage/1.0.0/AlamofireImage.podspec.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "Alamofire": [
-      "2.0.0"
+      "~> 2.0"
     ]
   }
 }


### PR DESCRIPTION
Updated the AlamofireImage 1.0.0 podspec to allow all Alamofire 2.x versions.
