### PR TITLE
[Update] libbson 1.1.11

### DIFF
--- a/Specs/libbson/1.1.11/libbson.podspec.json
+++ b/Specs/libbson/1.1.11/libbson.podspec.json
@@ -19,6 +19,7 @@
     "src/bson/*.{c,h}",
     "src/yajl/*.{c,h}"
   ],
+  "exclude_files": "src/**/*-win32.h",
   "header_mappings_dir": "src",
   "private_header_files": "src/bson/*-private.h",
   "module_name": "bson",


### PR DESCRIPTION
Omit win32 headers from framework

A couple notes about why I'm requesting this:
1. The affected header raises a compilation error when not on Windows, so no one will be adversely affected by this change.
2. I published this spec, but the library is upstream, and not under my control.
