### PR TITLE
Fix screenshots WARN

### DIFF
--- a/Specs/YBSlantedCollectionViewLayout/1.0.0/YBSlantedCollectionViewLayout.podspec.json
+++ b/Specs/YBSlantedCollectionViewLayout/1.0.0/YBSlantedCollectionViewLayout.podspec.json
@@ -4,7 +4,6 @@
   "summary": "UICollectionViewLayout allowing the display of slanted content on UICollectionView",
   "description": "YBSlantedCollectionViewLayout is a subclass of UICollectionViewLayout allowing the display of slanted content on UICollectionView.",
   "homepage": "https://github.com/yacir/YBSlantedCollectionViewLayout",
-  "screenshots": "https://raw.githubusercontent.com/yacir/YBSlantedCollectionViewLayout/master/Screenshots/YBSlantedCollectionViewLayout.gif",
   "license": "MIT",
   "authors": {
     "Yassir Barchi": "dev.yassir@gmail.com"


### PR DESCRIPTION
Because of this issue, users can't expand for more details. They are automatically redirected to the Github repository :/.

![capture d ecran 2016-03-01 a 16 41 19](https://cloud.githubusercontent.com/assets/2587473/13432107/7d8f118a-dfcc-11e5-8fea-6cb99abd9d5e.png)
