### PR TITLE
:head

### DIFF
--- a/Specs/EGOImageLoading/0.0.1/EGOImageLoading.podspec.json
+++ b/Specs/EGOImageLoading/0.0.1/EGOImageLoading.podspec.json
@@ -10,7 +10,7 @@
   "authors": "Shaun Harrison",
   "source": {
     "git": "https://github.com/enormego/EGOImageLoading.git",
-    "commit": "9a3fa6b657c6b8217a24ff87c1fe4f670401f3bd"
+    "commit": "4f4e6a626ef518d59dd38f5e69b835365f5a4830"
   },
   "source_files": "EGO*/*.{h,m}",
   "dependencies": {


### PR DESCRIPTION
A crash fix was made 4 years ago and then maintainer left without changing podspec. With cocoapods 0.39.0 we could use `:head`, but with cocoapods 1.0.0 we need to update podspec.
