### PR TITLE
source_files spec should be updated

### DIFF
--- a/Specs/FastImageCache/1.5/FastImageCache.podspec.json
+++ b/Specs/FastImageCache/1.5/FastImageCache.podspec.json
@@ -19,6 +19,6 @@
     "git": "https://github.com/path/FastImageCache.git",
     "tag": "1.5"
   },
-  "source_files": "FastImageCache/FastImageCache",
+  "source_files": [ "FastImageCache/FastImageCache", "FastImageCache/FastImageCache/FastImageCache/*.[hm]" ],
   "requires_arc": true
 }


### PR DESCRIPTION
After introducing umbrella header FastImageCache.h it looks like spec for source_files is incomplete. Actual implementation files aren't got fetched after **pod install** invocation.
