### PR TITLE
Fix - AlamofireImage 2.3.1 pod dependency

### DIFF
--- a/Specs/AlamofireImage/2.3.1/AlamofireImage.podspec.json
+++ b/Specs/AlamofireImage/2.3.1/AlamofireImage.podspec.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "Alamofire": [
-      "~> 3.1"
+      "~> 3.2"
     ]
   }
 }


### PR DESCRIPTION
I forgot to bump the Alamofire dependency requirement for the AlamofireImage 2.3.1 release. This small change updates the dependency to the version it should have been originally.

Also, it would be AMAZING if `pod trunk update` existed to avoid having to do this through a PR.
