### PR TITLE
add missing item to preserve_paths arrays

### DIFF
--- a/Specs/Crashlytics/3.4.1/Crashlytics.podspec.json
+++ b/Specs/Crashlytics/3.4.1/Crashlytics.podspec.json
@@ -25,7 +25,8 @@
     "tvos": "9.0"
   },
   "preserve_paths": [
-    "submit"
+    "submit",
+    "Crashlytics.framework/*"
   ],
   "ios": {
     "public_header_files": "iOS/Crashlytics.framework/Headers/*.h",

--- a/Specs/Fabric/1.6.1/Fabric.podspec.json
+++ b/Specs/Fabric/1.6.1/Fabric.podspec.json
@@ -13,7 +13,8 @@
   },
   "preserve_paths": [
     "uploadDSYM",
-    "run"
+    "run",
+    "Fabric.framework/*"
   ],
   "ios": {
     "public_header_files": "iOS/Fabric.framework/Headers/*.h",


### PR DESCRIPTION
This is required to maintain backwards compatibility with developers' current build chain setups.
