### PR TITLE
New sqlcipher 3.3.1 podspec

### DIFF
--- a/Specs/SQLCipher/3.3.1/SQLCipher.podspec.json
+++ b/Specs/SQLCipher/3.3.1/SQLCipher.podspec.json
@@ -1,0 +1,68 @@
+{
+    "authors": "Zetetic LLC",
+    "default_subspec": "standard",
+    "description": "SQLCipher is an open source extension to SQLite that provides transparent 256-bit AES encryption of database files.",
+    "homepage": "http://sqlcipher.net",
+    "license": "BSD",
+    "name": "SQLCipher",
+    "platforms": {
+        "ios": "8.0",
+        "osx": "10.9",
+        "tvos": "9.0",
+        "watchos": "2.0"
+    },
+    "prepare_command": "./configure --enable-tempstore=yes --with-crypto-lib=commoncrypto CFLAGS=\"-DSQLITE_HAS_CODEC -DSQLITE_TEMP_STORE=2 -DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_UNLOCK_NOTIFY\"; make sqlite3.c",
+    "requires_arc": true,
+    "source": {
+        "git": "https://github.com/sqlcipher/sqlcipher.git",
+        "tag": "v3.3.1"
+    },
+    "subspecs": [
+        {
+            "compiler_flags": [
+                "-DSQLITE_HAS_CODEC",
+                "-DSQLITE_TEMP_STORE=2",
+                "-DSQLITE_THREADSAFE",
+                "-DSQLCIPHER_CRYPTO_CC"
+            ],
+            "frameworks": "Security",
+            "name": "common",
+            "source_files": "sqlite3.{h,c}",
+            "xcconfig": {
+                "GCC_PREPROCESSOR_DEFINITIONS": "$(inherited) SQLITE_HAS_CODEC=1",
+                "OTHER_CFLAGS": "$(inherited) -DSQLITE_HAS_CODEC -DSQLITE_TEMP_STORE=2 -DSQLITE_THREADSAFE -DSQLCIPHER_CRYPTO_CC"
+            }
+        },
+        {
+            "dependencies": {
+                "SQLCipher/common": []
+            },
+            "name": "standard"
+        },
+        {
+            "compiler_flags": [
+                "-DSQLITE_ENABLE_FTS4",
+                "-DSQLITE_ENABLE_FTS3_PARENTHESIS"
+            ],
+            "dependencies": {
+                "SQLCipher/common": []
+            },
+            "name": "fts",
+            "xcconfig": {
+                "OTHER_CFLAGS": "$(inherited) -DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_FTS3_PARENTHESIS"
+            }
+        },
+        {
+            "compiler_flags": "-DSQLITE_ENABLE_UNLOCK_NOTIFY",
+            "dependencies": {
+                "SQLCipher/common": []
+            },
+            "name": "unlock_notify",
+            "xcconfig": {
+                "OTHER_CFLAGS": "$(inherited) -DSQLITE_ENABLE_UNLOCK_NOTIFY"
+            }
+        }
+    ],
+    "summary": "Full Database Encryption for SQLite.",
+    "version": "3.3.1"
+}

--- a/Specs/SQLCipher/3.3.1/SQLCipher.podspec.json
+++ b/Specs/SQLCipher/3.3.1/SQLCipher.podspec.json
@@ -23,14 +23,20 @@
                 "-DSQLITE_HAS_CODEC",
                 "-DSQLITE_TEMP_STORE=2",
                 "-DSQLITE_THREADSAFE",
-                "-DSQLCIPHER_CRYPTO_CC"
+                "-DSQLCIPHER_CRYPTO_CC",
+                "-Wno-ambiguous-macro",
+                "-Wno-#warnings",
+                "-Wno-conversion",
+                "-Wno-unused-const-variable",
+                "-Wno-unused-function",
+                "-Wno-unreachable-code"
             ],
             "frameworks": "Security",
             "name": "common",
             "source_files": "sqlite3.{h,c}",
             "xcconfig": {
                 "GCC_PREPROCESSOR_DEFINITIONS": "$(inherited) SQLITE_HAS_CODEC=1",
-                "OTHER_CFLAGS": "$(inherited) -DSQLITE_HAS_CODEC -DSQLITE_TEMP_STORE=2 -DSQLITE_THREADSAFE -DSQLCIPHER_CRYPTO_CC"
+                "OTHER_CFLAGS": "$(inherited) -DSQLITE_HAS_CODEC -DSQLITE_TEMP_STORE=2 -DSQLITE_THREADSAFE -DSQLCIPHER_CRYPTO_CC -Wno-ambiguous-macro -Wno-#warnings -Wno-conversion -Wno-unused-const-variable -Wno-unused-function -Wno-unreachable-code"
             }
         },
         {


### PR DESCRIPTION
Hello!

I'm not the maintainer of `sqlcipher` so I cannot push a podspec directly using `pod trunk`. Therefore I'm just submitting it manually. I've verified that it passes `pod spec lint` using CocoaPods 0.39.0.

If there's anything else you need me to do to help get this merged, please let me know. I'll also attempt to get the sqlcipher maintainers to give this a thumbs up.

Thanks for the awesome dependency management system! 🍻
