### PR TITLE
configured resource files to Beaconstac Pod

### DIFF
--- a/Specs/Beaconstac/1.3/Beaconstac.podspec.json
+++ b/Specs/Beaconstac/1.3/Beaconstac.podspec.json
@@ -21,6 +21,7 @@
     "CoreBluetooth",
     "CoreLocation"
   ],
+  "resource": "BeaconstacSDK/Beaconstac.framework/Versions/1.3/Resources/BeaconstacData.bundle",
   "requires_arc": true,
   "platforms": {
     "ios": "7.1"


### PR DESCRIPTION
Forgot to bundle files in the first podspec leading to crashes. As a good practice I was hoping to keep the cocoapod version same as that of the version release number hence want an update on the current one only, which is not possible in trunk without bumping up the version number.
