### PR TITLE
Update zziplib to fetch the proper library

### DIFF
--- a/Specs/zziplib/0.13.62/zziplib.podspec.json
+++ b/Specs/zziplib/0.13.62/zziplib.podspec.json
@@ -12,7 +12,7 @@
     "Tomi Ollila": "too@iki.fi"
   },
   "source": {
-    "http": "http://freefr.dl.sourceforge.net/project/zziplib/zziplib13/0.13.59/zziplib-0.13.59.tar.bz2"
+    "http": "http://freefr.dl.sourceforge.net/project/zziplib/zziplib13/0.13.62/zziplib-0.13.62.tar.bz2"
   },
   "requires_arc": false,
   "platforms": {


### PR DESCRIPTION
By mistake I pushed the 1st version of this spec with the wrong library source; please update. Thank you
