### PR TITLE
AudioKit repo URL updates for past versions

### DIFF
--- a/Specs/AudioKit/2.0.1/AudioKit.podspec.json
+++ b/Specs/AudioKit/2.0.1/AudioKit.podspec.json
@@ -9,7 +9,7 @@
   },
   "homepage": "http://audiokit.io/",
   "source": {
-    "git": "https://github.com/audiokit/AudioKit.git",
+    "git": "https://github.com/audiokit/AudioKitArchive.git",
     "tag": "v2.0.1-04-07-2015"
   },
   "summary": "Open-source audio synthesis, processing, & analysis platform.",

--- a/Specs/AudioKit/2.0/AudioKit.podspec.json
+++ b/Specs/AudioKit/2.0/AudioKit.podspec.json
@@ -9,7 +9,7 @@
   },
   "homepage": "http://audiokit.io/",
   "source": {
-    "git": "https://github.com/audiokit/AudioKit.git",
+    "git": "https://github.com/audiokit/AudioKitArchive.git",
     "tag": "v2.0-03-26-2015"
   },
   "summary": "Open-source audio synthesis, processing, & analysis platform.",

--- a/Specs/AudioKit/2.1.1/AudioKit.podspec.json
+++ b/Specs/AudioKit/2.1.1/AudioKit.podspec.json
@@ -9,7 +9,7 @@
   },
   "homepage": "http://audiokit.io/",
   "source": {
-    "git": "https://github.com/audiokit/AudioKit.git",
+    "git": "https://github.com/audiokit/AudioKitArchive.git",
     "tag": "v2.1.1-05-06-2015"
   },
   "summary": "Open-source audio synthesis, processing, & analysis platform.",

--- a/Specs/AudioKit/2.2/AudioKit.podspec.json
+++ b/Specs/AudioKit/2.2/AudioKit.podspec.json
@@ -9,7 +9,7 @@
   },
   "homepage": "http://audiokit.io/",
   "source": {
-    "git": "https://github.com/audiokit/AudioKit.git",
+    "git": "https://github.com/audiokit/AudioKitArchive.git",
     "tag": "v2.2-08-23-2015"
   },
   "summary": "Open-source audio synthesis, processing, & analysis platform.",

--- a/Specs/AudioKit/2.3/AudioKit.podspec.json
+++ b/Specs/AudioKit/2.3/AudioKit.podspec.json
@@ -9,7 +9,7 @@
   },
   "homepage": "http://audiokit.io/",
   "source": {
-    "git": "https://github.com/audiokit/AudioKit.git",
+    "git": "https://github.com/audiokit/AudioKitArchive.git",
     "tag": "v2.3"
   },
   "summary": "Open-source audio synthesis, processing, & analysis platform.",


### PR DESCRIPTION
We moved the source code for the AudioKit library to a different repo since AudioKit 3.0 started development from scratch and took over the old repo. Without these updates, the current pod is not functional.

This pull request simply updates the repo URLs for AudioKit 2.x pod specs.
