### PR TITLE
Rename pod “NuimoSwift” to “Nuimo”

### DIFF
--- a/Specs/Nuimo/0.0.1/Nuimo.podspec.json
+++ b/Specs/Nuimo/0.0.1/Nuimo.podspec.json
@@ -1,5 +1,5 @@
 {
-  "name": "NuimoSwift",
+  "name": "Nuimo",
   "version": "0.0.1",
   "summary": "Swift library for connecting and communicating with Senic's Nuimo controllers",
   "description": "Swift library for connecting and communicating with Senic's Nuimo controllers\n\n* Discover and connect Nuimo controllers via bluetooth low energy or websockets\n* Receive user gestures from Nuimo controllers\n* Send LED matrices to Nuimo controllers",

--- a/Specs/Nuimo/0.1.0/Nuimo.podspec.json
+++ b/Specs/Nuimo/0.1.0/Nuimo.podspec.json
@@ -1,5 +1,5 @@
 {
-  "name": "NuimoSwift",
+  "name": "Nuimo",
   "version": "0.1.0",
   "summary": "Swift library for connecting and communicating with Senic's Nuimo controllers",
   "description": "Swift library for connecting and communicating with Senic's Nuimo controllers\n* Discover and connect Nuimo controllers via bluetooth low energy or websockets\n* Receive user gestures from Nuimo controllers\n* Send LED matrices to Nuimo controllers",

--- a/Specs/Nuimo/0.1.1/Nuimo.podspec.json
+++ b/Specs/Nuimo/0.1.1/Nuimo.podspec.json
@@ -1,6 +1,6 @@
 {
-  "name": "NuimoSwift",
-  "version": "0.2.0",
+  "name": "Nuimo",
+  "version": "0.1.1",
   "summary": "Swift library for connecting and communicating with Senic's Nuimo controllers",
   "description": "Swift library for connecting and communicating with Senic's Nuimo controllers\n* Discover and connect Nuimo controllers via bluetooth low energy or websockets\n* Receive user gestures from Nuimo controllers\n* Send LED matrices to Nuimo controllers",
   "documentation_url": "https://github.com/getSenic/nuimo-swift",
@@ -19,7 +19,7 @@
   },
   "source": {
     "git": "https://github.com/getSenic/nuimo-swift.git",
-    "tag": "0.2.0"
+    "tag": "0.1.1"
   },
   "frameworks": "CoreBluetooth",
   "default_subspecs": "Core",

--- a/Specs/Nuimo/0.2.0/Nuimo.podspec.json
+++ b/Specs/Nuimo/0.2.0/Nuimo.podspec.json
@@ -1,6 +1,6 @@
 {
-  "name": "NuimoSwift",
-  "version": "0.1.1",
+  "name": "Nuimo",
+  "version": "0.2.0",
   "summary": "Swift library for connecting and communicating with Senic's Nuimo controllers",
   "description": "Swift library for connecting and communicating with Senic's Nuimo controllers\n* Discover and connect Nuimo controllers via bluetooth low energy or websockets\n* Receive user gestures from Nuimo controllers\n* Send LED matrices to Nuimo controllers",
   "documentation_url": "https://github.com/getSenic/nuimo-swift",
@@ -19,7 +19,7 @@
   },
   "source": {
     "git": "https://github.com/getSenic/nuimo-swift.git",
-    "tag": "0.1.1"
+    "tag": "0.2.0"
   },
   "frameworks": "CoreBluetooth",
   "default_subspecs": "Core",


### PR DESCRIPTION
I would like to rename my pod “NuimoSwift” to “Nuimo”. There is no known user of that pod yet as this pod is only going to be announced to the public soon.
