### PR TITLE
Fix MTLManagedObjectAdapter version so apple accepts app submission

### DIFF
--- a/Specs/MTLManagedObjectAdapter/1.0.1/MTLManagedObjectAdapter.podspec.json
+++ b/Specs/MTLManagedObjectAdapter/1.0.1/MTLManagedObjectAdapter.podspec.json
@@ -1,0 +1,38 @@
+{
+  "name": "MTLManagedObjectAdapter",
+  "version": "1.0.1",
+  "license": "MIT",
+  "summary": "Model framework for Cocoa and Cocoa Touch.",
+  "homepage": "https://github.com/Mantle/Mantle",
+  "authors": {
+    "GitHub": "support@github.com"
+  },
+  "source": {
+    "git": "https://github.com/Overcoat/MTLManagedObjectAdapter.git",
+    "tag": "1.0.0.1"
+  },
+  "requires_arc": true,
+  "platforms": {
+    "ios": "5.0",
+    "osx": "10.7",
+    "watchos": "2.0"
+  },
+  "source_files": "MTLManagedObjectAdapter",
+  "dependencies": {
+    "Mantle": [
+      "~> 2.0"
+    ]
+  },
+  "frameworks": [
+    "Foundation",
+    "CoreData"
+  ],
+  "prepare_command": "PREFIX=\"mtl_moa_\"\n# Add prefix to header imports\next_header_prefix_src() {\n  SOURCE_FILE=$1\n  EXT_HEADER_NAME=$2\n  sed -i.bak \"s/\"${EXT_HEADER_NAME}\"/\"${PREFIX}${EXT_HEADER_NAME}\"/g\" ${SOURCE_FILE} && rm ${SOURCE_FILE}.bak\n}\next_header_prefix_src MTLManagedObjectAdapter/MTLManagedObjectAdapter.m EXTRuntimeExtensions.h\next_header_prefix_src MTLManagedObjectAdapter/MTLManagedObjectAdapter.m EXTScope.h\next_header_prefix_src MTLManagedObjectAdapter/extobjc/EXTRuntimeExtensions.m EXTRuntimeExtensions.h\next_header_prefix_src MTLManagedObjectAdapter/extobjc/EXTScope.m EXTScope.h\n# Change header name\next_header_prefix_mv() {\n  SOURCE_FILE=$1\n  FILE_NAME=`basename ${SOURCE_FILE}`\n  DIR_NAME=`dirname ${SOURCE_FILE}`\n  mv ${SOURCE_FILE} `dirname ${SOURCE_FILE}`/${PREFIX}`basename ${SOURCE_FILE}`\n}\nexport -f ext_header_prefix_mv\nexport PREFIX=${PREFIX}\nfind MTLManagedObjectAdapter/extobjc -name \"*.h\" -exec bash -c 'ext_header_prefix_mv \"$0\"' {} \\;\nunset ext_header_prefix_mv\nunset PREFIX",
+  "subspecs": [
+    {
+      "name": "extobjc",
+      "source_files": "MTLManagedObjectAdapter/extobjc",
+      "private_header_files": "MTLManagedObjectAdapter/extobjc/*.h"
+    }
+  ]
+}


### PR DESCRIPTION
Update MTLManagedObjectAdapter version, because otherwise an app using this framework can't be submitted. Check Mantle/MTLManagedObjectAdapter#18
