### PR TITLE
fix audience network url

### DIFF
--- a/Specs/FBAudienceNetwork/4.6.0/FBAudienceNetwork.podspec.json
+++ b/Specs/FBAudienceNetwork/4.6.0/FBAudienceNetwork.podspec.json
@@ -13,7 +13,7 @@
     "ios": "7.0"
   },
   "source": {
-    "http": "http://developers.facebook.com/resources/FacebookSDKs-iOS-20150910.zip",
+    "http": "http://fb.me/FacebookSDKs-iOS-20150910.zip",
     "sha1": "dc1c4f2e76dafab75ec2f5e85e4f0bb508a353a9"
   },
   "public_header_files": "FBAudienceNetwork.framework/**/*.h",


### PR DESCRIPTION
Current url doesn't work, they've updated url on their website today morning.
