### PR TITLE
updated typo error in resources podspec json for Beaconstac

### DIFF
--- a/Specs/Beaconstac/1.3/Beaconstac.podspec.json
+++ b/Specs/Beaconstac/1.3/Beaconstac.podspec.json
@@ -21,7 +21,7 @@
     "CoreBluetooth",
     "CoreLocation"
   ],
-  "resource": "BeaconstacSDK/Beaconstac.framework/Versions/1.3/Resources/BeaconstacData.bundle",
+  "resources": "BeaconstacSDK/Beaconstac.framework/Versions/1.3/Resources/BeaconstacData.bundle",
   "requires_arc": true,
   "platforms": {
     "ios": "7.1"


### PR DESCRIPTION
The syntax in the podspec and that in the json is different which led to the typo error. It's crucial for us to maintain a podspec version and release version same hence the request.
