### PR TITLE
Deprecated AlamoImage in favor of AlamofireImage

### DIFF
--- a/Specs/AlamoImage/0.1.0/AlamoImage.podspec.json
+++ b/Specs/AlamoImage/0.1.0/AlamoImage.podspec.json
@@ -41,5 +41,6 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated_in_favor_of": "AlamofireImage"
 }

--- a/Specs/AlamoImage/0.1.1/AlamoImage.podspec.json
+++ b/Specs/AlamoImage/0.1.1/AlamoImage.podspec.json
@@ -41,5 +41,6 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated_in_favor_of": "AlamofireImage"
 }

--- a/Specs/AlamoImage/0.1.2/AlamoImage.podspec.json
+++ b/Specs/AlamoImage/0.1.2/AlamoImage.podspec.json
@@ -41,5 +41,6 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated_in_favor_of": "AlamofireImage"
 }

--- a/Specs/AlamoImage/0.1.3/AlamoImage.podspec.json
+++ b/Specs/AlamoImage/0.1.3/AlamoImage.podspec.json
@@ -41,5 +41,6 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated_in_favor_of": "AlamofireImage"
 }

--- a/Specs/AlamoImage/0.2.0/AlamoImage.podspec.json
+++ b/Specs/AlamoImage/0.2.0/AlamoImage.podspec.json
@@ -62,5 +62,6 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated_in_favor_of": "AlamofireImage"
 }

--- a/Specs/AlamoImage/0.2.1/AlamoImage.podspec.json
+++ b/Specs/AlamoImage/0.2.1/AlamoImage.podspec.json
@@ -62,5 +62,6 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated_in_favor_of": "AlamofireImage"
 }

--- a/Specs/AlamoImage/0.3.0/AlamoImage.podspec.json
+++ b/Specs/AlamoImage/0.3.0/AlamoImage.podspec.json
@@ -62,5 +62,6 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated_in_favor_of": "AlamofireImage"
 }

--- a/Specs/AlamoImage/0.3.7/AlamoImage.podspec.json
+++ b/Specs/AlamoImage/0.3.7/AlamoImage.podspec.json
@@ -62,5 +62,6 @@
         ]
       }
     }
-  ]
+  ],
+  "deprecated_in_favor_of": "AlamofireImage"
 }


### PR DESCRIPTION
I have been working with @gchiacchio to deprecate AlamoImage in favor of AlamofireImage. I'll try to get him to confirm this by commenting on this PR. The current plan is to keep the repo online and simply deprecate the pod. Eventually, the library and pod will probably be pulled down entirely. Thanks!
