### PR TITLE
[Add] ReactiveCocoa 4.0.3-alpha-1

### DIFF
--- a/Specs/ReactiveCocoa/4.0.3-alpha-1/ReactiveCocoa.podspec.json
+++ b/Specs/ReactiveCocoa/4.0.3-alpha-1/ReactiveCocoa.podspec.json
@@ -1,0 +1,82 @@
+{
+  "name": "ReactiveCocoa",
+  "version": "4.0.3-alpha-1",
+  "summary": "A framework for composing and transforming streams of values.",
+  "description": "ReactiveCocoa (RAC) is an Objective-C framework for Functional Reactive Programming.\nIt provides APIs for composing and transforming streams of values.",
+  "homepage": "https://github.com/ReactiveCocoa/ReactiveCocoa",
+  "license": {
+    "type": "MIT",
+    "file": "LICENSE.md"
+  },
+  "authors": {
+    "Josh Abernathy": "josh@github.com"
+  },
+  "platforms": {
+    "ios": "8.0",
+    "osx": "10.10",
+    "watchos": "2.0"
+  },
+  "source": {
+    "git": "https://github.com/ReactiveCocoa/ReactiveCocoa.git",
+    "tag": "v4.0-alpha.1"
+  },
+  "dependencies": {
+    "Result": [
+      "~> 0.6-beta.1"
+    ]
+  },
+  "default_subspecs": "UI",
+  "subspecs": [
+    {
+      "name": "no-arc",
+      "source_files": "ReactiveCocoa/Objective-C/RACObjCRuntime.{h,m}",
+      "requires_arc": false,
+      "frameworks": "Foundation"
+    },
+    {
+      "name": "Core",
+      "source_files": "ReactiveCocoa/**/*.{d,h,m,swift}",
+      "exclude_files": [
+        "ReactiveCocoa/**/*{RACObjCRuntime,AppKit,NSControl,NSText,NSTable,UIActionSheet,UIAlertView,UIBarButtonItem,UIButton,UICollectionReusableView,UIControl,UIDatePicker,UIGestureRecognizer,UIImagePicker,UIRefreshControl,UISegmentedControl,UISlider,UIStepper,UISwitch,UITableViewCell,UITableViewHeaderFooterView,UIText,MK}*"
+      ],
+      "header_dir": "ReactiveCocoa",
+      "private_header_files": [
+        "**/*Private.h",
+        "**/*EXTRuntimeExtensions.h",
+        "**/RACEmpty*.h"
+      ],
+      "frameworks": "Foundation",
+      "dependencies": {
+        "ReactiveCocoa/no-arc": [
+
+        ]
+      },
+      "watchos": {
+        "exclude_files": "**/NSURLConnection*",
+        "pod_target_xcconfig": {
+          "GCC_PREPROCESSOR_DEFINITIONS": "DTRACE_PROBES_DISABLED=1"
+        }
+      }
+    },
+    {
+      "name": "UI",
+      "dependencies": {
+        "ReactiveCocoa/Core": [
+
+        ]
+      },
+      "ios": {
+        "source_files": [
+          "ReactiveCocoa/**/*{UIActionSheet,UIAlertView,UIBarButtonItem,UIButton,UICollectionReusableView,UIControl,UIDatePicker,UIGestureRecognizer,UIImagePicker,UIRefreshControl,UISegmentedControl,UISlider,UIStepper,UISwitch,UITableViewCell,UITableViewHeaderFooterView,UIText,MK}*"
+        ],
+        "frameworks": "UIKit"
+      },
+      "osx": {
+        "source_files": [
+          "ReactiveCocoa/**/*{AppKit,NSControl,NSText,NSTable}*"
+        ],
+        "frameworks": "AppKit"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Removes `**/ReactiveCocoa.h` from `exclude_files`, forcing all platforms to include that source file. 

Excluding that file causes a build error when compiling a Swift 2.1 watch app, resulting in `<ReactiveCocoa/ReactiveCocoa.h> file not found`.
