### PR TITLE
Migrate specs that use the singular default_subspec to the plural def…

### DIFF
--- a/Specs/ABMultiton/2.0.3/ABMultiton.podspec.json
+++ b/Specs/ABMultiton/2.0.3/ABMultiton.podspec.json
@@ -20,7 +20,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/AFNetworking/2.0.0-RC3/AFNetworking.podspec.json
+++ b/Specs/AFNetworking/2.0.0-RC3/AFNetworking.podspec.json
@@ -18,7 +18,9 @@
     "ios": "6.0",
     "osx": "10.8"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/AGAsyncTestHelper/1.0/AGAsyncTestHelper.podspec.json
+++ b/Specs/AGAsyncTestHelper/1.0/AGAsyncTestHelper.podspec.json
@@ -14,7 +14,9 @@
     "git": "https://github.com/hfossli/AGAsyncTestHelper.git",
     "tag": "1.0"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/AGGeometryKit+POP/0.1/AGGeometryKit+POP.podspec.json
+++ b/Specs/AGGeometryKit+POP/0.1/AGGeometryKit+POP.podspec.json
@@ -15,7 +15,9 @@
     "git": "https://github.com/hfossli/AGGeometryKit-POP.git",
     "tag": "0.1"
   },
-  "default_subspec": "Default",
+  "default_subspecs": [
+    "Default"
+  ],
   "subspecs": [
     {
       "name": "Default",

--- a/Specs/AGGeometryKit/0.1.8.6/AGGeometryKit.podspec.json
+++ b/Specs/AGGeometryKit/0.1.8.6/AGGeometryKit.podspec.json
@@ -22,7 +22,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Default",
+  "default_subspecs": [
+    "Default"
+  ],
   "subspecs": [
     {
       "name": "Default",

--- a/Specs/AGGeometryKit/1.0.1/AGGeometryKit.podspec.json
+++ b/Specs/AGGeometryKit/1.0.1/AGGeometryKit.podspec.json
@@ -16,7 +16,9 @@
     "git": "https://github.com/hfossli/AGGeometryKit.git",
     "tag": "1.0.1"
   },
-  "default_subspec": "Default",
+  "default_subspecs": [
+    "Default"
+  ],
   "subspecs": [
     {
       "name": "Default",

--- a/Specs/AGGeometryKit/1.0/AGGeometryKit.podspec.json
+++ b/Specs/AGGeometryKit/1.0/AGGeometryKit.podspec.json
@@ -16,7 +16,9 @@
     "git": "https://github.com/hfossli/AGGeometryKit.git",
     "tag": "1.0"
   },
-  "default_subspec": "Default",
+  "default_subspecs": [
+    "Default"
+  ],
   "subspecs": [
     {
       "name": "Default",

--- a/Specs/AGImageChecker/1.0.1/AGImageChecker.podspec.json
+++ b/Specs/AGImageChecker/1.0.1/AGImageChecker.podspec.json
@@ -13,7 +13,9 @@
     "tag": "1.0.1"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/ARAnalytics/2.0.1/ARAnalytics.podspec.json
+++ b/Specs/ARAnalytics/2.0.1/ARAnalytics.podspec.json
@@ -18,7 +18,9 @@
     "ios": "5.0"
   },
   "description": "ARAnalytics is a Cocoapods only library, which provides a sane API for tracking events and some simple user data. It currently supports for iOS: TestFlight, Mixpanel, Localytics, Flurry, Google Analytics, KISSMetrics, Tapstream, Countly, Crittercism, Bugsnag, Helpshift and Crashlytics. And for OS X: KISSmetrics, Countly and Mixpanel. It does this by using subspecs from CocoaPods 0.17+ to let you decide which libraries you'd like to use.",
-  "default_subspec": "no_clash_HockeyApp",
+  "default_subspecs": [
+    "no_clash_HockeyApp"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/ARAnalytics/2.0.2/ARAnalytics.podspec.json
+++ b/Specs/ARAnalytics/2.0.2/ARAnalytics.podspec.json
@@ -18,7 +18,9 @@
     "ios": "5.0"
   },
   "description": "ARAnalytics is a Cocoapods only library, which provides a sane API for tracking events and some simple user data. It currently supports for iOS: TestFlight, Mixpanel, Localytics, Flurry, Google Analytics, KISSMetrics, Tapstream, Countly, Crittercism, Bugsnag, Helpshift and Crashlytics. And for OS X: KISSmetrics, Countly and Mixpanel. It does this by using subspecs from CocoaPods 0.17+ to let you decide which libraries you'd like to use.",
-  "default_subspec": "no_clash_HockeyApp",
+  "default_subspecs": [
+    "no_clash_HockeyApp"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/ARAnalytics/2.0/ARAnalytics.podspec.json
+++ b/Specs/ARAnalytics/2.0/ARAnalytics.podspec.json
@@ -18,7 +18,9 @@
     "ios": "5.0"
   },
   "description": "ARAnalytics is a Cocoapods only library, which provides a sane API for tracking events and some simple user data. It currently supports for iOS: TestFlight, Mixpanel, Localytics, Flurry, Google Analytics, KISSMetrics, Tapstream, Countly, Crittercism, Bugsnag, Helpshift and Crashlytics. And for OS X: KISSmetrics, Countly and Mixpanel. It does this by using subspecs from CocoaPods 0.17+ to let you decide which libraries you'd like to use.",
-  "default_subspec": "no_clash_HockeyApp",
+  "default_subspecs": [
+    "no_clash_HockeyApp"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/ARAnalytics/2.1.1/ARAnalytics.podspec.json
+++ b/Specs/ARAnalytics/2.1.1/ARAnalytics.podspec.json
@@ -19,7 +19,9 @@
   },
   "requires_arc": true,
   "description": "ARAnalytics is a Cocoapods only library, which provides a sane API for tracking events and some simple user data. It currently supports for iOS: TestFlight, Mixpanel, Localytics, Flurry, Google Analytics, KISSMetrics, Tapstream, Countly, Crittercism, Bugsnag, Helpshift and Crashlytics. And for OS X: KISSmetrics, Countly and Mixpanel.",
-  "default_subspec": "no_clash_HockeyApp",
+  "default_subspecs": [
+    "no_clash_HockeyApp"
+  ],
   "subspecs": [
     {
       "name": "CoreMac",

--- a/Specs/ARAnalytics/2.3.0/ARAnalytics.podspec.json
+++ b/Specs/ARAnalytics/2.3.0/ARAnalytics.podspec.json
@@ -19,7 +19,9 @@
   },
   "requires_arc": true,
   "description": "ARAnalytics is a Cocoapods only library, which provides a sane API for tracking events and some simple user data. It currently supports for iOS: TestFlight, Mixpanel, Localytics, Flurry, Google Analytics, KISSMetrics, Tapstream, Countly, Crittercism, Bugsnag, Helpshift, Heap and Crashlytics. And for OS X: KISSmetrics, Countly and Mixpanel. It does this by using subspecs from CocoaPods 0.17+ to let you decide which libraries you'd like to use.",
-  "default_subspec": "no_clash_HockeyApp",
+  "default_subspecs": [
+    "no_clash_HockeyApp"
+  ],
   "subspecs": [
     {
       "name": "CoreMac",

--- a/Specs/ARAnalytics/2.3.1/ARAnalytics.podspec.json
+++ b/Specs/ARAnalytics/2.3.1/ARAnalytics.podspec.json
@@ -19,7 +19,9 @@
   },
   "requires_arc": true,
   "description": "ARAnalytics is a Cocoapods only library, which provides a sane API for tracking events and some simple user data. It currently supports for iOS: TestFlight, Mixpanel, Localytics, Flurry, Google Analytics, KISSMetrics, Tapstream, Countly, Crittercism, Bugsnag, Helpshift, Heap and Crashlytics. And for OS X: KISSmetrics, Countly and Mixpanel. It does this by using subspecs from CocoaPods 0.17+ to let you decide which libraries you'd like to use.",
-  "default_subspec": "no_clash_HockeyApp",
+  "default_subspecs": [
+    "no_clash_HockeyApp"
+  ],
   "subspecs": [
     {
       "name": "CoreMac",

--- a/Specs/ARAnalytics/2.3.2/ARAnalytics.podspec.json
+++ b/Specs/ARAnalytics/2.3.2/ARAnalytics.podspec.json
@@ -19,7 +19,9 @@
   },
   "requires_arc": true,
   "description": "ARAnalytics is a Cocoapods only library, which provides a sane API for tracking events and some simple user data. It currently supports for iOS: TestFlight, Mixpanel, Localytics, Flurry, Google Analytics, KISSMetrics, Tapstream, Countly, Crittercism, Bugsnag, NewRelic, Amplitude, ParseAnalytics, HockeyApp, Helpshift, Heap and Crashlytics. And for OS X: KISSmetrics and Mixpanel. It does this by using subspecs from CocoaPods 0.17+ to let you decide which libraries you'd like to use.",
-  "default_subspec": "no_clash_HockeyApp",
+  "default_subspecs": [
+    "no_clash_HockeyApp"
+  ],
   "subspecs": [
     {
       "name": "CoreMac",

--- a/Specs/ARAnalytics/2.3.3/ARAnalytics.podspec.json
+++ b/Specs/ARAnalytics/2.3.3/ARAnalytics.podspec.json
@@ -19,7 +19,9 @@
   },
   "requires_arc": true,
   "description": "ARAnalytics is a Cocoapods only library, which provides a sane API for tracking events and some simple user data. It currently supports for iOS: TestFlight, Mixpanel, Localytics, Flurry, Google Analytics, KISSMetrics, Tapstream, Countly, Crittercism, Bugsnag, Helpshift, Heap and Crashlytics. And for OS X: KISSmetrics, Countly and Mixpanel. It does this by using subspecs from CocoaPods 0.17+ to let you decide which libraries you'd like to use.",
-  "default_subspec": "no_clash_HockeyApp",
+  "default_subspecs": [
+    "no_clash_HockeyApp"
+  ],
   "subspecs": [
     {
       "name": "CoreMac",

--- a/Specs/ARAnalytics/2.4.0/ARAnalytics.podspec.json
+++ b/Specs/ARAnalytics/2.4.0/ARAnalytics.podspec.json
@@ -20,7 +20,9 @@
   },
   "requires_arc": true,
   "description": "ARAnalytics is a Cocoapods only library, which provides a sane API for tracking events and some simple user data. It currently supports for iOS: TestFlight, Mixpanel, Localytics, Flurry, Google Analytics, KISSMetrics, Tapstream, Countly, Crittercism, Bugsnag, Helpshift, Chartbeat, Heap and Crashlytics. And for OS X: KISSmetrics, Countly and Mixpanel. It does this by using subspecs from CocoaPods 0.17+ to let you decide which libraries you'd like to use.",
-  "default_subspec": "no_clash_HockeyApp",
+  "default_subspecs": [
+    "no_clash_HockeyApp"
+  ],
   "subspecs": [
     {
       "name": "CoreMac",

--- a/Specs/ARAnalytics/2.4.3/ARAnalytics.podspec.json
+++ b/Specs/ARAnalytics/2.4.3/ARAnalytics.podspec.json
@@ -19,7 +19,9 @@
   },
   "requires_arc": true,
   "description": "ARAnalytics is a Cocoapods only library, which provides a sane API for tracking events and some simple user data. It currently supports for iOS: TestFlight, Mixpanel, Localytics, Flurry, Google Analytics, KISSMetrics, Tapstream, Countly, Crittercism, Bugsnag, Helpshift, Chartbeat, Heap and Crashlytics. And for OS X: KISSmetrics, Countly and Mixpanel. It does this by using subspecs from CocoaPods 0.17+ to let you decide which libraries you'd like to use.",
-  "default_subspec": "no_clash_HockeyApp",
+  "default_subspecs": [
+    "no_clash_HockeyApp"
+  ],
   "subspecs": [
     {
       "name": "CoreMac",

--- a/Specs/ARAnalytics/2.5.0/ARAnalytics.podspec.json
+++ b/Specs/ARAnalytics/2.5.0/ARAnalytics.podspec.json
@@ -19,7 +19,9 @@
   },
   "requires_arc": true,
   "description": "ARAnalytics is a Cocoapods only library, which provides a sane API for tracking events and some simple user data. It currently supports for iOS: TestFlight, Mixpanel, Localytics, Flurry, Google Analytics, KISSMetrics, Tapstream, Countly, Crittercism, Bugsnag, Helpshift, Chartbeat, Heap and Crashlytics. And for OS X: KISSmetrics, Countly and Mixpanel. It does this by using subspecs from CocoaPods 0.17+ to let you decide which libraries you'd like to use.",
-  "default_subspec": "no_clash_HockeyApp",
+  "default_subspecs": [
+    "no_clash_HockeyApp"
+  ],
   "subspecs": [
     {
       "name": "CoreMac",

--- a/Specs/ARAnalytics/2.6.0/ARAnalytics.podspec.json
+++ b/Specs/ARAnalytics/2.6.0/ARAnalytics.podspec.json
@@ -21,7 +21,9 @@
   },
   "social_media_url": "https://twitter.com/orta",
   "requires_arc": true,
-  "default_subspec": "no_clash_HockeyApp",
+  "default_subspecs": [
+    "no_clash_HockeyApp"
+  ],
   "description": "ARAnalytics is a analytics abstraction library offering a sane API for tracking events and user data. It currently supports on iOS: TestFlight, Mixpanel, Localytics, Flurry, GoogleAnalytics, KISSmetrics, Crittercism, Crashlytics, Bugsnag, Countly, Helpshift, Tapstream, NewRelic, Amplitude, HockeyApp, ParseAnalytics, HeapAnalytics and Chartbeat. And for OS X: KISSmetrics and Mixpanel. It does this by using CocoaPods subspecs to let you decide which libraries you'd like to use. You are free to also use the official API for any provider too. Also, comes with an amazing DSL to clear up your methods.",
   "subspecs": [
     {

--- a/Specs/ARAnalytics/2.7.1/ARAnalytics.podspec.json
+++ b/Specs/ARAnalytics/2.7.1/ARAnalytics.podspec.json
@@ -21,7 +21,9 @@
   },
   "social_media_url": "https://twitter.com/orta",
   "requires_arc": true,
-  "default_subspec": "no_clash_HockeyApp",
+  "default_subspecs": [
+    "no_clash_HockeyApp"
+  ],
   "description": "ARAnalytics is a analytics abstraction library offering a sane API for tracking events and user data. It currently supports on iOS: TestFlight, Mixpanel, Localytics, Flurry, GoogleAnalytics, KISSmetrics, Crittercism, Crashlytics, Bugsnag, Countly, Helpshift, Tapstream, NewRelic, Amplitude, HockeyApp, ParseAnalytics, HeapAnalytics, Chartbeat and UMengAnalytics. And for OS X: KISSmetrics and Mixpanel. It does this by using CocoaPods subspecs to let you decide which libraries you'd like to use. You are free to also use the official API for any provider too. Also, comes with an amazing DSL to clear up your methods.",
   "subspecs": [
     {

--- a/Specs/ATMHud@dhoerl/3.0.0/ATMHud@dhoerl.podspec.json
+++ b/Specs/ATMHud@dhoerl/3.0.0/ATMHud@dhoerl.podspec.json
@@ -25,7 +25,9 @@
     "https://github.com/dhoerl/ScreenShots/Caption+ProgressBar.png",
     "https://github.com/dhoerl/ScreenShots/Caption+ProgressBar_FixedSize"
   ],
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "description": "ATMHud offers a versatile and full featured HUD for yuour iOS projects. You can use either a traditional protocol based delegate or a block based one. A Demo app shows how to use most of the feature set and both delegates. You can set any of a caption, two types of progress indicators, and an image to the HUD, which resizes as needed. You can control where the progress indicator goes (top/bot/left/right), the view grayness and cover view's grayness/opacity. If you're showing the HUD with the keyboard up (for example), you can move the HUD's center.\n\nUsage:\n    // Keep a strong ivar reference to it (ie, \"ATMHud *hud\")\n\thud = [ATMHud new]; // using the block delegate\n\t[hud setCaption:@\"Caption and an activity indicator.\"];\n\t[hud setActivity:YES];\n\thud.blockDelegate = ....; // see demo project\n\t[hud showInView:self.view];\n\t...\n\t[hud hide];\n\t//the block delegate can release the hud and nil the ivar (see Demo app)\n\n",
   "subspecs": [
     {

--- a/Specs/AppCoreKit/2.3.0/AppCoreKit.podspec.json
+++ b/Specs/AppCoreKit/2.3.0/AppCoreKit.podspec.json
@@ -18,7 +18,9 @@
     "ios": "5.0"
   },
   "description": "AppCoreKit is an application framework designed to improve productivity while creating Apps for iOS. This is the result of a 3 years experience at Wherecloud and is a production framework that shipped more than 20 apps. AppCoreKit does not offer out of the box UI components but the technology to help you: Manage your data, Automatic serialization (KeyValue Store, Core Data), Objective-C runtime apis, Type and data structure conversions, View controllers and containers, Ui vs. Models synchronization with bindings, Appearance customization with cascading stylesheets, Responsive view layouts with a hbox/vbox model, Non homogenous Forms, Maps, Network, And more. Keep in mind that AppCoreKit is a toolbox. It is non intrusive so that you can cherry pick features and learn how to use it at your own pace. Screen Cast and high level description of the framework are available at http://www.appcorekit.net. A sample repository with binary versions of the framework is available at https://github.com/wherecloud/appcorekit-samples",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "frameworks": [
     "UIKit",
     "Foundation",

--- a/Specs/AppCoreKit/2.3.1/AppCoreKit.podspec.json
+++ b/Specs/AppCoreKit/2.3.1/AppCoreKit.podspec.json
@@ -18,7 +18,9 @@
     "ios": "5.0"
   },
   "description": "AppCoreKit is an application framework designed to improve productivity while creating Apps for iOS. This is the result of a 3 years experience at Wherecloud and is a production framework that shipped more than 20 apps. AppCoreKit does not offer out of the box UI components but the technology to help you: Manage your data, Automatic serialization (KeyValue Store, Core Data), Objective-C runtime apis, Type and data structure conversions, View controllers and containers, Ui vs. Models synchronization with bindings, Appearance customization with cascading stylesheets, Responsive view layouts with a hbox/vbox model, Non homogenous Forms, Maps, Network, And more. Keep in mind that AppCoreKit is a toolbox. It is non intrusive so that you can cherry pick features and learn how to use it at your own pace. Screen Cast and high level description of the framework are available at http://www.appcorekit.net. A sample repository with binary versions of the framework is available at https://github.com/wherecloud/appcorekit-samples",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "frameworks": [
     "UIKit",
     "Foundation",

--- a/Specs/AppCoreKit/2.3.2/AppCoreKit.podspec.json
+++ b/Specs/AppCoreKit/2.3.2/AppCoreKit.podspec.json
@@ -18,7 +18,9 @@
     "ios": "5.0"
   },
   "description": "AppCoreKit is an application framework designed to improve productivity while creating Apps for iOS. This is the result of a 3 years experience at Wherecloud and is a production framework that shipped more than 20 apps. AppCoreKit does not offer out of the box UI components but the technology to help you: Manage your data, Automatic serialization (KeyValue Store, Core Data), Objective-C runtime apis, Type and data structure conversions, View controllers and containers, Ui vs. Models synchronization with bindings, Appearance customization with cascading stylesheets, Responsive view layouts with a hbox/vbox model, Non homogenous Forms, Maps, Network, And more. Keep in mind that AppCoreKit is a toolbox. It is non intrusive so that you can cherry pick features and learn how to use it at your own pace. Screen Cast and high level description of the framework are available at http://www.appcorekit.net. A sample repository with binary versions of the framework is available at https://github.com/wherecloud/appcorekit-samples",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "frameworks": [
     "UIKit",
     "Foundation",

--- a/Specs/AppCoreKit/2.4.0/AppCoreKit.podspec.json
+++ b/Specs/AppCoreKit/2.4.0/AppCoreKit.podspec.json
@@ -18,7 +18,9 @@
     "ios": "5.0"
   },
   "description": "AppCoreKit is an application framework designed to improve productivity while creating Apps for iOS. This is the result of a 3 years experience at Wherecloud and is a production framework that shipped more than 20 apps. AppCoreKit does not offer out of the box UI components but the technology to help you: Manage your data, Automatic serialization (KeyValue Store, Core Data), Objective-C runtime apis, Type and data structure conversions, View controllers and containers, Ui vs. Models synchronization with bindings, Appearance customization with cascading stylesheets, Responsive view layouts with a hbox/vbox model, Non homogenous Forms, Maps, Network, And more. Keep in mind that AppCoreKit is a toolbox. It is non intrusive so that you can cherry pick features and learn how to use it at your own pace. Screen Cast and high level description of the framework are available at http://www.appcorekit.net. A sample repository with binary versions of the framework is available at https://github.com/wherecloud/appcorekit-samples",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "frameworks": [
     "UIKit",
     "Foundation",

--- a/Specs/BPForms/1.1.0/BPForms.podspec.json
+++ b/Specs/BPForms/1.1.0/BPForms.podspec.json
@@ -20,7 +20,9 @@
     "ios": "6.0"
   },
   "preserve_paths": "README*",
-  "default_subspec": "FloatLabel",
+  "default_subspecs": [
+    "FloatLabel"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/BPForms/2.0.0/BPForms.podspec.json
+++ b/Specs/BPForms/2.0.0/BPForms.podspec.json
@@ -20,7 +20,9 @@
     "ios": "6.0"
   },
   "preserve_paths": "README*",
-  "default_subspec": "FloatLabel",
+  "default_subspecs": [
+    "FloatLabel"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/BZObjectStore/1.0.5/BZObjectStore.podspec.json
+++ b/Specs/BZObjectStore/1.0.5/BZObjectStore.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/BZObjectStore/1.0.6/BZObjectStore.podspec.json
+++ b/Specs/BZObjectStore/1.0.6/BZObjectStore.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/BZObjectStore/1.0.7/BZObjectStore.podspec.json
+++ b/Specs/BZObjectStore/1.0.7/BZObjectStore.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/BZObjectStore/1.0.8/BZObjectStore.podspec.json
+++ b/Specs/BZObjectStore/1.0.8/BZObjectStore.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/BZObjectStore/1.0.9/BZObjectStore.podspec.json
+++ b/Specs/BZObjectStore/1.0.9/BZObjectStore.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/BeamMusicPlayerViewController/0.1.0/BeamMusicPlayerViewController.podspec.json
+++ b/Specs/BeamMusicPlayerViewController/0.1.0/BeamMusicPlayerViewController.podspec.json
@@ -28,7 +28,9 @@
       "~> 1.1"
     ]
   },
-  "default_subspec": "MediaPlayer",
+  "default_subspecs": [
+    "MediaPlayer"
+  ],
   "subspecs": [
     {
       "name": "MediaPlayer",

--- a/Specs/BeamMusicPlayerViewController/0.2.0/BeamMusicPlayerViewController.podspec.json
+++ b/Specs/BeamMusicPlayerViewController/0.2.0/BeamMusicPlayerViewController.podspec.json
@@ -31,7 +31,9 @@
       "~> 1.1"
     ]
   },
-  "default_subspec": "MediaPlayer",
+  "default_subspecs": [
+    "MediaPlayer"
+  ],
   "subspecs": [
     {
       "name": "MediaPlayer",

--- a/Specs/BeamMusicPlayerViewController/0.2.1/BeamMusicPlayerViewController.podspec.json
+++ b/Specs/BeamMusicPlayerViewController/0.2.1/BeamMusicPlayerViewController.podspec.json
@@ -31,7 +31,9 @@
       "~> 1.1"
     ]
   },
-  "default_subspec": "MediaPlayer",
+  "default_subspecs": [
+    "MediaPlayer"
+  ],
   "subspecs": [
     {
       "name": "MediaPlayer",

--- a/Specs/BlocksKit/2.0.0/BlocksKit.podspec.json
+++ b/Specs/BlocksKit/2.0.0/BlocksKit.podspec.json
@@ -17,7 +17,9 @@
     "osx": "10.7",
     "ios": "5.0"
   },
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "All",

--- a/Specs/BlocksKit/2.2.0/BlocksKit.podspec.json
+++ b/Specs/BlocksKit/2.2.0/BlocksKit.podspec.json
@@ -17,7 +17,9 @@
     "osx": "10.8",
     "ios": "6.0"
   },
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "All",

--- a/Specs/BlocksKit/2.2.2/BlocksKit.podspec.json
+++ b/Specs/BlocksKit/2.2.2/BlocksKit.podspec.json
@@ -17,7 +17,9 @@
     "osx": "10.8",
     "ios": "6.0"
   },
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "All",

--- a/Specs/BlocksKit/2.2.3/BlocksKit.podspec.json
+++ b/Specs/BlocksKit/2.2.3/BlocksKit.podspec.json
@@ -17,7 +17,9 @@
     "osx": "10.8",
     "ios": "6.0"
   },
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "All",

--- a/Specs/BotKit/0.1.10/BotKit.podspec.json
+++ b/Specs/BotKit/0.1.10/BotKit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Categories",
+  "default_subspecs": [
+    "Categories"
+  ],
   "subspecs": [
     {
       "name": "Categories",

--- a/Specs/BotKit/0.1.7/BotKit.podspec.json
+++ b/Specs/BotKit/0.1.7/BotKit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Categories",
+  "default_subspecs": [
+    "Categories"
+  ],
   "subspecs": [
     {
       "name": "Categories",

--- a/Specs/BotKit/0.1.8/BotKit.podspec.json
+++ b/Specs/BotKit/0.1.8/BotKit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Categories",
+  "default_subspecs": [
+    "Categories"
+  ],
   "subspecs": [
     {
       "name": "Categories",

--- a/Specs/BotKit/0.1.9/BotKit.podspec.json
+++ b/Specs/BotKit/0.1.9/BotKit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Categories",
+  "default_subspecs": [
+    "Categories"
+  ],
   "subspecs": [
     {
       "name": "Categories",

--- a/Specs/Brightcove-Player-SDK-IMA/1.0.7/Brightcove-Player-SDK-IMA.podspec.json
+++ b/Specs/Brightcove-Player-SDK-IMA/1.0.7/Brightcove-Player-SDK-IMA.podspec.json
@@ -23,7 +23,9 @@
       "~> 4.1"
     ]
   },
-  "default_subspec": "Default",
+  "default_subspecs": [
+    "Default"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/BrynKit/1.1.0/BrynKit.podspec.json
+++ b/Specs/BrynKit/1.1.0/BrynKit.podspec.json
@@ -23,7 +23,9 @@
       ">= 0.2.0"
     ]
   },
-  "default_subspec": "Main",
+  "default_subspecs": [
+    "Main"
+  ],
   "subspecs": [
     {
       "name": "Main",

--- a/Specs/BrynKit/1.2.1/BrynKit.podspec.json
+++ b/Specs/BrynKit/1.2.1/BrynKit.podspec.json
@@ -23,7 +23,9 @@
       ">= 0.2.5"
     ]
   },
-  "default_subspec": "Main",
+  "default_subspecs": [
+    "Main"
+  ],
   "subspecs": [
     {
       "name": "Main",

--- a/Specs/BrynKit/1.2.3/BrynKit.podspec.json
+++ b/Specs/BrynKit/1.2.3/BrynKit.podspec.json
@@ -23,7 +23,9 @@
       ">= 0.2.5"
     ]
   },
-  "default_subspec": "Main",
+  "default_subspecs": [
+    "Main"
+  ],
   "subspecs": [
     {
       "name": "Main",

--- a/Specs/BrynKit/1.2.4/BrynKit.podspec.json
+++ b/Specs/BrynKit/1.2.4/BrynKit.podspec.json
@@ -27,7 +27,9 @@
 
     ]
   },
-  "default_subspec": "Main",
+  "default_subspecs": [
+    "Main"
+  ],
   "subspecs": [
     {
       "name": "Main",

--- a/Specs/BrynKit/1.2.5/BrynKit.podspec.json
+++ b/Specs/BrynKit/1.2.5/BrynKit.podspec.json
@@ -27,7 +27,9 @@
 
     ]
   },
-  "default_subspec": "Main",
+  "default_subspecs": [
+    "Main"
+  ],
   "subspecs": [
     {
       "name": "Main",

--- a/Specs/BrynKit/1.2.6/BrynKit.podspec.json
+++ b/Specs/BrynKit/1.2.6/BrynKit.podspec.json
@@ -27,7 +27,9 @@
 
     ]
   },
-  "default_subspec": "Main",
+  "default_subspecs": [
+    "Main"
+  ],
   "subspecs": [
     {
       "name": "Main",

--- a/Specs/BrynKit/1.3.0/BrynKit.podspec.json
+++ b/Specs/BrynKit/1.3.0/BrynKit.podspec.json
@@ -23,7 +23,9 @@
   "xcconfig": {
     "CLANG_ENABLE_MODULES": "YES"
   },
-  "default_subspec": "Main",
+  "default_subspecs": [
+    "Main"
+  ],
   "frameworks": [
     "CoreVideo",
     "CoreGraphics"

--- a/Specs/BrynKit/1.3.1/BrynKit.podspec.json
+++ b/Specs/BrynKit/1.3.1/BrynKit.podspec.json
@@ -23,7 +23,9 @@
   "xcconfig": {
     "CLANG_ENABLE_MODULES": "YES"
   },
-  "default_subspec": "Main",
+  "default_subspecs": [
+    "Main"
+  ],
   "frameworks": [
     "CoreVideo",
     "CoreGraphics"

--- a/Specs/CJKit/0.10.0/CJKit.podspec.json
+++ b/Specs/CJKit/0.10.0/CJKit.podspec.json
@@ -17,7 +17,9 @@
     "git": "https://github.com/clubjudge/objc-sdk.git",
     "tag": "0.10.0"
   },
-  "default_subspec": "base",
+  "default_subspecs": [
+    "base"
+  ],
   "public_header_files": "CJAPIClient/**/*.h",
   "frameworks": "CoreLocation",
   "requires_arc": true,

--- a/Specs/CJKit/0.10.1/CJKit.podspec.json
+++ b/Specs/CJKit/0.10.1/CJKit.podspec.json
@@ -17,7 +17,9 @@
     "git": "https://github.com/clubjudge/objc-sdk.git",
     "tag": "0.10.1"
   },
-  "default_subspec": "base",
+  "default_subspecs": [
+    "base"
+  ],
   "public_header_files": "CJAPIClient/**/*.h",
   "frameworks": "CoreLocation",
   "requires_arc": true,

--- a/Specs/CJKit/0.2.0/CJKit.podspec.json
+++ b/Specs/CJKit/0.2.0/CJKit.podspec.json
@@ -17,7 +17,9 @@
     "git": "https://github.com/clubjudge/objc-sdk.git",
     "tag": "0.2.0"
   },
-  "default_subspec": "base",
+  "default_subspecs": [
+    "base"
+  ],
   "public_header_files": "CJAPIClient/**/*.h",
   "frameworks": "CoreLocation",
   "requires_arc": true,

--- a/Specs/CJKit/0.3.0/CJKit.podspec.json
+++ b/Specs/CJKit/0.3.0/CJKit.podspec.json
@@ -17,7 +17,9 @@
     "git": "https://github.com/clubjudge/objc-sdk.git",
     "tag": "0.3.0"
   },
-  "default_subspec": "base",
+  "default_subspecs": [
+    "base"
+  ],
   "public_header_files": "CJAPIClient/**/*.h",
   "frameworks": "CoreLocation",
   "requires_arc": true,

--- a/Specs/CJKit/0.3.1/CJKit.podspec.json
+++ b/Specs/CJKit/0.3.1/CJKit.podspec.json
@@ -17,7 +17,9 @@
     "git": "https://github.com/clubjudge/objc-sdk.git",
     "tag": "0.3.1"
   },
-  "default_subspec": "base",
+  "default_subspecs": [
+    "base"
+  ],
   "public_header_files": "CJAPIClient/**/*.h",
   "frameworks": "CoreLocation",
   "requires_arc": true,

--- a/Specs/CJKit/0.3.7/CJKit.podspec.json
+++ b/Specs/CJKit/0.3.7/CJKit.podspec.json
@@ -17,7 +17,9 @@
     "git": "https://github.com/clubjudge/objc-sdk.git",
     "tag": "0.3.7"
   },
-  "default_subspec": "base",
+  "default_subspecs": [
+    "base"
+  ],
   "public_header_files": "CJAPIClient/**/*.h",
   "frameworks": "CoreLocation",
   "requires_arc": true,

--- a/Specs/CJKit/0.4.0/CJKit.podspec.json
+++ b/Specs/CJKit/0.4.0/CJKit.podspec.json
@@ -17,7 +17,9 @@
     "git": "https://github.com/clubjudge/objc-sdk.git",
     "tag": "0.4.0"
   },
-  "default_subspec": "base",
+  "default_subspecs": [
+    "base"
+  ],
   "public_header_files": "CJAPIClient/**/*.h",
   "frameworks": "CoreLocation",
   "requires_arc": true,

--- a/Specs/CJKit/0.6.0/CJKit.podspec.json
+++ b/Specs/CJKit/0.6.0/CJKit.podspec.json
@@ -17,7 +17,9 @@
     "git": "https://github.com/clubjudge/objc-sdk.git",
     "tag": "0.6.0"
   },
-  "default_subspec": "base",
+  "default_subspecs": [
+    "base"
+  ],
   "public_header_files": "CJAPIClient/**/*.h",
   "frameworks": "CoreLocation",
   "requires_arc": true,

--- a/Specs/CJKit/0.6.1/CJKit.podspec.json
+++ b/Specs/CJKit/0.6.1/CJKit.podspec.json
@@ -17,7 +17,9 @@
     "git": "https://github.com/clubjudge/objc-sdk.git",
     "tag": "0.6.1"
   },
-  "default_subspec": "base",
+  "default_subspecs": [
+    "base"
+  ],
   "public_header_files": "CJAPIClient/**/*.h",
   "frameworks": "CoreLocation",
   "requires_arc": true,

--- a/Specs/CJKit/0.6.2/CJKit.podspec.json
+++ b/Specs/CJKit/0.6.2/CJKit.podspec.json
@@ -17,7 +17,9 @@
     "git": "https://github.com/clubjudge/objc-sdk.git",
     "tag": "0.6.2"
   },
-  "default_subspec": "base",
+  "default_subspecs": [
+    "base"
+  ],
   "public_header_files": "CJAPIClient/**/*.h",
   "frameworks": "CoreLocation",
   "requires_arc": true,

--- a/Specs/CJKit/0.6.3/CJKit.podspec.json
+++ b/Specs/CJKit/0.6.3/CJKit.podspec.json
@@ -17,7 +17,9 @@
     "git": "https://github.com/clubjudge/objc-sdk.git",
     "tag": "0.6.3"
   },
-  "default_subspec": "base",
+  "default_subspecs": [
+    "base"
+  ],
   "public_header_files": "CJAPIClient/**/*.h",
   "frameworks": "CoreLocation",
   "requires_arc": true,

--- a/Specs/CJKit/0.7.0/CJKit.podspec.json
+++ b/Specs/CJKit/0.7.0/CJKit.podspec.json
@@ -17,7 +17,9 @@
     "git": "https://github.com/clubjudge/objc-sdk.git",
     "tag": "0.7.0"
   },
-  "default_subspec": "base",
+  "default_subspecs": [
+    "base"
+  ],
   "public_header_files": "CJAPIClient/**/*.h",
   "frameworks": "CoreLocation",
   "requires_arc": true,

--- a/Specs/CJKit/0.8.0/CJKit.podspec.json
+++ b/Specs/CJKit/0.8.0/CJKit.podspec.json
@@ -17,7 +17,9 @@
     "git": "https://github.com/clubjudge/objc-sdk.git",
     "tag": "0.8.0"
   },
-  "default_subspec": "base",
+  "default_subspecs": [
+    "base"
+  ],
   "public_header_files": "CJAPIClient/**/*.h",
   "frameworks": "CoreLocation",
   "requires_arc": true,

--- a/Specs/CJKit/0.9.0/CJKit.podspec.json
+++ b/Specs/CJKit/0.9.0/CJKit.podspec.json
@@ -17,7 +17,9 @@
     "git": "https://github.com/clubjudge/objc-sdk.git",
     "tag": "0.9.0"
   },
-  "default_subspec": "base",
+  "default_subspecs": [
+    "base"
+  ],
   "public_header_files": "CJAPIClient/**/*.h",
   "frameworks": "CoreLocation",
   "requires_arc": true,

--- a/Specs/CLImageEditor/0.0.3/CLImageEditor.podspec.json
+++ b/Specs/CLImageEditor/0.0.3/CLImageEditor.podspec.json
@@ -24,7 +24,9 @@
     "Accelerate"
   ],
   "header_mappings_dir": "CLImageEditor",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/CLImageEditor/0.0.4/CLImageEditor.podspec.json
+++ b/Specs/CLImageEditor/0.0.4/CLImageEditor.podspec.json
@@ -24,7 +24,9 @@
     "Accelerate"
   ],
   "header_mappings_dir": "CLImageEditor",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/CLImageEditor/0.0.5/CLImageEditor.podspec.json
+++ b/Specs/CLImageEditor/0.0.5/CLImageEditor.podspec.json
@@ -24,7 +24,9 @@
     "Accelerate"
   ],
   "header_mappings_dir": "CLImageEditor",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/CLImageEditor/0.0.6/CLImageEditor.podspec.json
+++ b/Specs/CLImageEditor/0.0.6/CLImageEditor.podspec.json
@@ -24,7 +24,9 @@
     "Accelerate"
   ],
   "header_mappings_dir": "CLImageEditor",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/CLImageEditor/0.0.7/CLImageEditor.podspec.json
+++ b/Specs/CLImageEditor/0.0.7/CLImageEditor.podspec.json
@@ -24,7 +24,9 @@
     "Accelerate"
   ],
   "header_mappings_dir": "CLImageEditor",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/CLImageEditor/0.0.8/CLImageEditor.podspec.json
+++ b/Specs/CLImageEditor/0.0.8/CLImageEditor.podspec.json
@@ -24,7 +24,9 @@
     "Accelerate"
   ],
   "header_mappings_dir": "CLImageEditor",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/CLImageEditor/0.0.9/CLImageEditor.podspec.json
+++ b/Specs/CLImageEditor/0.0.9/CLImageEditor.podspec.json
@@ -24,7 +24,9 @@
     "Accelerate"
   ],
   "header_mappings_dir": "CLImageEditor",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/CocoaFFmpeg/2.2.0/CocoaFFmpeg.podspec.json
+++ b/Specs/CocoaFFmpeg/2.2.0/CocoaFFmpeg.podspec.json
@@ -19,7 +19,9 @@
     "ios": null
   },
   "requires_arc": false,
-  "default_subspec": "precompiled",
+  "default_subspecs": [
+    "precompiled"
+  ],
   "subspecs": [
     {
       "name": "precompiled",

--- a/Specs/CocoaLumberjack/1.8.0/CocoaLumberjack.podspec.json
+++ b/Specs/CocoaLumberjack/1.8.0/CocoaLumberjack.podspec.json
@@ -15,7 +15,9 @@
   "requires_arc": true,
   "preserve_paths": "Lumberjack/**/README*",
   "public_header_files": "Lumberjack/**/*.h",
-  "default_subspec": "Extensions",
+  "default_subspecs": [
+    "Extensions"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/CocoaLumberjack/1.8.1/CocoaLumberjack.podspec.json
+++ b/Specs/CocoaLumberjack/1.8.1/CocoaLumberjack.podspec.json
@@ -15,7 +15,9 @@
   "requires_arc": true,
   "preserve_paths": "Lumberjack/**/README*",
   "public_header_files": "Lumberjack/**/*.h",
-  "default_subspec": "Extensions",
+  "default_subspecs": [
+    "Extensions"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/Cordova/3.1.0/Cordova.podspec.json
+++ b/Specs/Cordova/3.1.0/Cordova.podspec.json
@@ -19,7 +19,9 @@
     "MobileCoreServices",
     "AssetsLibrary"
   ],
-  "default_subspec": "Base",
+  "default_subspecs": [
+    "Base"
+  ],
   "subspecs": [
     {
       "name": "Base",

--- a/Specs/Cordova/3.2.0/Cordova.podspec.json
+++ b/Specs/Cordova/3.2.0/Cordova.podspec.json
@@ -19,7 +19,9 @@
     "MobileCoreServices",
     "AssetsLibrary"
   ],
-  "default_subspec": "Base",
+  "default_subspecs": [
+    "Base"
+  ],
   "subspecs": [
     {
       "name": "Base",

--- a/Specs/Cordova/3.3.0/Cordova.podspec.json
+++ b/Specs/Cordova/3.3.0/Cordova.podspec.json
@@ -19,7 +19,9 @@
     "MobileCoreServices",
     "AssetsLibrary"
   ],
-  "default_subspec": "Base",
+  "default_subspecs": [
+    "Base"
+  ],
   "subspecs": [
     {
       "name": "Base",

--- a/Specs/Cordova/3.4.0/Cordova.podspec.json
+++ b/Specs/Cordova/3.4.0/Cordova.podspec.json
@@ -19,7 +19,9 @@
     "MobileCoreServices",
     "AssetsLibrary"
   ],
-  "default_subspec": "Base",
+  "default_subspecs": [
+    "Base"
+  ],
   "subspecs": [
     {
       "name": "Base",

--- a/Specs/DKNavbarBackButton/0.1.0/DKNavbarBackButton.podspec.json
+++ b/Specs/DKNavbarBackButton/0.1.0/DKNavbarBackButton.podspec.json
@@ -17,7 +17,9 @@
   "platforms": {
     "ios": "7.0"
   },
-  "default_subspec": "core",
+  "default_subspecs": [
+    "core"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/DKNavbarBackButton/0.1.1/DKNavbarBackButton.podspec.json
+++ b/Specs/DKNavbarBackButton/0.1.1/DKNavbarBackButton.podspec.json
@@ -17,7 +17,9 @@
   "platforms": {
     "ios": "7.0"
   },
-  "default_subspec": "core",
+  "default_subspecs": [
+    "core"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/DKNavbarBackButton/0.1.2/DKNavbarBackButton.podspec.json
+++ b/Specs/DKNavbarBackButton/0.1.2/DKNavbarBackButton.podspec.json
@@ -17,7 +17,9 @@
   "platforms": {
     "ios": "7.0"
   },
-  "default_subspec": "core",
+  "default_subspecs": [
+    "core"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/DKNavbarBackButton/0.1.3/DKNavbarBackButton.podspec.json
+++ b/Specs/DKNavbarBackButton/0.1.3/DKNavbarBackButton.podspec.json
@@ -17,7 +17,9 @@
   "platforms": {
     "ios": "7.0"
   },
-  "default_subspec": "core",
+  "default_subspecs": [
+    "core"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/DKNavbarBackButton/0.1.4/DKNavbarBackButton.podspec.json
+++ b/Specs/DKNavbarBackButton/0.1.4/DKNavbarBackButton.podspec.json
@@ -18,7 +18,9 @@
     "ios": "7.0"
   },
   "requires_arc": true,
-  "default_subspec": "core",
+  "default_subspecs": [
+    "core"
+  ],
   "subspecs": [
     {
       "name": "core",

--- a/Specs/DTModelStorage/0.1.0/DTModelStorage.podspec.json
+++ b/Specs/DTModelStorage/0.1.0/DTModelStorage.podspec.json
@@ -22,7 +22,9 @@
     ]
   },
   "source_files": "DTModelStorage/DTModelStorage.h",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/DTModelStorage/0.2.0/DTModelStorage.podspec.json
+++ b/Specs/DTModelStorage/0.2.0/DTModelStorage.podspec.json
@@ -22,7 +22,9 @@
     ]
   },
   "source_files": "DTModelStorage/DTModelStorage.h",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/DTModelStorage/0.3.0/DTModelStorage.podspec.json
+++ b/Specs/DTModelStorage/0.3.0/DTModelStorage.podspec.json
@@ -22,7 +22,9 @@
     ]
   },
   "source_files": "DTModelStorage/DTModelStorage.h",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/DTModelStorage/0.3.1/DTModelStorage.podspec.json
+++ b/Specs/DTModelStorage/0.3.1/DTModelStorage.podspec.json
@@ -22,7 +22,9 @@
     ]
   },
   "source_files": "DTModelStorage/DTModelStorage.h",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/DTModelStorage/0.4.0/DTModelStorage.podspec.json
+++ b/Specs/DTModelStorage/0.4.0/DTModelStorage.podspec.json
@@ -22,7 +22,9 @@
     ]
   },
   "source_files": "DTModelStorage/DTModelStorage.h",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/DTModelStorage/0.4.1/DTModelStorage.podspec.json
+++ b/Specs/DTModelStorage/0.4.1/DTModelStorage.podspec.json
@@ -22,7 +22,9 @@
     ]
   },
   "source_files": "DTModelStorage/DTModelStorage.h",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/DTModelStorage/0.5.0/DTModelStorage.podspec.json
+++ b/Specs/DTModelStorage/0.5.0/DTModelStorage.podspec.json
@@ -22,7 +22,9 @@
     ]
   },
   "source_files": "DTModelStorage/DTModelStorage.h",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/DTModelStorage/0.5.1/DTModelStorage.podspec.json
+++ b/Specs/DTModelStorage/0.5.1/DTModelStorage.podspec.json
@@ -22,7 +22,9 @@
     ]
   },
   "source_files": "DTModelStorage/DTModelStorage.h",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/DTModelStorage/0.6.0/DTModelStorage.podspec.json
+++ b/Specs/DTModelStorage/0.6.0/DTModelStorage.podspec.json
@@ -22,7 +22,9 @@
     ]
   },
   "source_files": "DTModelStorage/DTModelStorage.h",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/DZNCategories/1.1/DZNCategories.podspec.json
+++ b/Specs/DZNCategories/1.1/DZNCategories.podspec.json
@@ -18,7 +18,9 @@
     "ios": "7.0"
   },
   "requires_arc": true,
-  "default_subspec": "Foundation",
+  "default_subspecs": [
+    "Foundation"
+  ],
   "header_mappings_dir": "Source",
   "subspecs": [
     {

--- a/Specs/DrawReport/0.1/DrawReport.podspec.json
+++ b/Specs/DrawReport/0.1/DrawReport.podspec.json
@@ -17,7 +17,9 @@
   "requires_arc": true,
   "public_header_files": "DrawReport/*.h",
   "source_files": "DrawReport/DRPDrawReport.h",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/Ejecta/1.2/Ejecta.podspec.json
+++ b/Specs/Ejecta/1.2/Ejecta.podspec.json
@@ -15,7 +15,9 @@
   },
   "source_files": "Classes/**/*.{h,m,mm}",
   "resources": "ejecta.js",
-  "default_subspec": "Library",
+  "default_subspecs": [
+    "Library"
+  ],
   "frameworks": [
     "SystemConfiguration",
     "CoreText",

--- a/Specs/Ensembles/0.2.0/Ensembles.podspec.json
+++ b/Specs/Ensembles/0.2.0/Ensembles.podspec.json
@@ -21,7 +21,9 @@
     "submodules": true
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/Ensembles/0.3.0/Ensembles.podspec.json
+++ b/Specs/Ensembles/0.3.0/Ensembles.podspec.json
@@ -21,7 +21,9 @@
     "submodules": true
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/Ensembles/0.4.0/Ensembles.podspec.json
+++ b/Specs/Ensembles/0.4.0/Ensembles.podspec.json
@@ -21,7 +21,9 @@
     "submodules": true
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/Ensembles/1.0.1/Ensembles.podspec.json
+++ b/Specs/Ensembles/1.0.1/Ensembles.podspec.json
@@ -21,7 +21,9 @@
     "submodules": true
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/Ensembles/1.0/Ensembles.podspec.json
+++ b/Specs/Ensembles/1.0/Ensembles.podspec.json
@@ -21,7 +21,9 @@
     "submodules": true
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/Ensembles/1.1/Ensembles.podspec.json
+++ b/Specs/Ensembles/1.1/Ensembles.podspec.json
@@ -21,7 +21,9 @@
     "submodules": true
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/EnumeratorKit/0.1.1/EnumeratorKit.podspec.json
+++ b/Specs/EnumeratorKit/0.1.1/EnumeratorKit.podspec.json
@@ -17,7 +17,9 @@
     "tag": "0.1.1"
   },
   "source_files": "EnumeratorKit/EnumeratorKit.h",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/EnumeratorKit/0.1/EnumeratorKit.podspec.json
+++ b/Specs/EnumeratorKit/0.1/EnumeratorKit.podspec.json
@@ -17,7 +17,9 @@
     "tag": "0.1"
   },
   "source_files": "EnumeratorKit/EnumeratorKit.h",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/ErnKit/0.0.10/ErnKit.podspec.json
+++ b/Specs/ErnKit/0.0.10/ErnKit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/ErnKit/0.0.7/ErnKit.podspec.json
+++ b/Specs/ErnKit/0.0.7/ErnKit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/ErnKit/0.0.8/ErnKit.podspec.json
+++ b/Specs/ErnKit/0.0.8/ErnKit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/ErnKit/0.0.9/ErnKit.podspec.json
+++ b/Specs/ErnKit/0.0.9/ErnKit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/ErrorKit/0.0.1/ErrorKit.podspec.json
+++ b/Specs/ErrorKit/0.0.1/ErrorKit.podspec.json
@@ -17,7 +17,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/ErrorKit/0.0.2/ErrorKit.podspec.json
+++ b/Specs/ErrorKit/0.0.2/ErrorKit.podspec.json
@@ -17,7 +17,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/ErrorKit/0.0.3/ErrorKit.podspec.json
+++ b/Specs/ErrorKit/0.0.3/ErrorKit.podspec.json
@@ -17,7 +17,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/ErrorKit/0.0.4/ErrorKit.podspec.json
+++ b/Specs/ErrorKit/0.0.4/ErrorKit.podspec.json
@@ -17,7 +17,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/ErrorKit/0.0.5/ErrorKit.podspec.json
+++ b/Specs/ErrorKit/0.0.5/ErrorKit.podspec.json
@@ -17,7 +17,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/ErrorKit/0.0.6/ErrorKit.podspec.json
+++ b/Specs/ErrorKit/0.0.6/ErrorKit.podspec.json
@@ -17,7 +17,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/ErrorKit/0.1.0/ErrorKit.podspec.json
+++ b/Specs/ErrorKit/0.1.0/ErrorKit.podspec.json
@@ -18,7 +18,9 @@
   },
   "requires_arc": true,
   "prefix_header_contents": "#define ERROR_KIT 1",
-  "default_subspec": "Default",
+  "default_subspecs": [
+    "Default"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/ErrorKit/0.1.1/ErrorKit.podspec.json
+++ b/Specs/ErrorKit/0.1.1/ErrorKit.podspec.json
@@ -18,7 +18,9 @@
   },
   "requires_arc": true,
   "prefix_header_contents": "#define ERROR_KIT 1",
-  "default_subspec": "Default",
+  "default_subspecs": [
+    "Default"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/FFmpeg/2.2/FFmpeg.podspec.json
+++ b/Specs/FFmpeg/2.2/FFmpeg.podspec.json
@@ -19,7 +19,9 @@
     "tag": "2.2",
     "submodules": true
   },
-  "default_subspec": "precompiled",
+  "default_subspecs": [
+    "precompiled"
+  ],
   "subspecs": [
     {
       "name": "precompiled",

--- a/Specs/FMDB/2.0/FMDB.podspec.json
+++ b/Specs/FMDB/2.0/FMDB.podspec.json
@@ -11,7 +11,9 @@
     "git": "https://github.com/ccgus/fmdb.git",
     "tag": "v2.0"
   },
-  "default_subspec": "standard",
+  "default_subspecs": [
+    "standard"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/FMDB/2.1/FMDB.podspec.json
+++ b/Specs/FMDB/2.1/FMDB.podspec.json
@@ -11,7 +11,9 @@
     "git": "https://github.com/ccgus/fmdb.git",
     "tag": "v2.1"
   },
-  "default_subspec": "standard",
+  "default_subspecs": [
+    "standard"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/FMDB/2.2/FMDB.podspec.json
+++ b/Specs/FMDB/2.2/FMDB.podspec.json
@@ -11,7 +11,9 @@
     "git": "https://github.com/ccgus/fmdb.git",
     "tag": "2.2-pod"
   },
-  "default_subspec": "standard",
+  "default_subspecs": [
+    "standard"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/FMDB/2.3/FMDB.podspec.json
+++ b/Specs/FMDB/2.3/FMDB.podspec.json
@@ -11,7 +11,9 @@
     "git": "https://github.com/ccgus/fmdb.git",
     "tag": "v2.3"
   },
-  "default_subspec": "standard",
+  "default_subspecs": [
+    "standard"
+  ],
   "requires_arc": true,
   "subspecs": [
     {

--- a/Specs/FSClassExtensions/1.1.1/FSClassExtensions.podspec.json
+++ b/Specs/FSClassExtensions/1.1.1/FSClassExtensions.podspec.json
@@ -15,7 +15,9 @@
     "git": "https://github.com/FocalShift/FSClassExtensions.git",
     "tag": "1.1.1"
   },
-  "default_subspec": "Shared",
+  "default_subspecs": [
+    "Shared"
+  ],
   "platforms": {
     "ios": "6.1"
   },

--- a/Specs/FSClassExtensions/1.2.0/FSClassExtensions.podspec.json
+++ b/Specs/FSClassExtensions/1.2.0/FSClassExtensions.podspec.json
@@ -15,7 +15,9 @@
     "git": "https://github.com/FocalShift/FSClassExtensions.git",
     "tag": "1.2.0"
   },
-  "default_subspec": "Shared",
+  "default_subspecs": [
+    "Shared"
+  ],
   "platforms": {
     "ios": "6.1"
   },

--- a/Specs/FSClassExtensions/1.4.0/FSClassExtensions.podspec.json
+++ b/Specs/FSClassExtensions/1.4.0/FSClassExtensions.podspec.json
@@ -14,7 +14,9 @@
     "git": "https://github.com/FocalShift/FSClassExtensions.git",
     "tag": "1.4.0"
   },
-  "default_subspec": "Shared",
+  "default_subspecs": [
+    "Shared"
+  ],
   "platforms": {
     "ios": "6.1"
   },

--- a/Specs/FSClassExtensions/1.4.1/FSClassExtensions.podspec.json
+++ b/Specs/FSClassExtensions/1.4.1/FSClassExtensions.podspec.json
@@ -14,7 +14,9 @@
     "git": "https://github.com/FocalShift/FSClassExtensions.git",
     "tag": "1.4.1"
   },
-  "default_subspec": "Shared",
+  "default_subspecs": [
+    "Shared"
+  ],
   "platforms": {
     "ios": "6.1"
   },

--- a/Specs/FSClassExtensions/1.5.0/FSClassExtensions.podspec.json
+++ b/Specs/FSClassExtensions/1.5.0/FSClassExtensions.podspec.json
@@ -14,7 +14,9 @@
     "git": "https://github.com/FocalShift/FSClassExtensions.git",
     "tag": "1.5.0"
   },
-  "default_subspec": "Shared",
+  "default_subspecs": [
+    "Shared"
+  ],
   "platforms": {
     "ios": "6.1"
   },

--- a/Specs/FSClassExtensions/1.6.0/FSClassExtensions.podspec.json
+++ b/Specs/FSClassExtensions/1.6.0/FSClassExtensions.podspec.json
@@ -14,7 +14,9 @@
     "git": "https://github.com/FocalShift/FSClassExtensions.git",
     "tag": "1.6.0"
   },
-  "default_subspec": "Shared",
+  "default_subspecs": [
+    "Shared"
+  ],
   "platforms": {
     "ios": "6.1"
   },

--- a/Specs/FlurrySDK/4.3.2/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.3.2/FlurrySDK.podspec.json
@@ -24,7 +24,9 @@
     "Security",
     "CoreGraphics"
   ],
-  "default_subspec": "FlurrySDK",
+  "default_subspecs": [
+    "FlurrySDK"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/FlurrySDK/4.4.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/4.4.0/FlurrySDK.podspec.json
@@ -24,7 +24,9 @@
     "Security",
     "CoreGraphics"
   ],
-  "default_subspec": "FlurrySDK",
+  "default_subspecs": [
+    "FlurrySDK"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/FlurrySDK/5.0.0/FlurrySDK.podspec.json
+++ b/Specs/FlurrySDK/5.0.0/FlurrySDK.podspec.json
@@ -18,7 +18,9 @@
   "platforms": {
     "ios": null
   },
-  "default_subspec": "FlurrySDK",
+  "default_subspecs": [
+    "FlurrySDK"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Foursquare-iOS-API/1.1.3/Foursquare-iOS-API.podspec.json
+++ b/Specs/Foursquare-iOS-API/1.1.3/Foursquare-iOS-API.podspec.json
@@ -9,7 +9,9 @@
     "git": "https://github.com/baztokyo/foursquare-ios-api.git",
     "tag": "1.1.3"
   },
-  "default_subspec": "Core+SBJson",
+  "default_subspecs": [
+    "Core+SBJson"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Foursquare-iOS-API/1.1.4/Foursquare-iOS-API.podspec.json
+++ b/Specs/Foursquare-iOS-API/1.1.4/Foursquare-iOS-API.podspec.json
@@ -9,7 +9,9 @@
     "git": "https://github.com/baztokyo/foursquare-ios-api.git",
     "tag": "1.1.4"
   },
-  "default_subspec": "Core+SBJson",
+  "default_subspecs": [
+    "Core+SBJson"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Foursquare-iOS-API/1.1.5/Foursquare-iOS-API.podspec.json
+++ b/Specs/Foursquare-iOS-API/1.1.5/Foursquare-iOS-API.podspec.json
@@ -12,7 +12,9 @@
   "platforms": {
     "ios": null
   },
-  "default_subspec": "Core+SBJson",
+  "default_subspecs": [
+    "Core+SBJson"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Foursquare-iOS-API/1.1.6/Foursquare-iOS-API.podspec.json
+++ b/Specs/Foursquare-iOS-API/1.1.6/Foursquare-iOS-API.podspec.json
@@ -12,7 +12,9 @@
   "platforms": {
     "ios": null
   },
-  "default_subspec": "Core+SBJson",
+  "default_subspecs": [
+    "Core+SBJson"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/GCDObjects/0.0.1/GCDObjects.podspec.json
+++ b/Specs/GCDObjects/0.0.1/GCDObjects.podspec.json
@@ -23,7 +23,9 @@
   "xcconfig": {
     "CLANG_ENABLE_MODULES": "YES"
   },
-  "default_subspec": "Main",
+  "default_subspecs": [
+    "Main"
+  ],
   "subspecs": [
     {
       "name": "Main",

--- a/Specs/GCDObjects/0.0.2/GCDObjects.podspec.json
+++ b/Specs/GCDObjects/0.0.2/GCDObjects.podspec.json
@@ -23,7 +23,9 @@
   "xcconfig": {
     "CLANG_ENABLE_MODULES": "YES"
   },
-  "default_subspec": "Main",
+  "default_subspecs": [
+    "Main"
+  ],
   "subspecs": [
     {
       "name": "Main",

--- a/Specs/GCDWebServer/2.0.1/GCDWebServer.podspec.json
+++ b/Specs/GCDWebServer/2.0.1/GCDWebServer.podspec.json
@@ -19,7 +19,9 @@
     "osx": "10.7"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/GCDWebServer/2.0/GCDWebServer.podspec.json
+++ b/Specs/GCDWebServer/2.0/GCDWebServer.podspec.json
@@ -19,7 +19,9 @@
     "osx": "10.7"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/GCDWebServer/2.1.1/GCDWebServer.podspec.json
+++ b/Specs/GCDWebServer/2.1.1/GCDWebServer.podspec.json
@@ -19,7 +19,9 @@
     "osx": "10.7"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/GCDWebServer/2.2/GCDWebServer.podspec.json
+++ b/Specs/GCDWebServer/2.2/GCDWebServer.podspec.json
@@ -19,7 +19,9 @@
     "osx": "10.7"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/GCDWebServer/2.3.1/GCDWebServer.podspec.json
+++ b/Specs/GCDWebServer/2.3.1/GCDWebServer.podspec.json
@@ -19,7 +19,9 @@
     "osx": "10.7"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/GCDWebServer/2.3.2/GCDWebServer.podspec.json
+++ b/Specs/GCDWebServer/2.3.2/GCDWebServer.podspec.json
@@ -19,7 +19,9 @@
     "osx": "10.7"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/GCDWebServer/2.3/GCDWebServer.podspec.json
+++ b/Specs/GCDWebServer/2.3/GCDWebServer.podspec.json
@@ -19,7 +19,9 @@
     "osx": "10.7"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/GCDWebServer/2.4/GCDWebServer.podspec.json
+++ b/Specs/GCDWebServer/2.4/GCDWebServer.podspec.json
@@ -19,7 +19,9 @@
     "osx": "10.7"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/GDRealtime/0.0.1/GDRealtime.podspec.json
+++ b/Specs/GDRealtime/0.0.1/GDRealtime.podspec.json
@@ -14,7 +14,9 @@
     "git": "https://github.com/goodow/GDRealtime.git",
     "tag": "v0.0.1"
   },
-  "default_subspec": "default",
+  "default_subspecs": [
+    "default"
+  ],
   "header_mappings_dir": "Classes/generated/include",
   "requires_arc": true,
   "subspecs": [

--- a/Specs/GDRealtime/0.3.0/GDRealtime.podspec.json
+++ b/Specs/GDRealtime/0.3.0/GDRealtime.podspec.json
@@ -19,7 +19,9 @@
     "osx": "10.8"
   },
   "requires_arc": true,
-  "default_subspec": "default",
+  "default_subspecs": [
+    "default"
+  ],
   "header_mappings_dir": "Classes/generated/include",
   "subspecs": [
     {

--- a/Specs/Google-API-Client/0.0.3/Google-API-Client.podspec.json
+++ b/Specs/Google-API-Client/0.0.3/Google-API-Client.podspec.json
@@ -31,7 +31,9 @@
 
     ]
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/HTPressableButton/1.1.1/HTPressableButton.podspec.json
+++ b/Specs/HTPressableButton/1.1.1/HTPressableButton.podspec.json
@@ -20,7 +20,9 @@
     "tag": "1.1.1"
   },
   "requires_arc": true,
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "All",

--- a/Specs/HTPressableButton/1.2.0/HTPressableButton.podspec.json
+++ b/Specs/HTPressableButton/1.2.0/HTPressableButton.podspec.json
@@ -20,7 +20,9 @@
     "tag": "1.2.0"
   },
   "requires_arc": true,
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "All",

--- a/Specs/IGHTMLQuery/0.6.0/IGHTMLQuery.podspec.json
+++ b/Specs/IGHTMLQuery/0.6.0/IGHTMLQuery.podspec.json
@@ -20,7 +20,9 @@
   "xcconfig": {
     "HEADER_SEARCH_PATHS": "$(SDKROOT)/usr/include/libxml2"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/IGHTMLQuery/0.6.1/IGHTMLQuery.podspec.json
+++ b/Specs/IGHTMLQuery/0.6.1/IGHTMLQuery.podspec.json
@@ -20,7 +20,9 @@
   "xcconfig": {
     "HEADER_SEARCH_PATHS": "$(SDKROOT)/usr/include/libxml2"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/IGHTMLQuery/0.6.2/IGHTMLQuery.podspec.json
+++ b/Specs/IGHTMLQuery/0.6.2/IGHTMLQuery.podspec.json
@@ -20,7 +20,9 @@
   "xcconfig": {
     "HEADER_SEARCH_PATHS": "$(SDKROOT)/usr/include/libxml2"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/IGHTMLQuery/0.6.3/IGHTMLQuery.podspec.json
+++ b/Specs/IGHTMLQuery/0.6.3/IGHTMLQuery.podspec.json
@@ -20,7 +20,9 @@
   "xcconfig": {
     "HEADER_SEARCH_PATHS": "$(SDKROOT)/usr/include/libxml2"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "7.0",
     "osx": "10.9"

--- a/Specs/IGHTMLQuery/0.6.4/IGHTMLQuery.podspec.json
+++ b/Specs/IGHTMLQuery/0.6.4/IGHTMLQuery.podspec.json
@@ -20,7 +20,9 @@
   "xcconfig": {
     "HEADER_SEARCH_PATHS": "$(SDKROOT)/usr/include/libxml2"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "7.0",
     "osx": "10.9"

--- a/Specs/IGHTMLQuery/0.6.5/IGHTMLQuery.podspec.json
+++ b/Specs/IGHTMLQuery/0.6.5/IGHTMLQuery.podspec.json
@@ -20,7 +20,9 @@
   "xcconfig": {
     "HEADER_SEARCH_PATHS": "$(SDKROOT)/usr/include/libxml2"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "7.0",
     "osx": "10.9"

--- a/Specs/IGHTMLQuery/0.6.6/IGHTMLQuery.podspec.json
+++ b/Specs/IGHTMLQuery/0.6.6/IGHTMLQuery.podspec.json
@@ -20,7 +20,9 @@
   "xcconfig": {
     "HEADER_SEARCH_PATHS": "$(SDKROOT)/usr/include/libxml2"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "7.0",
     "osx": "10.9"

--- a/Specs/IGHTMLQuery/0.7.0/IGHTMLQuery.podspec.json
+++ b/Specs/IGHTMLQuery/0.7.0/IGHTMLQuery.podspec.json
@@ -20,7 +20,9 @@
   "xcconfig": {
     "HEADER_SEARCH_PATHS": "$(SDKROOT)/usr/include/libxml2"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "7.0",
     "osx": "10.9"

--- a/Specs/IGHTMLQuery/0.7.1/IGHTMLQuery.podspec.json
+++ b/Specs/IGHTMLQuery/0.7.1/IGHTMLQuery.podspec.json
@@ -20,7 +20,9 @@
   "xcconfig": {
     "HEADER_SEARCH_PATHS": "$(SDKROOT)/usr/include/libxml2"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "7.0",
     "osx": "10.9"

--- a/Specs/IGHTMLQuery/0.7.2/IGHTMLQuery.podspec.json
+++ b/Specs/IGHTMLQuery/0.7.2/IGHTMLQuery.podspec.json
@@ -20,7 +20,9 @@
   "xcconfig": {
     "HEADER_SEARCH_PATHS": "$(SDKROOT)/usr/include/libxml2"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "7.0",
     "osx": "10.9"

--- a/Specs/IGHTMLQuery/0.8.0/IGHTMLQuery.podspec.json
+++ b/Specs/IGHTMLQuery/0.8.0/IGHTMLQuery.podspec.json
@@ -20,7 +20,9 @@
   "xcconfig": {
     "HEADER_SEARCH_PATHS": "$(SDKROOT)/usr/include/libxml2"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "7.0",
     "osx": "10.9"

--- a/Specs/IGHTMLQuery/0.8.1/IGHTMLQuery.podspec.json
+++ b/Specs/IGHTMLQuery/0.8.1/IGHTMLQuery.podspec.json
@@ -20,7 +20,9 @@
   "xcconfig": {
     "HEADER_SEARCH_PATHS": "$(SDKROOT)/usr/include/libxml2"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "7.0",
     "osx": "10.9"

--- a/Specs/IGScraperKit/0.3.0/IGScraperKit.podspec.json
+++ b/Specs/IGScraperKit/0.3.0/IGScraperKit.podspec.json
@@ -15,7 +15,9 @@
     "git": "https://github.com/siuying/IGScraperKit.git",
     "tag": "0.3.0"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "7.0",
     "osx": "10.9"

--- a/Specs/IGScraperKit/0.3.1/IGScraperKit.podspec.json
+++ b/Specs/IGScraperKit/0.3.1/IGScraperKit.podspec.json
@@ -15,7 +15,9 @@
     "git": "https://github.com/siuying/IGScraperKit.git",
     "tag": "0.3.1"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "7.0",
     "osx": "10.9"

--- a/Specs/IGScraperKit/0.3.2/IGScraperKit.podspec.json
+++ b/Specs/IGScraperKit/0.3.2/IGScraperKit.podspec.json
@@ -15,7 +15,9 @@
     "git": "https://github.com/siuying/IGScraperKit.git",
     "tag": "0.3.2"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "7.0",
     "osx": "10.9"

--- a/Specs/InneractiveAdSDK/2.0.1/InneractiveAdSDK.podspec.json
+++ b/Specs/InneractiveAdSDK/2.0.1/InneractiveAdSDK.podspec.json
@@ -16,7 +16,9 @@
   "source": {
     "http": "http://inneractive-assets.s3.amazonaws.com/sdk/files/inneractiveAdSDK-iOS-v2.0.1.zip"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "prepare_command": "    mv inneractiveAdSDK/armv7-7s/InneractiveAdSDK.a inneractiveAdSDK/armv7-7s/libInneractiveAdSDK.a\n    mv inneractiveIAdAdapter/armv7-7s/InneractiveIAdAdapter.a inneractiveIAdAdapter/armv7-7s/libInneractiveIAdAdapter.a\n",
   "requires_arc": false,
   "subspecs": [

--- a/Specs/J2ObjC/0.8.6.1/J2ObjC.podspec.json
+++ b/Specs/J2ObjC/0.8.6.1/J2ObjC.podspec.json
@@ -17,7 +17,9 @@
     "osx": "10.8"
   },
   "requires_arc": false,
-  "default_subspec": "lib/jre",
+  "default_subspecs": [
+    "lib/jre"
+  ],
   "header_mappings_dir": "dist/include",
   "subspecs": [
     {

--- a/Specs/J2ObjC/0.8.8/J2ObjC.podspec.json
+++ b/Specs/J2ObjC/0.8.8/J2ObjC.podspec.json
@@ -13,7 +13,9 @@
     "tag": "v0.8.8-lib"
   },
   "requires_arc": false,
-  "default_subspec": "lib/jre",
+  "default_subspecs": [
+    "lib/jre"
+  ],
   "header_mappings_dir": "dist/include",
   "prepare_command": "    scripts/download_distribution.sh\n",
   "subspecs": [

--- a/Specs/J2ObjC/0.9/J2ObjC.podspec.json
+++ b/Specs/J2ObjC/0.9/J2ObjC.podspec.json
@@ -13,7 +13,9 @@
     "tag": "v0.9-lib"
   },
   "requires_arc": false,
-  "default_subspec": "lib/jre",
+  "default_subspecs": [
+    "lib/jre"
+  ],
   "header_mappings_dir": "dist/include",
   "prepare_command": "    scripts/download_distribution.sh\n",
   "subspecs": [

--- a/Specs/KHGravatar/1.0.0/KHGravatar.podspec.json
+++ b/Specs/KHGravatar/1.0.0/KHGravatar.podspec.json
@@ -15,7 +15,9 @@
     "tag": "1.0.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/KIF/3.0.0/KIF.podspec.json
+++ b/Specs/KIF/3.0.0/KIF.podspec.json
@@ -17,7 +17,9 @@
     "ios": "4.3"
   },
   "frameworks": "CoreGraphics",
-  "default_subspec": "XCTest",
+  "default_subspecs": [
+    "XCTest"
+  ],
   "requires_arc": false,
   "prefix_header_contents": "#import <CoreGraphics/CoreGraphics.h>",
   "subspecs": [

--- a/Specs/KIF/3.0.1/KIF.podspec.json
+++ b/Specs/KIF/3.0.1/KIF.podspec.json
@@ -17,7 +17,9 @@
     "ios": "4.3"
   },
   "frameworks": "CoreGraphics",
-  "default_subspec": "XCTest",
+  "default_subspecs": [
+    "XCTest"
+  ],
   "requires_arc": false,
   "prefix_header_contents": "#import <CoreGraphics/CoreGraphics.h>",
   "subspecs": [

--- a/Specs/KIF/3.0.2/KIF.podspec.json
+++ b/Specs/KIF/3.0.2/KIF.podspec.json
@@ -17,7 +17,9 @@
     "ios": "5.1"
   },
   "frameworks": "CoreGraphics",
-  "default_subspec": "XCTest",
+  "default_subspecs": [
+    "XCTest"
+  ],
   "requires_arc": true,
   "prefix_header_contents": "#import <CoreGraphics/CoreGraphics.h>",
   "subspecs": [

--- a/Specs/KIF/3.0.3/KIF.podspec.json
+++ b/Specs/KIF/3.0.3/KIF.podspec.json
@@ -17,7 +17,9 @@
     "ios": "5.1"
   },
   "frameworks": "CoreGraphics",
-  "default_subspec": "XCTest",
+  "default_subspecs": [
+    "XCTest"
+  ],
   "requires_arc": true,
   "prefix_header_contents": "#import <CoreGraphics/CoreGraphics.h>",
   "subspecs": [

--- a/Specs/KIF/3.0.4/KIF.podspec.json
+++ b/Specs/KIF/3.0.4/KIF.podspec.json
@@ -17,7 +17,9 @@
     "ios": "5.1"
   },
   "frameworks": "CoreGraphics",
-  "default_subspec": "XCTest",
+  "default_subspecs": [
+    "XCTest"
+  ],
   "requires_arc": true,
   "prefix_header_contents": "#import <CoreGraphics/CoreGraphics.h>",
   "subspecs": [

--- a/Specs/Kiwi-KIF/1.0.1/Kiwi-KIF.podspec.json
+++ b/Specs/Kiwi-KIF/1.0.1/Kiwi-KIF.podspec.json
@@ -23,7 +23,9 @@
       "~>2.0.0"
     ]
   },
-  "default_subspec": "SenTestingKit",
+  "default_subspecs": [
+    "SenTestingKit"
+  ],
   "subspecs": [
     {
       "name": "SenTestingKit",

--- a/Specs/Kiwi-KIF/1.1.0/Kiwi-KIF.podspec.json
+++ b/Specs/Kiwi-KIF/1.1.0/Kiwi-KIF.podspec.json
@@ -18,7 +18,9 @@
     "tag": "1.1.0"
   },
   "requires_arc": true,
-  "default_subspec": "SenTestingKit",
+  "default_subspecs": [
+    "SenTestingKit"
+  ],
   "dependencies": {
     "KIF": [
       "~>3.0.0"

--- a/Specs/Kiwi/2.2.2/Kiwi.podspec.json
+++ b/Specs/Kiwi/2.2.2/Kiwi.podspec.json
@@ -31,7 +31,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "SenTestingKit",
+  "default_subspecs": [
+    "SenTestingKit"
+  ],
   "subspecs": [
     {
       "name": "SenTestingKit",

--- a/Specs/Kiwi/2.2.3/Kiwi.podspec.json
+++ b/Specs/Kiwi/2.2.3/Kiwi.podspec.json
@@ -31,7 +31,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "SenTestingKit",
+  "default_subspecs": [
+    "SenTestingKit"
+  ],
   "subspecs": [
     {
       "name": "SenTestingKit",

--- a/Specs/Kiwi/2.2.4/Kiwi.podspec.json
+++ b/Specs/Kiwi/2.2.4/Kiwi.podspec.json
@@ -31,7 +31,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "SenTestingKit",
+  "default_subspecs": [
+    "SenTestingKit"
+  ],
   "subspecs": [
     {
       "name": "SenTestingKit",

--- a/Specs/LWF/1.0.0/LWF.podspec.json
+++ b/Specs/LWF/1.0.0/LWF.podspec.json
@@ -23,7 +23,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "xcconfig": {
     "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
     "CLANG_CXX_LIBRARY": "libc++"

--- a/Specs/LWF/1.0.1/LWF.podspec.json
+++ b/Specs/LWF/1.0.1/LWF.podspec.json
@@ -23,7 +23,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "xcconfig": {
     "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
     "CLANG_CXX_LIBRARY": "libc++"

--- a/Specs/LWF/1.0.2/LWF.podspec.json
+++ b/Specs/LWF/1.0.2/LWF.podspec.json
@@ -23,7 +23,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "xcconfig": {
     "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
     "CLANG_CXX_LIBRARY": "libc++"

--- a/Specs/LWF/1.0.3/LWF.podspec.json
+++ b/Specs/LWF/1.0.3/LWF.podspec.json
@@ -23,7 +23,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "xcconfig": {
     "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
     "CLANG_CXX_LIBRARY": "libc++"

--- a/Specs/LWF/1.0.4/LWF.podspec.json
+++ b/Specs/LWF/1.0.4/LWF.podspec.json
@@ -23,7 +23,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "xcconfig": {
     "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
     "CLANG_CXX_LIBRARY": "libc++"

--- a/Specs/LWF/1.0.5/LWF.podspec.json
+++ b/Specs/LWF/1.0.5/LWF.podspec.json
@@ -23,7 +23,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "xcconfig": {
     "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
     "CLANG_CXX_LIBRARY": "libc++"

--- a/Specs/LWF/1.0.6/LWF.podspec.json
+++ b/Specs/LWF/1.0.6/LWF.podspec.json
@@ -23,7 +23,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "xcconfig": {
     "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
     "CLANG_CXX_LIBRARY": "libc++"

--- a/Specs/MDMultilineTextView/0.0.5/MDMultilineTextView.podspec.json
+++ b/Specs/MDMultilineTextView/0.0.5/MDMultilineTextView.podspec.json
@@ -16,7 +16,9 @@
     "git": "https://github.com/frnde/MDMultilineTextView.git",
     "tag": "0.0.5"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/MMRecord/1.0.0/MMRecord.podspec.json
+++ b/Specs/MMRecord/1.0.0/MMRecord.podspec.json
@@ -12,7 +12,9 @@
     "tag": "1.0.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "5.0",
     "osx": "10.7"

--- a/Specs/MMRecord/1.0.1/MMRecord.podspec.json
+++ b/Specs/MMRecord/1.0.1/MMRecord.podspec.json
@@ -12,7 +12,9 @@
     "tag": "1.0.1"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "5.0",
     "osx": "10.7"

--- a/Specs/MMRecord/1.0.2/MMRecord.podspec.json
+++ b/Specs/MMRecord/1.0.2/MMRecord.podspec.json
@@ -12,7 +12,9 @@
     "tag": "1.0.2"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "5.0",
     "osx": "10.7"

--- a/Specs/MMRecord/1.0.3/MMRecord.podspec.json
+++ b/Specs/MMRecord/1.0.3/MMRecord.podspec.json
@@ -12,7 +12,9 @@
     "tag": "1.0.3"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "5.0",
     "osx": "10.7"

--- a/Specs/MMRecord/1.1.0/MMRecord.podspec.json
+++ b/Specs/MMRecord/1.1.0/MMRecord.podspec.json
@@ -12,7 +12,9 @@
     "tag": "1.1.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "5.0",
     "osx": "10.7"

--- a/Specs/MMRecord/1.1.1/MMRecord.podspec.json
+++ b/Specs/MMRecord/1.1.1/MMRecord.podspec.json
@@ -12,7 +12,9 @@
     "tag": "1.1.1"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "5.0",
     "osx": "10.7"

--- a/Specs/MMRecord/1.2.0/MMRecord.podspec.json
+++ b/Specs/MMRecord/1.2.0/MMRecord.podspec.json
@@ -12,7 +12,9 @@
     "tag": "1.2.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "6.0",
     "osx": "10.8"

--- a/Specs/MMRecord/1.3.0/MMRecord.podspec.json
+++ b/Specs/MMRecord/1.3.0/MMRecord.podspec.json
@@ -12,7 +12,9 @@
     "tag": "1.3.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "6.0",
     "osx": "10.8"

--- a/Specs/MSSpec/0.0.1/MSSpec.podspec.json
+++ b/Specs/MSSpec/0.0.1/MSSpec.podspec.json
@@ -11,7 +11,9 @@
   "authors": {
     "NachoSoto": "hello@nachosoto.com"
   },
-  "default_subspec": "App",
+  "default_subspecs": [
+    "App"
+  ],
   "requires_arc": true,
   "platforms": {
     "ios": "7.0",

--- a/Specs/MSSpec/0.0.2/MSSpec.podspec.json
+++ b/Specs/MSSpec/0.0.2/MSSpec.podspec.json
@@ -11,7 +11,9 @@
   "authors": {
     "NachoSoto": "hello@nachosoto.com"
   },
-  "default_subspec": "App",
+  "default_subspecs": [
+    "App"
+  ],
   "requires_arc": true,
   "platforms": {
     "ios": "7.0",

--- a/Specs/MSSpec/0.0.3/MSSpec.podspec.json
+++ b/Specs/MSSpec/0.0.3/MSSpec.podspec.json
@@ -11,7 +11,9 @@
   "authors": {
     "NachoSoto": "hello@nachosoto.com"
   },
-  "default_subspec": "App",
+  "default_subspecs": [
+    "App"
+  ],
   "requires_arc": true,
   "platforms": {
     "ios": "7.0",

--- a/Specs/MSSpec/0.0.4/MSSpec.podspec.json
+++ b/Specs/MSSpec/0.0.4/MSSpec.podspec.json
@@ -11,7 +11,9 @@
   "authors": {
     "NachoSoto": "hello@nachosoto.com"
   },
-  "default_subspec": "App",
+  "default_subspecs": [
+    "App"
+  ],
   "requires_arc": true,
   "platforms": {
     "ios": "7.0",

--- a/Specs/MSSpec/0.0.5/MSSpec.podspec.json
+++ b/Specs/MSSpec/0.0.5/MSSpec.podspec.json
@@ -11,7 +11,9 @@
   "authors": {
     "NachoSoto": "hello@nachosoto.com"
   },
-  "default_subspec": "App",
+  "default_subspecs": [
+    "App"
+  ],
   "requires_arc": true,
   "platforms": {
     "ios": "7.0",

--- a/Specs/MSSpec/0.0.6/MSSpec.podspec.json
+++ b/Specs/MSSpec/0.0.6/MSSpec.podspec.json
@@ -11,7 +11,9 @@
   "authors": {
     "NachoSoto": "hello@nachosoto.com"
   },
-  "default_subspec": "App",
+  "default_subspecs": [
+    "App"
+  ],
   "requires_arc": true,
   "platforms": {
     "ios": "6.0",

--- a/Specs/MSSpec/0.0.7/MSSpec.podspec.json
+++ b/Specs/MSSpec/0.0.7/MSSpec.podspec.json
@@ -11,7 +11,9 @@
   "authors": {
     "NachoSoto": "hello@nachosoto.com"
   },
-  "default_subspec": "App",
+  "default_subspecs": [
+    "App"
+  ],
   "requires_arc": true,
   "platforms": {
     "ios": "6.0",

--- a/Specs/MSSpec/0.1.0/MSSpec.podspec.json
+++ b/Specs/MSSpec/0.1.0/MSSpec.podspec.json
@@ -11,7 +11,9 @@
   "authors": {
     "NachoSoto": "hello@nachosoto.com"
   },
-  "default_subspec": "App",
+  "default_subspecs": [
+    "App"
+  ],
   "requires_arc": true,
   "platforms": {
     "ios": "6.0",

--- a/Specs/MSSpec/0.1.1/MSSpec.podspec.json
+++ b/Specs/MSSpec/0.1.1/MSSpec.podspec.json
@@ -11,7 +11,9 @@
   "authors": {
     "NachoSoto": "hello@nachosoto.com"
   },
-  "default_subspec": "App",
+  "default_subspecs": [
+    "App"
+  ],
   "requires_arc": true,
   "platforms": {
     "ios": "6.0",

--- a/Specs/MSSpec/0.1.2/MSSpec.podspec.json
+++ b/Specs/MSSpec/0.1.2/MSSpec.podspec.json
@@ -11,7 +11,9 @@
   "authors": {
     "NachoSoto": "hello@nachosoto.com"
   },
-  "default_subspec": "App",
+  "default_subspecs": [
+    "App"
+  ],
   "requires_arc": true,
   "platforms": {
     "ios": "6.0",

--- a/Specs/MagicalRecord/2.0.3/MagicalRecord.podspec.json
+++ b/Specs/MagicalRecord/2.0.3/MagicalRecord.podspec.json
@@ -14,7 +14,9 @@
   "description": "Handy fetching, threading and data import helpers to make Core Data a little easier to use.",
   "frameworks": "CoreData",
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/MagicalRecord/2.0.4/MagicalRecord.podspec.json
+++ b/Specs/MagicalRecord/2.0.4/MagicalRecord.podspec.json
@@ -14,7 +14,9 @@
   "description": "Handy fetching, threading and data import helpers to make Core Data a little easier to use.",
   "frameworks": "CoreData",
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/MagicalRecord/2.0.7/MagicalRecord.podspec.json
+++ b/Specs/MagicalRecord/2.0.7/MagicalRecord.podspec.json
@@ -14,7 +14,9 @@
   "description": "Handy fetching, threading and data import helpers to make Core Data a little easier to use.",
   "frameworks": "CoreData",
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/MagicalRecord/2.0.8/MagicalRecord.podspec.json
+++ b/Specs/MagicalRecord/2.0.8/MagicalRecord.podspec.json
@@ -14,7 +14,9 @@
   "description": "Handy fetching, threading and data import helpers to make Core Data a little easier to use.",
   "frameworks": "CoreData",
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/MagicalRecord/2.0/MagicalRecord.podspec.json
+++ b/Specs/MagicalRecord/2.0/MagicalRecord.podspec.json
@@ -14,7 +14,9 @@
   "description": "Handy fetching, threading and data import helpers to make Core Data a little easier to use.",
   "frameworks": "CoreData",
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/MagicalRecord/2.1/MagicalRecord.podspec.json
+++ b/Specs/MagicalRecord/2.1/MagicalRecord.podspec.json
@@ -14,7 +14,9 @@
   "description": "Handy fetching, threading and data import helpers to make Core Data a little easier to use.",
   "frameworks": "CoreData",
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/MagicalRecord/2.2/MagicalRecord.podspec.json
+++ b/Specs/MagicalRecord/2.2/MagicalRecord.podspec.json
@@ -14,7 +14,9 @@
   "description": "Handy fetching, threading and data import helpers to make Core Data a little easier to use.",
   "frameworks": "CoreData",
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/MoPubClient/1.11.0.0/MoPubClient.podspec.json
+++ b/Specs/MoPubClient/1.11.0.0/MoPubClient.podspec.json
@@ -29,7 +29,9 @@
     "StoreKit",
     "CoreLocation"
   ],
-  "default_subspec": "Classes",
+  "default_subspecs": [
+    "Classes"
+  ],
   "subspecs": [
     {
       "name": "TouchJSON",

--- a/Specs/MoPubClient/1.12.1.0/MoPubClient.podspec.json
+++ b/Specs/MoPubClient/1.12.1.0/MoPubClient.podspec.json
@@ -25,7 +25,9 @@
     "StoreKit",
     "CoreLocation"
   ],
-  "default_subspec": "Classes",
+  "default_subspecs": [
+    "Classes"
+  ],
   "dependencies": {
     "TouchJSON": [
 

--- a/Specs/MoPubClient/1.12.2.0/MoPubClient.podspec.json
+++ b/Specs/MoPubClient/1.12.2.0/MoPubClient.podspec.json
@@ -25,7 +25,9 @@
     "StoreKit",
     "CoreLocation"
   ],
-  "default_subspec": "Classes",
+  "default_subspecs": [
+    "Classes"
+  ],
   "dependencies": {
     "TouchJSON": [
 

--- a/Specs/MoPubClient/1.12.3.0/MoPubClient.podspec.json
+++ b/Specs/MoPubClient/1.12.3.0/MoPubClient.podspec.json
@@ -25,7 +25,9 @@
     "StoreKit",
     "CoreLocation"
   ],
-  "default_subspec": "Classes",
+  "default_subspecs": [
+    "Classes"
+  ],
   "dependencies": {
     "TouchJSON": [
 

--- a/Specs/MoPubClient/1.12.5.0/MoPubClient.podspec.json
+++ b/Specs/MoPubClient/1.12.5.0/MoPubClient.podspec.json
@@ -25,7 +25,9 @@
     "StoreKit",
     "CoreLocation"
   ],
-  "default_subspec": "Classes",
+  "default_subspecs": [
+    "Classes"
+  ],
   "dependencies": {
     "TouchJSON": [
 

--- a/Specs/MoPubClient/1.13.0.0/MoPubClient.podspec.json
+++ b/Specs/MoPubClient/1.13.0.0/MoPubClient.podspec.json
@@ -25,7 +25,9 @@
     "CoreLocation",
     "MediaPlayer"
   ],
-  "default_subspec": "Classes",
+  "default_subspecs": [
+    "Classes"
+  ],
   "dependencies": {
     "TouchJSON": [
 

--- a/Specs/MoPubClient/1.14.0.0/MoPubClient.podspec.json
+++ b/Specs/MoPubClient/1.14.0.0/MoPubClient.podspec.json
@@ -25,7 +25,9 @@
     "CoreLocation",
     "MediaPlayer"
   ],
-  "default_subspec": "Classes",
+  "default_subspecs": [
+    "Classes"
+  ],
   "dependencies": {
     "TouchJSON": [
 

--- a/Specs/MoPubClient/1.14.1.0/MoPubClient.podspec.json
+++ b/Specs/MoPubClient/1.14.1.0/MoPubClient.podspec.json
@@ -25,7 +25,9 @@
     "CoreLocation",
     "MediaPlayer"
   ],
-  "default_subspec": "Classes",
+  "default_subspecs": [
+    "Classes"
+  ],
   "dependencies": {
     "TouchJSON": [
 

--- a/Specs/MoPubClient/1.16.0.0/MoPubClient.podspec.json
+++ b/Specs/MoPubClient/1.16.0.0/MoPubClient.podspec.json
@@ -25,7 +25,9 @@
     "CoreLocation",
     "MediaPlayer"
   ],
-  "default_subspec": "Classes",
+  "default_subspecs": [
+    "Classes"
+  ],
   "dependencies": {
     "TouchJSON": [
 

--- a/Specs/MoPubClient/1.17.0.0/MoPubClient.podspec.json
+++ b/Specs/MoPubClient/1.17.0.0/MoPubClient.podspec.json
@@ -25,7 +25,9 @@
     "CoreLocation",
     "MediaPlayer"
   ],
-  "default_subspec": "Classes",
+  "default_subspecs": [
+    "Classes"
+  ],
   "dependencies": {
     "TouchJSON": [
 

--- a/Specs/MoPubClient/1.17.2.0/MoPubClient.podspec.json
+++ b/Specs/MoPubClient/1.17.2.0/MoPubClient.podspec.json
@@ -25,7 +25,9 @@
     "CoreLocation",
     "MediaPlayer"
   ],
-  "default_subspec": "Classes",
+  "default_subspecs": [
+    "Classes"
+  ],
   "dependencies": {
     "TouchJSON": [
 

--- a/Specs/MoPubClient/1.17.3.0/MoPubClient.podspec.json
+++ b/Specs/MoPubClient/1.17.3.0/MoPubClient.podspec.json
@@ -25,7 +25,9 @@
     "CoreLocation",
     "MediaPlayer"
   ],
-  "default_subspec": "Classes",
+  "default_subspecs": [
+    "Classes"
+  ],
   "dependencies": {
     "TouchJSON": [
 

--- a/Specs/MoPubClient/2.0.0/MoPubClient.podspec.json
+++ b/Specs/MoPubClient/2.0.0/MoPubClient.podspec.json
@@ -27,7 +27,9 @@
     "MediaPlayer"
   ],
   "deprecated_in_favor_of": "mopub-ios-sdk",
-  "default_subspec": "Classes",
+  "default_subspecs": [
+    "Classes"
+  ],
   "subspecs": [
     {
       "name": "iAdAdapter",

--- a/Specs/NSRails/2.1.2/NSRails.podspec.json
+++ b/Specs/NSRails/2.1.2/NSRails.podspec.json
@@ -20,7 +20,9 @@
   },
   "frameworks": "CoreData",
   "requires_arc": true,
-  "default_subspec": "NSRails",
+  "default_subspecs": [
+    "NSRails"
+  ],
   "subspecs": [
     {
       "name": "NSRails",

--- a/Specs/OCDiscount/0.1.0/OCDiscount.podspec.json
+++ b/Specs/OCDiscount/0.1.0/OCDiscount.podspec.json
@@ -23,7 +23,9 @@
     "frameworks": "Foundation",
     "source_files": "OCDiscount/*.{h,m}"
   },
-  "default_subspec": "discount",
+  "default_subspecs": [
+    "discount"
+  ],
   "requires_arc": true,
   "subspecs": [
     {

--- a/Specs/OCDiscount/0.2.0/OCDiscount.podspec.json
+++ b/Specs/OCDiscount/0.2.0/OCDiscount.podspec.json
@@ -23,7 +23,9 @@
     "frameworks": "Foundation",
     "source_files": "OCDiscount/*.{h,m}"
   },
-  "default_subspec": "discount",
+  "default_subspecs": [
+    "discount"
+  ],
   "requires_arc": true,
   "subspecs": [
     {

--- a/Specs/OLImageView/1.0.0/OLImageView.podspec.json
+++ b/Specs/OLImageView/1.0.0/OLImageView.podspec.json
@@ -27,7 +27,9 @@
     "QuartzCore"
   ],
   "requires_arc": true,
-  "default_subspec": "AFNetworking",
+  "default_subspecs": [
+    "AFNetworking"
+  ],
   "subspecs": [
     {
       "name": "AFNetworking",

--- a/Specs/OLImageView/1.1.0/OLImageView.podspec.json
+++ b/Specs/OLImageView/1.1.0/OLImageView.podspec.json
@@ -27,7 +27,9 @@
     "QuartzCore"
   ],
   "requires_arc": true,
-  "default_subspec": "AFNetworking",
+  "default_subspecs": [
+    "AFNetworking"
+  ],
   "subspecs": [
     {
       "name": "AFNetworking",

--- a/Specs/OLImageView/1.2.0/OLImageView.podspec.json
+++ b/Specs/OLImageView/1.2.0/OLImageView.podspec.json
@@ -27,7 +27,9 @@
     "QuartzCore"
   ],
   "requires_arc": true,
-  "default_subspec": "AFNetworking",
+  "default_subspecs": [
+    "AFNetworking"
+  ],
   "subspecs": [
     {
       "name": "AFNetworking",

--- a/Specs/OLImageView/1.3.0/OLImageView.podspec.json
+++ b/Specs/OLImageView/1.3.0/OLImageView.podspec.json
@@ -27,7 +27,9 @@
     "QuartzCore"
   ],
   "requires_arc": true,
-  "default_subspec": "AFNetworking",
+  "default_subspecs": [
+    "AFNetworking"
+  ],
   "subspecs": [
     {
       "name": "AFNetworking",

--- a/Specs/OMPromises/0.1.1/OMPromises.podspec.json
+++ b/Specs/OMPromises/0.1.1/OMPromises.podspec.json
@@ -19,7 +19,9 @@
     "tag": "0.1.1"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/OMPromises/0.1.2/OMPromises.podspec.json
+++ b/Specs/OMPromises/0.1.2/OMPromises.podspec.json
@@ -19,7 +19,9 @@
     "tag": "0.1.2"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/OMPromises/0.2.0/OMPromises.podspec.json
+++ b/Specs/OMPromises/0.2.0/OMPromises.podspec.json
@@ -19,7 +19,9 @@
     "tag": "0.2.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/OMPromises/0.2.1/OMPromises.podspec.json
+++ b/Specs/OMPromises/0.2.1/OMPromises.podspec.json
@@ -19,7 +19,9 @@
     "tag": "0.2.1"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/OMPromises/0.3.0/OMPromises.podspec.json
+++ b/Specs/OMPromises/0.3.0/OMPromises.podspec.json
@@ -19,7 +19,9 @@
     "tag": "0.3.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/OpenSSL/1.0.0/OpenSSL.podspec.json
+++ b/Specs/OpenSSL/1.0.0/OpenSSL.podspec.json
@@ -27,7 +27,9 @@
     "e_os2.h"
   ],
   "public_header_files": "include/openssl/*",
-  "default_subspec": "ssl",
+  "default_subspecs": [
+    "ssl"
+  ],
   "subspecs": [
     {
       "name": "crypto",

--- a/Specs/OrigamiEngine/1.0.11/OrigamiEngine.podspec.json
+++ b/Specs/OrigamiEngine/1.0.11/OrigamiEngine.podspec.json
@@ -12,7 +12,9 @@
     "tag": "1.0.11",
     "submodules": true
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "requires_arc": false,
   "platforms": {
     "ios": "5.0",

--- a/Specs/OrigamiEngine/1.0.12/OrigamiEngine.podspec.json
+++ b/Specs/OrigamiEngine/1.0.12/OrigamiEngine.podspec.json
@@ -12,7 +12,9 @@
     "tag": "1.0.12",
     "submodules": true
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "requires_arc": false,
   "platforms": {
     "ios": "5.0",

--- a/Specs/PLDatabase/2.0-alpha/PLDatabase.podspec.json
+++ b/Specs/PLDatabase/2.0-alpha/PLDatabase.podspec.json
@@ -17,7 +17,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "standard",
+  "default_subspecs": [
+    "standard"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Parse-SDK-Helpers/1.1.0/Parse-SDK-Helpers.podspec.json
+++ b/Specs/Parse-SDK-Helpers/1.1.0/Parse-SDK-Helpers.podspec.json
@@ -34,7 +34,9 @@
     }
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/PivotalCoreKit/0.0.3/PivotalCoreKit.podspec.json
+++ b/Specs/PivotalCoreKit/0.0.3/PivotalCoreKit.podspec.json
@@ -17,7 +17,9 @@
   "platforms": {
     "ios": "5.0"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/PlaceKit/1.0.0/PlaceKit.podspec.json
+++ b/Specs/PlaceKit/1.0.0/PlaceKit.podspec.json
@@ -17,7 +17,9 @@
   },
   "exclude_files": "Demo",
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/Quantcast-Measure-iOS4/1.2.13/Quantcast-Measure-iOS4.podspec.json
+++ b/Specs/Quantcast-Measure-iOS4/1.2.13/Quantcast-Measure-iOS4.podspec.json
@@ -18,7 +18,9 @@
   "platforms": {
     "ios": "4.0"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Quantcast-Measure/1.2.10/Quantcast-Measure.podspec.json
+++ b/Specs/Quantcast-Measure/1.2.10/Quantcast-Measure.podspec.json
@@ -18,7 +18,9 @@
   "platforms": {
     "ios": "5.0"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Quantcast-Measure/1.2.13/Quantcast-Measure.podspec.json
+++ b/Specs/Quantcast-Measure/1.2.13/Quantcast-Measure.podspec.json
@@ -18,7 +18,9 @@
   "platforms": {
     "ios": "5.0"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Quantcast-Measure/1.4.0/Quantcast-Measure.podspec.json
+++ b/Specs/Quantcast-Measure/1.4.0/Quantcast-Measure.podspec.json
@@ -18,7 +18,9 @@
   "platforms": {
     "ios": "5.0"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/Quantcast-Measure/1.4.2/Quantcast-Measure.podspec.json
+++ b/Specs/Quantcast-Measure/1.4.2/Quantcast-Measure.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/QuickDialog/1.0/QuickDialog.podspec.json
+++ b/Specs/QuickDialog/1.0/QuickDialog.podspec.json
@@ -17,7 +17,9 @@
   },
   "description": "QuickDialog allows you to create HIG-compliant iOS forms for your apps without having to directly deal with UITableViews, delegates and data sources. Fast and efficient, you can create forms with multiple text fields, or with thousands of items with no sweat!",
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "prefix_header_contents": "#ifdef __OBJC__\n    #import \"QuickDialog.h\"\n#endif\n",
   "subspecs": [
     {

--- a/Specs/RDHCollectionViewGridLayout/0.0.1/RDHCollectionViewGridLayout.podspec.json
+++ b/Specs/RDHCollectionViewGridLayout/0.0.1/RDHCollectionViewGridLayout.podspec.json
@@ -15,7 +15,9 @@
     "CoreGraphics"
   ],
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/RDHCollectionViewGridLayout/0.0.2/RDHCollectionViewGridLayout.podspec.json
+++ b/Specs/RDHCollectionViewGridLayout/0.0.2/RDHCollectionViewGridLayout.podspec.json
@@ -15,7 +15,9 @@
     "CoreGraphics"
   ],
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/RDHCollectionViewGridLayout/1.0.0/RDHCollectionViewGridLayout.podspec.json
+++ b/Specs/RDHCollectionViewGridLayout/1.0.0/RDHCollectionViewGridLayout.podspec.json
@@ -15,7 +15,9 @@
     "CoreGraphics"
   ],
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/RKXMLDictionarySerialization/1.1.0/RKXMLDictionarySerialization.podspec.json
+++ b/Specs/RKXMLDictionarySerialization/1.1.0/RKXMLDictionarySerialization.podspec.json
@@ -18,7 +18,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/RMStore/0.5/RMStore.podspec.json
+++ b/Specs/RMStore/0.5/RMStore.podspec.json
@@ -15,7 +15,9 @@
   },
   "frameworks": "StoreKit",
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/ReactiveCocoa/2.1.2/ReactiveCocoa.podspec.json
+++ b/Specs/ReactiveCocoa/2.1.2/ReactiveCocoa.podspec.json
@@ -19,7 +19,9 @@
   },
   "compiler_flags": "-DOS_OBJECT_USE_OBJC=0",
   "prepare_command": "    find . \\( -regex '.*EXT.*\\.[mh]$' -o -regex '.*metamacros\\.[mh]$' \\) -execdir mv {} RAC{} \\;\n    find . -regex '.*\\.[hm]' -exec sed -i '' -E 's@\"(EXT.*|metamacros)\\.h\"@\"RAC\\1.h\"@' {} \\;\n    find . -regex '.*\\.[hm]' -exec sed -i '' -E 's@<ReactiveCocoa/(EXT.*)\\.h>@<ReactiveCocoa/RAC\\1.h>@' {} \\;\n",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "no-arc",

--- a/Specs/ReactiveCocoa/2.3.1/ReactiveCocoa.podspec.json
+++ b/Specs/ReactiveCocoa/2.3.1/ReactiveCocoa.podspec.json
@@ -19,7 +19,9 @@
   },
   "compiler_flags": "-DOS_OBJECT_USE_OBJC=0",
   "prepare_command": "    find . \\( -regex '.*EXT.*\\.[mh]$' -o -regex '.*metamacros\\.[mh]$' \\) -execdir mv {} RAC{} \\;\n    find . -regex '.*\\.[hm]' -exec sed -i '' -E 's@\"(EXT.*|metamacros)\\.h\"@\"RAC\\1.h\"@' {} \\;\n    find . -regex '.*\\.[hm]' -exec sed -i '' -E 's@<ReactiveCocoa/(EXT.*)\\.h>@<ReactiveCocoa/RAC\\1.h>@' {} \\;\n",
-  "default_subspec": "UI",
+  "default_subspecs": [
+    "UI"
+  ],
   "subspecs": [
     {
       "name": "no-arc",

--- a/Specs/ReactiveCocoa/2.3/ReactiveCocoa.podspec.json
+++ b/Specs/ReactiveCocoa/2.3/ReactiveCocoa.podspec.json
@@ -19,7 +19,9 @@
   },
   "compiler_flags": "-DOS_OBJECT_USE_OBJC=0",
   "prepare_command": "    find . \\( -regex '.*EXT.*\\.[mh]$' -o -regex '.*metamacros\\.[mh]$' \\) -execdir mv {} RAC{} \\;\n    find . -regex '.*\\.[hm]' -exec sed -i '' -E 's@\"(EXT.*|metamacros)\\.h\"@\"RAC\\1.h\"@' {} \\;\n    find . -regex '.*\\.[hm]' -exec sed -i '' -E 's@<ReactiveCocoa/(EXT.*)\\.h>@<ReactiveCocoa/RAC\\1.h>@' {} \\;\n",
-  "default_subspec": "UI",
+  "default_subspecs": [
+    "UI"
+  ],
   "subspecs": [
     {
       "name": "no-arc",

--- a/Specs/RestKit/0.10.0/RestKit.podspec.json
+++ b/Specs/RestKit/0.10.0/RestKit.podspec.json
@@ -12,7 +12,9 @@
   },
   "license": "Apache License, Version 2.0",
   "source_files": "Code/RestKit.h",
-  "default_subspec": "JSON",
+  "default_subspecs": [
+    "JSON"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/RestKit/0.10.1/RestKit.podspec.json
+++ b/Specs/RestKit/0.10.1/RestKit.podspec.json
@@ -12,7 +12,9 @@
   },
   "license": "Apache License, Version 2.0",
   "source_files": "Code/RestKit.h",
-  "default_subspec": "JSON",
+  "default_subspecs": [
+    "JSON"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/RestKit/0.10.2/RestKit.podspec.json
+++ b/Specs/RestKit/0.10.2/RestKit.podspec.json
@@ -12,7 +12,9 @@
   },
   "license": "Apache License, Version 2.0",
   "source_files": "Code/RestKit.h",
-  "default_subspec": "JSON",
+  "default_subspecs": [
+    "JSON"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/RestKit/0.10.3/RestKit.podspec.json
+++ b/Specs/RestKit/0.10.3/RestKit.podspec.json
@@ -12,7 +12,9 @@
   },
   "license": "Apache License, Version 2.0",
   "source_files": "Code/RestKit.h",
-  "default_subspec": "JSON",
+  "default_subspecs": [
+    "JSON"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/RestKit/0.20.0-pre1/RestKit.podspec.json
+++ b/Specs/RestKit/0.20.0-pre1/RestKit.podspec.json
@@ -16,7 +16,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/RestKit/0.20.0-pre2/RestKit.podspec.json
+++ b/Specs/RestKit/0.20.0-pre2/RestKit.podspec.json
@@ -16,7 +16,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/RestKit/0.20.0-pre3/RestKit.podspec.json
+++ b/Specs/RestKit/0.20.0-pre3/RestKit.podspec.json
@@ -16,7 +16,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/RestKit/0.20.0-pre4/RestKit.podspec.json
+++ b/Specs/RestKit/0.20.0-pre4/RestKit.podspec.json
@@ -16,7 +16,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/RestKit/0.20.0-pre6/RestKit.podspec.json
+++ b/Specs/RestKit/0.20.0-pre6/RestKit.podspec.json
@@ -16,7 +16,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/RestKit/0.20.0-rc1/RestKit.podspec.json
+++ b/Specs/RestKit/0.20.0-rc1/RestKit.podspec.json
@@ -16,7 +16,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "prefix_header_contents": "#ifdef __OBJC__\n#import <CoreData/CoreData.h>\n#endif /* __OBJC__*/\n",
   "subspecs": [
     {

--- a/Specs/RestKit/0.20.0/RestKit.podspec.json
+++ b/Specs/RestKit/0.20.0/RestKit.podspec.json
@@ -16,7 +16,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "prefix_header_contents": "#ifdef __OBJC__\n#import <CoreData/CoreData.h>\n#endif /* __OBJC__*/\n",
   "subspecs": [
     {

--- a/Specs/RestKit/0.20.0pre5/RestKit.podspec.json
+++ b/Specs/RestKit/0.20.0pre5/RestKit.podspec.json
@@ -17,7 +17,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/RestKit/0.20.1/RestKit.podspec.json
+++ b/Specs/RestKit/0.20.1/RestKit.podspec.json
@@ -16,7 +16,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "prefix_header_contents": "#ifdef __OBJC__\n#import <CoreData/CoreData.h>\n#endif /* __OBJC__*/\n",
   "subspecs": [
     {

--- a/Specs/RestKit/0.20.2/RestKit.podspec.json
+++ b/Specs/RestKit/0.20.2/RestKit.podspec.json
@@ -16,7 +16,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "prefix_header_contents": "#ifdef __OBJC__\n#import <CoreData/CoreData.h>\n#endif /* __OBJC__*/\n",
   "subspecs": [
     {

--- a/Specs/RestKit/0.20.3/RestKit.podspec.json
+++ b/Specs/RestKit/0.20.3/RestKit.podspec.json
@@ -16,7 +16,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "prefix_header_contents": "#ifdef __OBJC__\n#import <CoreData/CoreData.h>\n#endif /* __OBJC__*/\n",
   "subspecs": [
     {

--- a/Specs/RestKit/0.21.0/RestKit.podspec.json
+++ b/Specs/RestKit/0.21.0/RestKit.podspec.json
@@ -16,7 +16,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "prefix_header_contents": "#ifdef COCOAPODS_POD_AVAILABLE_RestKit_CoreData\n    #import <CoreData/CoreData.h>\n#endif\n",
   "header_mappings_dir": "Code",
   "subspecs": [

--- a/Specs/RestKit/0.22.0/RestKit.podspec.json
+++ b/Specs/RestKit/0.22.0/RestKit.podspec.json
@@ -16,7 +16,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "prefix_header_contents": "#ifdef COCOAPODS_POD_AVAILABLE_RestKit_CoreData\n    #import <CoreData/CoreData.h>\n#endif\n",
   "header_mappings_dir": "Code",
   "subspecs": [

--- a/Specs/RestKit/0.23.1/RestKit.podspec.json
+++ b/Specs/RestKit/0.23.1/RestKit.podspec.json
@@ -17,7 +17,9 @@
     "ios": "5.0",
     "osx": "10.7"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "prefix_header_contents": "#ifdef COCOAPODS_POD_AVAILABLE_RestKit_CoreData\n    #import <CoreData/CoreData.h>\n#endif\n",
   "header_mappings_dir": "Code",
   "subspecs": [

--- a/Specs/SAX-JSON-Parser/1.1.0/SAX-JSON-Parser.podspec.json
+++ b/Specs/SAX-JSON-Parser/1.1.0/SAX-JSON-Parser.podspec.json
@@ -18,7 +18,9 @@
     "tag": "v1.1.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "description": "The JSONObjectExtractor utility class can provide a SAX style parser for the special case of JSON arrays containing dictionaries. Itaccepts a stream of NSData objects from a NSURLConnection or NSURLSession, which comprise a JSON array. Then, it passes NSJSONSerialization decoded objects back to the delegate as they are detected. In addition, if the JSON stream is from a MongoDB service, it intercepts and rewrites 'ObjectID(...)' and 'new Date(...)' fields, so the JSON can be parsed by NSJSONSerialization. The overhead cost for this rewriting is trivial, and several orders of magnitude faster than using regular expressions on the raw text to do it. For proper usage, see the demo project on github.\n",
   "subspecs": [
     {

--- a/Specs/SBPickerSelector/1.0.0/SBPickerSelector.podspec.json
+++ b/Specs/SBPickerSelector/1.0.0/SBPickerSelector.podspec.json
@@ -17,7 +17,9 @@
   "platforms": {
     "ios": "5.0"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/SBPickerSelector/1.0.1/SBPickerSelector.podspec.json
+++ b/Specs/SBPickerSelector/1.0.1/SBPickerSelector.podspec.json
@@ -17,7 +17,9 @@
   "platforms": {
     "ios": "5.0"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/SDWebImage/2.7.4/SDWebImage.podspec.json
+++ b/Specs/SDWebImage/2.7.4/SDWebImage.podspec.json
@@ -15,7 +15,9 @@
     "tag": "2.7.4"
   },
   "description": "This library provides a category for UIImageVIew with support for remote images coming from the web. It provides an UIImageView category adding web image and cache management to the Cocoa Touch framework, an asynchronous image downloader, an asynchronous memory + disk image caching with automatic cache expiration handling, a guarantee that the same URL won't be downloaded several times, a guarantee that bogus URLs won't be retried again and again, and performances!",
-  "default_subspec": "Main",
+  "default_subspecs": [
+    "Main"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/SDWebImage/2.7/SDWebImage.podspec.json
+++ b/Specs/SDWebImage/2.7/SDWebImage.podspec.json
@@ -15,7 +15,9 @@
     "tag": "2.7"
   },
   "description": "This library provides a category for UIImageVIew with support for remote images coming from the web. It provides an UIImageView category adding web image and cache management to the Cocoa Touch framework, an asynchronous image downloader, an asynchronous memory + disk image caching with automatic cache expiration handling, a guarantee that the same URL won't be downloaded several times, a guarantee that bogus URLs won't be retried again and again, and performances!",
-  "default_subspec": "Main",
+  "default_subspecs": [
+    "Main"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/SDWebImage/3.0/SDWebImage.podspec.json
+++ b/Specs/SDWebImage/3.0/SDWebImage.podspec.json
@@ -15,7 +15,9 @@
     "tag": "3.0"
   },
   "description": "This library provides a category for UIImageVIew with support for remote images coming from the web. It provides an UIImageView category adding web image and cache management to the Cocoa Touch framework, an asynchronous image downloader, an asynchronous memory + disk image caching with automatic cache expiration handling, a guarantee that the same URL won't be downloaded several times, a guarantee that bogus URLs won't be retried again and again, and performances!",
-  "default_subspec": "Main",
+  "default_subspecs": [
+    "Main"
+  ],
   "requires_arc": true,
   "subspecs": [
     {

--- a/Specs/SDWebImage/3.1/SDWebImage.podspec.json
+++ b/Specs/SDWebImage/3.1/SDWebImage.podspec.json
@@ -15,7 +15,9 @@
     "tag": "3.1"
   },
   "description": "This library provides a category for UIImageVIew with support for remote images coming from the web. It provides an UIImageView category adding web image and cache management to the Cocoa Touch framework, an asynchronous image downloader, an asynchronous memory + disk image caching with automatic cache expiration handling, a guarantee that the same URL won't be downloaded several times, a guarantee that bogus URLs won't be retried again and again, and performances!",
-  "default_subspec": "Main",
+  "default_subspecs": [
+    "Main"
+  ],
   "requires_arc": true,
   "subspecs": [
     {

--- a/Specs/SDWebImage/3.2/SDWebImage.podspec.json
+++ b/Specs/SDWebImage/3.2/SDWebImage.podspec.json
@@ -16,7 +16,9 @@
   },
   "description": "This library provides a category for UIImageVIew with support for remote images coming from the web. It provides an UIImageView category adding web image and cache management to the Cocoa Touch framework, an asynchronous image downloader, an asynchronous memory + disk image caching with automatic cache expiration handling, a guarantee that the same URL won't be downloaded several times, a guarantee that bogus URLs won't be retried again and again, and performances!",
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/SDWebImage/3.4/SDWebImage.podspec.json
+++ b/Specs/SDWebImage/3.4/SDWebImage.podspec.json
@@ -17,7 +17,9 @@
   "description": "This library provides a category for UIImageView with support for remote images coming from the web. It provides an UIImageView category adding web image and cache management to the Cocoa Touch framework, an asynchronous image downloader, an asynchronous memory + disk image caching with automatic cache expiration handling, a guarantee that the same URL won't be downloaded several times, a guarantee that bogus URLs won't be retried again and again, and performances!",
   "requires_arc": true,
   "frameworks": "ImageIO",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/SDWebImage/3.5.1/SDWebImage.podspec.json
+++ b/Specs/SDWebImage/3.5.1/SDWebImage.podspec.json
@@ -17,7 +17,9 @@
   "description": "This library provides a category for UIImageView with support for remote images coming from the web. It provides an UIImageView category adding web image and cache management to the Cocoa Touch framework, an asynchronous image downloader, an asynchronous memory + disk image caching with automatic cache expiration handling, a guarantee that the same URL won't be downloaded several times, a guarantee that bogus URLs won't be retried again and again, and performances!",
   "requires_arc": true,
   "frameworks": "ImageIO",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/SDWebImage/3.5.2/SDWebImage.podspec.json
+++ b/Specs/SDWebImage/3.5.2/SDWebImage.podspec.json
@@ -17,7 +17,9 @@
   "description": "This library provides a category for UIImageView with support for remote images coming from the web. It provides an UIImageView category adding web image and cache management to the Cocoa Touch framework, an asynchronous image downloader, an asynchronous memory + disk image caching with automatic cache expiration handling, a guarantee that the same URL won't be downloaded several times, a guarantee that bogus URLs won't be retried again and again, and performances!",
   "requires_arc": true,
   "frameworks": "ImageIO",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/SDWebImage/3.5.4/SDWebImage.podspec.json
+++ b/Specs/SDWebImage/3.5.4/SDWebImage.podspec.json
@@ -17,7 +17,9 @@
   "description": "This library provides a category for UIImageView with support for remote images coming from the web. It provides an UIImageView category adding web image and cache management to the Cocoa Touch framework, an asynchronous image downloader, an asynchronous memory + disk image caching with automatic cache expiration handling, a guarantee that the same URL won't be downloaded several times, a guarantee that bogus URLs won't be retried again and again, and performances!",
   "requires_arc": true,
   "frameworks": "ImageIO",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/SDWebImage/3.5/SDWebImage.podspec.json
+++ b/Specs/SDWebImage/3.5/SDWebImage.podspec.json
@@ -17,7 +17,9 @@
   "description": "This library provides a category for UIImageView with support for remote images coming from the web. It provides an UIImageView category adding web image and cache management to the Cocoa Touch framework, an asynchronous image downloader, an asynchronous memory + disk image caching with automatic cache expiration handling, a guarantee that the same URL won't be downloaded several times, a guarantee that bogus URLs won't be retried again and again, and performances!",
   "requires_arc": true,
   "frameworks": "ImageIO",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/SDWebImage/3.6/SDWebImage.podspec.json
+++ b/Specs/SDWebImage/3.6/SDWebImage.podspec.json
@@ -17,7 +17,9 @@
   "description": "This library provides a category for UIImageView with support for remote images coming from the web. It provides an UIImageView category adding web image and cache management to the Cocoa Touch framework, an asynchronous image downloader, an asynchronous memory + disk image caching with automatic cache expiration handling, a guarantee that the same URL won't be downloaded several times, a guarantee that bogus URLs won't be retried again and again, and performances!",
   "requires_arc": true,
   "frameworks": "ImageIO",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/SHTestCaseAdditions/1.2.1/SHTestCaseAdditions.podspec.json
+++ b/Specs/SHTestCaseAdditions/1.2.1/SHTestCaseAdditions.podspec.json
@@ -12,7 +12,9 @@
     "git": "https://github.com/seivan/SHTestCaseAdditions.git",
     "tag": "1.2.1"
   },
-  "default_subspec": "XCTest",
+  "default_subspecs": [
+    "XCTest"
+  ],
   "requires_arc": true,
   "subspecs": [
     {

--- a/Specs/SHTestCaseAdditions/1.3.0/SHTestCaseAdditions.podspec.json
+++ b/Specs/SHTestCaseAdditions/1.3.0/SHTestCaseAdditions.podspec.json
@@ -12,7 +12,9 @@
     "git": "https://github.com/seivan/SHTestCaseAdditions.git",
     "tag": "1.3.0"
   },
-  "default_subspec": "XCTest",
+  "default_subspecs": [
+    "XCTest"
+  ],
   "requires_arc": true,
   "subspecs": [
     {

--- a/Specs/SHTestCaseAdditions/1.4.0/SHTestCaseAdditions.podspec.json
+++ b/Specs/SHTestCaseAdditions/1.4.0/SHTestCaseAdditions.podspec.json
@@ -12,7 +12,9 @@
     "git": "https://github.com/seivan/SHTestCaseAdditions.git",
     "tag": "1.4.0"
   },
-  "default_subspec": "XCTest",
+  "default_subspecs": [
+    "XCTest"
+  ],
   "requires_arc": true,
   "subspecs": [
     {

--- a/Specs/SHTestCaseAdditions/1.4.1/SHTestCaseAdditions.podspec.json
+++ b/Specs/SHTestCaseAdditions/1.4.1/SHTestCaseAdditions.podspec.json
@@ -12,7 +12,9 @@
     "git": "https://github.com/seivan/SHTestCaseAdditions.git",
     "tag": "1.4.1"
   },
-  "default_subspec": "XCTest",
+  "default_subspecs": [
+    "XCTest"
+  ],
   "requires_arc": true,
   "subspecs": [
     {

--- a/Specs/SLRESTfulCoreData/1.0.3/SLRESTfulCoreData.podspec.json
+++ b/Specs/SLRESTfulCoreData/1.0.3/SLRESTfulCoreData.podspec.json
@@ -20,7 +20,9 @@
   "authors": {
     "Oliver Letterer": "oliver.letterer@gmail.com"
   },
-  "default_subspec": "Complete",
+  "default_subspecs": [
+    "Complete"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/SLRESTfulCoreData/1.1.6/SLRESTfulCoreData.podspec.json
+++ b/Specs/SLRESTfulCoreData/1.1.6/SLRESTfulCoreData.podspec.json
@@ -20,7 +20,9 @@
   "authors": {
     "Oliver Letterer": "oliver.letterer@gmail.com"
   },
-  "default_subspec": "Complete",
+  "default_subspecs": [
+    "Complete"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/SLRESTfulCoreData/1.3.4/SLRESTfulCoreData.podspec.json
+++ b/Specs/SLRESTfulCoreData/1.3.4/SLRESTfulCoreData.podspec.json
@@ -20,7 +20,9 @@
   "authors": {
     "Oliver Letterer": "oliver.letterer@gmail.com"
   },
-  "default_subspec": "Complete",
+  "default_subspecs": [
+    "Complete"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/SLRESTfulCoreData/1.4.2/SLRESTfulCoreData.podspec.json
+++ b/Specs/SLRESTfulCoreData/1.4.2/SLRESTfulCoreData.podspec.json
@@ -20,7 +20,9 @@
   "authors": {
     "Oliver Letterer": "oliver.letterer@gmail.com"
   },
-  "default_subspec": "Complete",
+  "default_subspecs": [
+    "Complete"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/SLRESTfulCoreData/1.5.2/SLRESTfulCoreData.podspec.json
+++ b/Specs/SLRESTfulCoreData/1.5.2/SLRESTfulCoreData.podspec.json
@@ -20,7 +20,9 @@
   "authors": {
     "Oliver Letterer": "oliver.letterer@gmail.com"
   },
-  "default_subspec": "Complete",
+  "default_subspecs": [
+    "Complete"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/SLRESTfulCoreData/1.5.3/SLRESTfulCoreData.podspec.json
+++ b/Specs/SLRESTfulCoreData/1.5.3/SLRESTfulCoreData.podspec.json
@@ -20,7 +20,9 @@
   "authors": {
     "Oliver Letterer": "oliver.letterer@gmail.com"
   },
-  "default_subspec": "Complete",
+  "default_subspecs": [
+    "Complete"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/SLRESTfulCoreData/1.6.2/SLRESTfulCoreData.podspec.json
+++ b/Specs/SLRESTfulCoreData/1.6.2/SLRESTfulCoreData.podspec.json
@@ -20,7 +20,9 @@
   "authors": {
     "Oliver Letterer": "oliver.letterer@gmail.com"
   },
-  "default_subspec": "Complete",
+  "default_subspecs": [
+    "Complete"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/SQLCipher/3.0.1/SQLCipher.podspec.json
+++ b/Specs/SQLCipher/3.0.1/SQLCipher.podspec.json
@@ -11,7 +11,9 @@
     "tag": "v3.0.1"
   },
   "prepare_command": "    ./configure --enable-tempstore=yes --with-crypto-lib=commoncrypto CFLAGS=\"-DSQLITE_HAS_CODEC -DSQLITE_TEMP_STORE=2 -DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_UNLOCK_NOTIFY\"\n    make sqlite3.c\n",
-  "default_subspec": "standard",
+  "default_subspecs": [
+    "standard"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/SQLCipher/3.1.0/SQLCipher.podspec.json
+++ b/Specs/SQLCipher/3.1.0/SQLCipher.podspec.json
@@ -11,7 +11,9 @@
     "tag": "v3.1.0"
   },
   "prepare_command": "    ./configure --enable-tempstore=yes --with-crypto-lib=commoncrypto CFLAGS=\"-DSQLITE_HAS_CODEC -DSQLITE_TEMP_STORE=2 -DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_UNLOCK_NOTIFY\"\n    make sqlite3.c\n",
-  "default_subspec": "standard",
+  "default_subspecs": [
+    "standard"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/STDebugKit/0.1.1/STDebugKit.podspec.json
+++ b/Specs/STDebugKit/0.1.1/STDebugKit.podspec.json
@@ -17,7 +17,9 @@
   },
   "frameworks": "Foundation",
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/STDebugKit/0.2.0/STDebugKit.podspec.json
+++ b/Specs/STDebugKit/0.2.0/STDebugKit.podspec.json
@@ -17,7 +17,9 @@
   },
   "frameworks": "Foundation",
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/STDebugKit/0.3.0/STDebugKit.podspec.json
+++ b/Specs/STDebugKit/0.3.0/STDebugKit.podspec.json
@@ -17,7 +17,9 @@
   },
   "frameworks": "Foundation",
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/Sailthru_SDK_iOS/3.2.6/Sailthru_SDK_iOS.podspec.json
+++ b/Specs/Sailthru_SDK_iOS/3.2.6/Sailthru_SDK_iOS.podspec.json
@@ -17,7 +17,9 @@
     "tag": "v3.2.6"
   },
   "requires_arc": true,
-  "default_subspec": "ios7",
+  "default_subspecs": [
+    "ios7"
+  ],
   "description": "The SailthruSDK is provided to current Sailthru, Inc clients who have an iOS App. Clients\ncan use the SDK to register a user with Sailthru, and thus create the linkage necessary to \nsupport push notifications. The client app may optionally send tracking information, by sending\nin tags and URLs, and obtain recommendations (URLs) to show the user as desired.\n",
   "subspecs": [
     {

--- a/Specs/Sailthru_SDK_iOS/3.2.7/Sailthru_SDK_iOS.podspec.json
+++ b/Specs/Sailthru_SDK_iOS/3.2.7/Sailthru_SDK_iOS.podspec.json
@@ -19,7 +19,9 @@
     "tag": "v3.2.7"
   },
   "requires_arc": true,
-  "default_subspec": "ios7",
+  "default_subspecs": [
+    "ios7"
+  ],
   "description": "The SailthruSDK is provided to current Sailthru, Inc clients who have an iOS App. Clients\ncan use the SDK to register a user with Sailthru, and thus create the linkage necessary to \nsupport push notifications. The client app may optionally send tracking information, by sending\nin tags and URLs, and obtain recommendations (URLs) to show the user as desired.\n",
   "subspecs": [
     {

--- a/Specs/Sailthru_SDK_iOS/3.3.0/Sailthru_SDK_iOS.podspec.json
+++ b/Specs/Sailthru_SDK_iOS/3.3.0/Sailthru_SDK_iOS.podspec.json
@@ -19,7 +19,9 @@
     "tag": "v3.3.0"
   },
   "requires_arc": true,
-  "default_subspec": "ios7",
+  "default_subspecs": [
+    "ios7"
+  ],
   "description": "                              The SailthruSDK is provided to current Sailthru, Inc clients who have an iOS App. Clients\n                              can use the SDK to register a user with Sailthru, and thus create the linkage necessary to \n                              support push notifications. The client app may optionally send tracking information, by sending\n                              in tags and URLs, and obtain recommendations (URLs) to show the user as desired.\n",
   "subspecs": [
     {

--- a/Specs/Sealant/1.0/Sealant.podspec.json
+++ b/Specs/Sealant/1.0/Sealant.podspec.json
@@ -17,7 +17,9 @@
   "description": "This pod provides a set of utilities for automated testing on iOS.",
   "preserve_paths": "Scripts",
   "requires_arc": true,
-  "default_subspec": "Sealant",
+  "default_subspecs": [
+    "Sealant"
+  ],
   "subspecs": [
     {
       "name": "Sealant",

--- a/Specs/StanKit/0.1.1/StanKit.podspec.json
+++ b/Specs/StanKit/0.1.1/StanKit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "7.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/StanKit/0.1/StanKit.podspec.json
+++ b/Specs/StanKit/0.1/StanKit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "7.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/StanKit/0.2/StanKit.podspec.json
+++ b/Specs/StanKit/0.2/StanKit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "7.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/TMCategories/1.0.0/TMCategories.podspec.json
+++ b/Specs/TMCategories/1.0.0/TMCategories.podspec.json
@@ -15,7 +15,9 @@
   "platforms": {
     "ios": "7.1"
   },
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "All",

--- a/Specs/TMCategories/1.1.0/TMCategories.podspec.json
+++ b/Specs/TMCategories/1.1.0/TMCategories.podspec.json
@@ -15,7 +15,9 @@
   "platforms": {
     "ios": "7.1"
   },
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "All",

--- a/Specs/TMCategories/1.2.0/TMCategories.podspec.json
+++ b/Specs/TMCategories/1.2.0/TMCategories.podspec.json
@@ -15,7 +15,9 @@
   "platforms": {
     "ios": "7.1"
   },
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "All",

--- a/Specs/TMCategories/1.2.1/TMCategories.podspec.json
+++ b/Specs/TMCategories/1.2.1/TMCategories.podspec.json
@@ -15,7 +15,9 @@
   "platforms": {
     "ios": "7.1"
   },
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "All",

--- a/Specs/TenzingCore/0.2.0/TenzingCore.podspec.json
+++ b/Specs/TenzingCore/0.2.0/TenzingCore.podspec.json
@@ -18,7 +18,9 @@
   },
   "header_dir": "TenzingCore",
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/TenzingCore/0.2.1/TenzingCore.podspec.json
+++ b/Specs/TenzingCore/0.2.1/TenzingCore.podspec.json
@@ -18,7 +18,9 @@
   },
   "header_dir": "TenzingCore",
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/TestFlightFeedback/1.0.0/TestFlightFeedback.podspec.json
+++ b/Specs/TestFlightFeedback/1.0.0/TestFlightFeedback.podspec.json
@@ -23,7 +23,9 @@
       "~> 2.0.0"
     ]
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/TestFlightFeedback/2.0.0/TestFlightFeedback.podspec.json
+++ b/Specs/TestFlightFeedback/2.0.0/TestFlightFeedback.podspec.json
@@ -23,7 +23,9 @@
       ">= 2.0"
     ]
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/TestFlightFeedback/2.0.1/TestFlightFeedback.podspec.json
+++ b/Specs/TestFlightFeedback/2.0.1/TestFlightFeedback.podspec.json
@@ -22,7 +22,9 @@
       ">= 2.0"
     ]
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/TestFlightFeedback/2.1.0/TestFlightFeedback.podspec.json
+++ b/Specs/TestFlightFeedback/2.1.0/TestFlightFeedback.podspec.json
@@ -22,7 +22,9 @@
       ">= 2.0"
     ]
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/TestFlightFeedback/2.1.1/TestFlightFeedback.podspec.json
+++ b/Specs/TestFlightFeedback/2.1.1/TestFlightFeedback.podspec.json
@@ -17,7 +17,9 @@
     "git": "https://github.com/DZamataev/TestFlightFeedback.git",
     "tag": "2.1.1"
   },
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "requires_arc": true,
   "subspecs": [
     {

--- a/Specs/Three20/1.0.11/Three20.podspec.json
+++ b/Specs/Three20/1.0.11/Three20.podspec.json
@@ -87,7 +87,9 @@
   },
   "source_files": "src/Three20/{Sources,Headers}/*.{h,m}",
   "resources": "src/Three20.bundle",
-  "default_subspec": "UI",
+  "default_subspecs": [
+    "UI"
+  ],
   "requires_arc": false,
   "prepare_command": "echo \"This Pod relies on the removed \\`pre_install\\` or \\`post_install\\` hooks and therefore will no longer continue to work. Please try updating to the latest version of this Pod or updating the Pod specification. See http://blog.cocoapods.org/CocoaPods-Trunk/ for more details.\" && exit 1",
   "subspecs": [

--- a/Specs/TwelveTwentyToolkit/0.0.1/TwelveTwentyToolkit.podspec.json
+++ b/Specs/TwelveTwentyToolkit/0.0.1/TwelveTwentyToolkit.podspec.json
@@ -17,7 +17,9 @@
   },
   "source_files": "TwelveTwentyToolkit/TwelveTwentyToolkit.h",
   "requires_arc": true,
-  "default_subspec": "CoreGraphics",
+  "default_subspecs": [
+    "CoreGraphics"
+  ],
   "subspecs": [
     {
       "name": "CoreGraphics",

--- a/Specs/UI7Kit/0.8.10/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.10/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.11/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.11/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.12/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.12/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.13/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.13/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.14/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.14/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.15/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.15/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.16/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.16/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.17/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.17/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.18/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.18/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.19/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.19/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.20/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.20/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.21/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.21/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.22/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.22/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.24/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.24/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.25/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.25/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.26/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.26/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.27/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.27/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.8/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.8/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.8.9/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.8.9/UI7Kit.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.9.10/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.9.10/UI7Kit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.9.11/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.9.11/UI7Kit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.9.12/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.9.12/UI7Kit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.9.13/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.9.13/UI7Kit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.9.14/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.9.14/UI7Kit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.9.16/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.9.16/UI7Kit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.9.17/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.9.17/UI7Kit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.9.18/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.9.18/UI7Kit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.9.2/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.9.2/UI7Kit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.9.3/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.9.3/UI7Kit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.9.4/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.9.4/UI7Kit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.9.5/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.9.5/UI7Kit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.9.6/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.9.6/UI7Kit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.9.7/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.9.7/UI7Kit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.9.8/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.9.8/UI7Kit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.9.9/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.9.9/UI7Kit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UI7Kit/0.9/UI7Kit.podspec.json
+++ b/Specs/UI7Kit/0.9/UI7Kit.podspec.json
@@ -19,7 +19,9 @@
     "ios": "5.0"
   },
   "header_dir": "UI7Kit",
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/UIKitResources/7.0/UIKitResources.podspec.json
+++ b/Specs/UIKitResources/7.0/UIKitResources.podspec.json
@@ -12,7 +12,9 @@
     "git": "https://github.com/youknowone/UIKitResources.git",
     "tag": "7.0"
   },
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/WTGlyphFontSet/0.5/WTGlyphFontSet.podspec.json
+++ b/Specs/WTGlyphFontSet/0.5/WTGlyphFontSet.podspec.json
@@ -18,7 +18,9 @@
     "git": "https://github.com/waterlou/WTGlyphFontSet.git",
     "tag": "0.5"
   },
-  "default_subspec": "core",
+  "default_subspecs": [
+    "core"
+  ],
   "subspecs": [
     {
       "name": "core",

--- a/Specs/WTGlyphFontSet/0.6/WTGlyphFontSet.podspec.json
+++ b/Specs/WTGlyphFontSet/0.6/WTGlyphFontSet.podspec.json
@@ -18,7 +18,9 @@
     "git": "https://github.com/waterlou/WTGlyphFontSet.git",
     "tag": "0.6"
   },
-  "default_subspec": "core",
+  "default_subspecs": [
+    "core"
+  ],
   "subspecs": [
     {
       "name": "core",

--- a/Specs/Wabbly/1.0.0/Wabbly.podspec.json
+++ b/Specs/Wabbly/1.0.0/Wabbly.podspec.json
@@ -18,7 +18,9 @@
     "ios": "7.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/WhirlyGlobe/2.0/WhirlyGlobe.podspec.json
+++ b/Specs/WhirlyGlobe/2.0/WhirlyGlobe.podspec.json
@@ -14,7 +14,9 @@
     "git": "https://github.com/mousebird/WhirlyGlobe.git",
     "tag": "v2.0"
   },
-  "default_subspec": "Component",
+  "default_subspecs": [
+    "Component"
+  ],
   "platforms": {
     "ios": "5.0"
   },

--- a/Specs/WhirlyGlobe/2.1/WhirlyGlobe.podspec.json
+++ b/Specs/WhirlyGlobe/2.1/WhirlyGlobe.podspec.json
@@ -13,7 +13,9 @@
     "git": "https://github.com/mousebird/WhirlyGlobe.git",
     "tag": "v2.1"
   },
-  "default_subspec": "Component",
+  "default_subspecs": [
+    "Component"
+  ],
   "platforms": {
     "ios": "5.0"
   },

--- a/Specs/WorkflowSchema/0.4.0/WorkflowSchema.podspec.json
+++ b/Specs/WorkflowSchema/0.4.0/WorkflowSchema.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "All",

--- a/Specs/WorkflowSchema/0.5.0/WorkflowSchema.podspec.json
+++ b/Specs/WorkflowSchema/0.5.0/WorkflowSchema.podspec.json
@@ -15,7 +15,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "All",

--- a/Specs/XNGAPIClient/0.2.1/XNGAPIClient.podspec.json
+++ b/Specs/XNGAPIClient/0.2.1/XNGAPIClient.podspec.json
@@ -16,7 +16,9 @@
   },
   "requires_arc": true,
   "homepage": "https://www.xing.com",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "subspecs": [
     {
       "name": "Core",

--- a/Specs/YapDatabase/2.4.2/YapDatabase.podspec.json
+++ b/Specs/YapDatabase/2.4.2/YapDatabase.podspec.json
@@ -15,7 +15,9 @@
     "git": "https://github.com/yaptv/YapDatabase.git",
     "tag": "2.4.2"
   },
-  "default_subspec": "standard",
+  "default_subspecs": [
+    "standard"
+  ],
   "requires_arc": true,
   "subspecs": [
     {

--- a/Specs/ZXingObjC/3.0.0/ZXingObjC.podspec.json
+++ b/Specs/ZXingObjC/3.0.0/ZXingObjC.podspec.json
@@ -37,7 +37,9 @@
       "QuartzCore"
     ]
   },
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "All",

--- a/Specs/ZXingObjC/3.0.1/ZXingObjC.podspec.json
+++ b/Specs/ZXingObjC/3.0.1/ZXingObjC.podspec.json
@@ -37,7 +37,9 @@
       "QuartzCore"
     ]
   },
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "subspecs": [
     {
       "name": "All",

--- a/Specs/ZumeroSync/1.0.0.1556/ZumeroSync.podspec.json
+++ b/Specs/ZumeroSync/1.0.0.1556/ZumeroSync.podspec.json
@@ -13,7 +13,9 @@
     "tag": "1.0.0.1556"
   },
   "requires_arc": true,
-  "default_subspec": "SQLite",
+  "default_subspecs": [
+    "SQLite"
+  ],
   "subspecs": [
     {
       "name": "common",

--- a/Specs/ZumeroSync/1.0.1.1596/ZumeroSync.podspec.json
+++ b/Specs/ZumeroSync/1.0.1.1596/ZumeroSync.podspec.json
@@ -13,7 +13,9 @@
     "tag": "1.0.1.1596"
   },
   "requires_arc": true,
-  "default_subspec": "SQLite",
+  "default_subspecs": [
+    "SQLite"
+  ],
   "subspecs": [
     {
       "name": "common",

--- a/Specs/ZumeroSync/1.0.1.1597/ZumeroSync.podspec.json
+++ b/Specs/ZumeroSync/1.0.1.1597/ZumeroSync.podspec.json
@@ -13,7 +13,9 @@
     "tag": "1.0.1.1597"
   },
   "requires_arc": true,
-  "default_subspec": "SQLite",
+  "default_subspecs": [
+    "SQLite"
+  ],
   "subspecs": [
     {
       "name": "common",

--- a/Specs/ZumeroSync/1.1.0.1729/ZumeroSync.podspec.json
+++ b/Specs/ZumeroSync/1.1.0.1729/ZumeroSync.podspec.json
@@ -14,7 +14,9 @@
   },
   "social_media_url": "https://twitter.com/zumero_uno",
   "requires_arc": true,
-  "default_subspec": "SQLite",
+  "default_subspecs": [
+    "SQLite"
+  ],
   "subspecs": [
     {
       "name": "common",

--- a/Specs/ZumeroSync/1.1.1.1749/ZumeroSync.podspec.json
+++ b/Specs/ZumeroSync/1.1.1.1749/ZumeroSync.podspec.json
@@ -14,7 +14,9 @@
   },
   "social_media_url": "https://twitter.com/zumero_uno",
   "requires_arc": true,
-  "default_subspec": "SQLite",
+  "default_subspecs": [
+    "SQLite"
+  ],
   "subspecs": [
     {
       "name": "common",

--- a/Specs/ZumeroSync/1.2.0.1792/ZumeroSync.podspec.json
+++ b/Specs/ZumeroSync/1.2.0.1792/ZumeroSync.podspec.json
@@ -14,7 +14,9 @@
   },
   "social_media_url": "https://twitter.com/zumero_uno",
   "requires_arc": true,
-  "default_subspec": "SQLite",
+  "default_subspecs": [
+    "SQLite"
+  ],
   "subspecs": [
     {
       "name": "common",

--- a/Specs/ZumeroSync/1.2.0.1800/ZumeroSync.podspec.json
+++ b/Specs/ZumeroSync/1.2.0.1800/ZumeroSync.podspec.json
@@ -14,7 +14,9 @@
   },
   "social_media_url": "https://twitter.com/zumero_uno",
   "requires_arc": true,
-  "default_subspec": "SQLite",
+  "default_subspecs": [
+    "SQLite"
+  ],
   "subspecs": [
     {
       "name": "common",

--- a/Specs/ZumeroSync/1.3.0.1880/ZumeroSync.podspec.json
+++ b/Specs/ZumeroSync/1.3.0.1880/ZumeroSync.podspec.json
@@ -14,7 +14,9 @@
   },
   "social_media_url": "https://twitter.com/zumero_uno",
   "requires_arc": true,
-  "default_subspec": "SQLite",
+  "default_subspecs": [
+    "SQLite"
+  ],
   "subspecs": [
     {
       "name": "common",

--- a/Specs/cocos2d/1.1.rc0/cocos2d.podspec.json
+++ b/Specs/cocos2d/1.1.rc0/cocos2d.podspec.json
@@ -16,7 +16,9 @@
     "git": "https://github.com/cocos2d/cocos2d-iphone.git",
     "commit": "7ee5b9abf645c32379a45317986a308204277bb1"
   },
-  "default_subspec": "cocos2d",
+  "default_subspecs": [
+    "cocos2d"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/iOS-FakeWeb/0.1.0/iOS-FakeWeb.podspec.json
+++ b/Specs/iOS-FakeWeb/0.1.0/iOS-FakeWeb.podspec.json
@@ -15,7 +15,9 @@
     "ios": null
   },
   "requires_arc": true,
-  "default_subspec": "NSURLConnection",
+  "default_subspecs": [
+    "NSURLConnection"
+  ],
   "subspecs": [
     {
       "name": "NSURLConnection",

--- a/Specs/iOS-FakeWeb/0.1.1/iOS-FakeWeb.podspec.json
+++ b/Specs/iOS-FakeWeb/0.1.1/iOS-FakeWeb.podspec.json
@@ -15,7 +15,9 @@
     "ios": null
   },
   "requires_arc": true,
-  "default_subspec": "NSURLConnection",
+  "default_subspecs": [
+    "NSURLConnection"
+  ],
   "subspecs": [
     {
       "name": "NSURLConnection",

--- a/Specs/iOSBlocks/1.1/iOSBlocks.podspec.json
+++ b/Specs/iOSBlocks/1.1/iOSBlocks.podspec.json
@@ -18,7 +18,9 @@
     "ios": "5.0"
   },
   "requires_arc": true,
-  "default_subspec": "UIKit",
+  "default_subspecs": [
+    "UIKit"
+  ],
   "header_mappings_dir": "Source",
   "subspecs": [
     {

--- a/Specs/iPhoneMK/1.2.1/iPhoneMK.podspec.json
+++ b/Specs/iPhoneMK/1.2.1/iPhoneMK.podspec.json
@@ -21,7 +21,9 @@
     "AVFoundation",
     "QuartzCore"
   ],
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/iPhoneMK/1.2.2/iPhoneMK.podspec.json
+++ b/Specs/iPhoneMK/1.2.2/iPhoneMK.podspec.json
@@ -21,7 +21,9 @@
     "AVFoundation",
     "QuartzCore"
   ],
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/iPhoneMK/1.2.3/iPhoneMK.podspec.json
+++ b/Specs/iPhoneMK/1.2.3/iPhoneMK.podspec.json
@@ -21,7 +21,9 @@
     "AVFoundation",
     "QuartzCore"
   ],
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/iPhoneMK/1.4.0/iPhoneMK.podspec.json
+++ b/Specs/iPhoneMK/1.4.0/iPhoneMK.podspec.json
@@ -21,7 +21,9 @@
     "AVFoundation",
     "QuartzCore"
   ],
-  "default_subspec": "All",
+  "default_subspecs": [
+    "All"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/jre_emul/0.7.2/jre_emul.podspec.json
+++ b/Specs/jre_emul/0.7.2/jre_emul.podspec.json
@@ -12,7 +12,9 @@
     "git": "https://github.com/goodow/j2objc.git",
     "tag": "v0.7.2"
   },
-  "default_subspec": "jre",
+  "default_subspecs": [
+    "jre"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/jre_emul/0.8.5/jre_emul.podspec.json
+++ b/Specs/jre_emul/0.8.5/jre_emul.podspec.json
@@ -12,7 +12,9 @@
     "git": "https://github.com/goodow/j2objc.git",
     "tag": "v0.8.5"
   },
-  "default_subspec": "jre",
+  "default_subspecs": [
+    "jre"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/jre_emul/0.8.6.1/jre_emul.podspec.json
+++ b/Specs/jre_emul/0.8.6.1/jre_emul.podspec.json
@@ -17,7 +17,9 @@
     "osx": "10.8"
   },
   "requires_arc": false,
-  "default_subspec": "jre",
+  "default_subspecs": [
+    "jre"
+  ],
   "subspecs": [
     {
       "name": "jre",

--- a/Specs/libPusher/1.5/libPusher.podspec.json
+++ b/Specs/libPusher/1.5/libPusher.podspec.json
@@ -11,7 +11,9 @@
   },
   "requires_arc": true,
   "header_dir": "Pusher",
-  "default_subspec": "Core",
+  "default_subspecs": [
+    "Core"
+  ],
   "platforms": {
     "ios": "5.0",
     "osx": "10.8"

--- a/Specs/mopub-ios-sdk/2.1.0/mopub-ios-sdk.podspec.json
+++ b/Specs/mopub-ios-sdk/2.1.0/mopub-ios-sdk.podspec.json
@@ -36,7 +36,9 @@
     "StoreKit"
   ],
   "requires_arc": false,
-  "default_subspec": "MoPubSDK",
+  "default_subspecs": [
+    "MoPubSDK"
+  ],
   "subspecs": [
     {
       "name": "MoPubSDK",

--- a/Specs/spatialite/4.1.0/spatialite.podspec.json
+++ b/Specs/spatialite/4.1.0/spatialite.podspec.json
@@ -32,7 +32,9 @@
   "public_header_files": "src/headers/**/*.h",
   "private_header_files": "src/headers/spatialite_private.h",
   "header_mappings_dir": "src/headers/",
-  "default_subspec": "standard",
+  "default_subspecs": [
+    "standard"
+  ],
   "libraries": [
     "z",
     "iconv"

--- a/Specs/spatialite/4.1.1/spatialite.podspec.json
+++ b/Specs/spatialite/4.1.1/spatialite.podspec.json
@@ -33,7 +33,9 @@
   "public_header_files": "src/headers/**/*.h",
   "private_header_files": "src/headers/spatialite_private.h",
   "header_mappings_dir": "src/headers/",
-  "default_subspec": "standard",
+  "default_subspecs": [
+    "standard"
+  ],
   "prepare_command": "./configure --enable-geos=no --enable-proj=no --enable-freexl=no\n \ncat >> ./config.h <<CONFIG_H\n\n#undef OMIT_GEOS\n#undef OMIT_PROJ\n\n// this is disabled since something is going wrong while linking for i386 architecture\n#undef GEOS_ADVANCED\n\nCONFIG_H\n",
   "libraries": [
     "z",

--- a/Specs/sqlite3/3.7.17.0/sqlite3.podspec.json
+++ b/Specs/sqlite3/3.7.17.0/sqlite3.podspec.json
@@ -10,7 +10,9 @@
   "source": {
     "http": "http://www.sqlite.org/2013/sqlite-amalgamation-3071700.zip"
   },
-  "default_subspec": "common",
+  "default_subspecs": [
+    "common"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/sqlite3/3.8.0.2/sqlite3.podspec.json
+++ b/Specs/sqlite3/3.8.0.2/sqlite3.podspec.json
@@ -10,7 +10,9 @@
   "source": {
     "http": "http://www.sqlite.org/2013/sqlite-amalgamation-3080002.zip"
   },
-  "default_subspec": "common",
+  "default_subspecs": [
+    "common"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/sqlite3/3.8.0/sqlite3.podspec.json
+++ b/Specs/sqlite3/3.8.0/sqlite3.podspec.json
@@ -10,7 +10,9 @@
   "source": {
     "http": "http://www.sqlite.org/2013/sqlite-amalgamation-3080000.zip"
   },
-  "default_subspec": "common",
+  "default_subspecs": [
+    "common"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/sqlite3/3.8.1/sqlite3.podspec.json
+++ b/Specs/sqlite3/3.8.1/sqlite3.podspec.json
@@ -10,7 +10,9 @@
   "source": {
     "http": "http://www.sqlite.org/2013/sqlite-amalgamation-3080100.zip"
   },
-  "default_subspec": "common",
+  "default_subspecs": [
+    "common"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/sqlite3/3.8.4.1/sqlite3.podspec.json
+++ b/Specs/sqlite3/3.8.4.1/sqlite3.podspec.json
@@ -10,7 +10,9 @@
   "source": {
     "http": "http://www.sqlite.org/2014/sqlite-amalgamation-3080401.zip"
   },
-  "default_subspec": "common",
+  "default_subspecs": [
+    "common"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/sqlite3/3.8.4.2/sqlite3.podspec.json
+++ b/Specs/sqlite3/3.8.4.2/sqlite3.podspec.json
@@ -10,7 +10,9 @@
   "source": {
     "http": "http://www.sqlite.org/2014/sqlite-amalgamation-3080402.zip"
   },
-  "default_subspec": "common",
+  "default_subspecs": [
+    "common"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/sqlite3/3.8.4.3/sqlite3.podspec.json
+++ b/Specs/sqlite3/3.8.4.3/sqlite3.podspec.json
@@ -10,7 +10,9 @@
   "source": {
     "http": "http://www.sqlite.org/2014/sqlite-amalgamation-3080403.zip"
   },
-  "default_subspec": "common",
+  "default_subspecs": [
+    "common"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/sqlite3/3.8.5/sqlite3.podspec.json
+++ b/Specs/sqlite3/3.8.5/sqlite3.podspec.json
@@ -10,7 +10,9 @@
   "source": {
     "http": "http://www.sqlite.org/2014/sqlite-amalgamation-3080500.zip"
   },
-  "default_subspec": "common",
+  "default_subspecs": [
+    "common"
+  ],
   "requires_arc": false,
   "subspecs": [
     {

--- a/Specs/sqlite3/3.8.6/sqlite3.podspec.json
+++ b/Specs/sqlite3/3.8.6/sqlite3.podspec.json
@@ -10,7 +10,9 @@
   "source": {
     "http": "http://www.sqlite.org/2014/sqlite-amalgamation-3080600.zip"
   },
-  "default_subspec": "common",
+  "default_subspecs": [
+    "common"
+  ],
   "requires_arc": false,
   "subspecs": [
     {


### PR DESCRIPTION
…ault_subspecs

@kylef you're changing adding the plural broke this about 20 months ago. Please review @keith.

---

Done with the following script:

``` ruby
#!/usr/bin/env ruby

require 'bundler/inline'

gemfile do
    gem 'cocoapods'
    gem 'json'
end

master = Pod::SourcesManager.master.first
pods = master.pods
pod_versions = pods.flat_map { |p| master.versions(p).map { |v| [p,v] }}
paths = pod_versions.map { |p, v| master.specification_path(p, v) }

paths.each do |path|
    contents = path.read
    next unless contents.gsub!(/default_subspec":\s*"(.*)"/, 'default_subspecs": ["\1"]')
    contents = JSON.pretty_generate(JSON.load(contents)) << "\n"
    path.open('w') { |f| f << contents }
end
```
