### PR TITLE
Add podspecs for Helpshift SDK version 5.5.1

### DIFF
--- a/Helpshift/5.5.0bitcode/Helpshift.podspec
+++ b/Helpshift/5.5.0bitcode/Helpshift.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name                = 'Helpshift'
+  s.version             = '5.5.0-bitcode'
+  s.summary             = 'Customer service helpdesk for mobile applications.'
+  s.license             = { :type => 'Commercial', :text => 'See http://www.helpshift.com/terms/' }
+  s.homepage            = 'http://www.helpshift.com/'
+  s.author              = { 'Helpshift' => 'support@helpshift.com' }
+  s.source              = { :http => 'https://d3e51fp79zp4el.cloudfront.net/library/ios/v5.5/helpshift-sdk-ios-v5.5.0.zip', :type => :zip}
+  s.platform            = :ios, '7.0'
+  s.source_files        = 'helpshift-sdk-ios-v5.5.0/*.h'
+  s.resources           = ["helpshift-sdk-ios-v5.5.0/HsUIResourceBundle.bundle", "helpshift-sdk-ios-v5.5.0/HSLocalization/*.lproj", "helpshift-sdk-ios-v5.5.0/HSThemes/*.plist"]
+  s.preserve_paths      = 'helpshift-sdk-ios-v5.5.0/libHelpshift-bitcode.a', 'helpshift-sdk-ios-v5.5.0/HSLocalization/*.lproj', 'helpshift-sdk-ios-v5.5.0/HSThemes/*.plist'
+  s.frameworks          = 'CoreGraphics', 'QuartzCore', 'CoreText', 'SystemConfiguration', 'CoreTelephony', 'Foundation', 'UIKit', 'Security', 'QuickLook', 'CoreLocation', 'MobileCoreServices', 'CoreSpotlight'
+  s.libraries           = 'sqlite3.0', 'z', 'Helpshift-bitcode'
+  s.xcconfig            = {'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Helpshift/helpshift-sdk-ios-v5.5.0"'}
+  s.documentation_url   = 'http://developers.helpshift.com/ios/'
+  s.requires_arc        = false
+end

--- a/Helpshift/5.5.0xcode6/Helpshift.podspec
+++ b/Helpshift/5.5.0xcode6/Helpshift.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name                = 'Helpshift'
+  s.version             = '5.5.0-xcode6'
+  s.summary             = 'Customer service helpdesk for mobile applications.'
+  s.license             = { :type => 'Commercial', :text => 'See http://www.helpshift.com/terms/' }
+  s.homepage            = 'http://www.helpshift.com/'
+  s.author              = { 'Helpshift' => 'support@helpshift.com' }
+  s.source              = { :http => 'https://d3e51fp79zp4el.cloudfront.net/library/ios/v5.5/helpshift-sdk-ios-v5.5.0.zip', :type => :zip}
+  s.platform            = :ios, '7.0'
+  s.source_files        = 'helpshift-sdk-ios-v5.5.0/*.h'
+  s.resources           = ["helpshift-sdk-ios-v5.5.0/HsUIResourceBundle.bundle", "helpshift-sdk-ios-v5.5.0/HSLocalization/*.lproj", "helpshift-sdk-ios-v5.5.0/HSThemes/*.plist"]
+  s.preserve_paths      = 'helpshift-sdk-ios-v5.5.0/libHelpshift-xcode6.a', 'helpshift-sdk-ios-v5.5.0/HSLocalization/*.lproj', 'helpshift-sdk-ios-v5.5.0/HSThemes/*.plist'
+  s.frameworks          = 'CoreGraphics', 'QuartzCore', 'CoreText', 'SystemConfiguration', 'CoreTelephony', 'Foundation', 'UIKit', 'Security', 'QuickLook', 'CoreLocation', 'MobileCoreServices', 'CoreSpotlight'
+  s.libraries           = 'sqlite3.0', 'z', 'Helpshift-xcode6'
+  s.xcconfig            = {'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Helpshift/helpshift-sdk-ios-v5.5.0"'}
+  s.documentation_url   = 'http://developers.helpshift.com/ios/'
+  s.requires_arc        = false
+end

--- a/Helpshift/5.5.1/Helpshift.podspec
+++ b/Helpshift/5.5.1/Helpshift.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name                = 'Helpshift'
+  s.version             = '5.5.1'
+  s.summary             = 'Customer service helpdesk for mobile applications.'
+  s.license             = { :type => 'Commercial', :text => 'See http://www.helpshift.com/terms/' }
+  s.homepage            = 'http://www.helpshift.com/'
+  s.author              = { 'Helpshift' => 'support@helpshift.com' }
+  s.source              = { :http => 'https://d3e51fp79zp4el.cloudfront.net/library/ios/v5.5/helpshift-sdk-ios-v5.5.1.zip', :type => :zip}
+  s.platform            = :ios, '7.0'
+  s.source_files        = 'helpshift-sdk-ios-v5.5.1/*.h'
+  s.resources           = ["helpshift-sdk-ios-v5.5.1/HsUIResourceBundle.bundle", "helpshift-sdk-ios-v5.5.1/HSLocalization/*.lproj", "helpshift-sdk-ios-v5.5.1/HSThemes/*.plist"]
+  s.preserve_paths      = 'helpshift-sdk-ios-v5.5.1/libHelpshift.a', 'helpshift-sdk-ios-v5.5.1/HSLocalization/*.lproj', 'helpshift-sdk-ios-v5.5.1/HSThemes/*.plist'
+  s.frameworks          = 'CoreGraphics', 'QuartzCore', 'CoreText', 'SystemConfiguration', 'CoreTelephony', 'Foundation', 'UIKit', 'Security', 'QuickLook', 'CoreLocation', 'MobileCoreServices', 'CoreSpotlight'
+  s.libraries           = 'sqlite3.0', 'z', 'Helpshift'
+  s.xcconfig            = {'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Helpshift/helpshift-sdk-ios-v5.5.1"'}
+  s.documentation_url   = 'http://developers.helpshift.com/ios/'
+  s.requires_arc        = false
+end

--- a/Helpshift/5.5.1bitcode/Helpshift.podspec
+++ b/Helpshift/5.5.1bitcode/Helpshift.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name                = 'Helpshift'
+  s.version             = '5.5.1-bitcode'
+  s.summary             = 'Customer service helpdesk for mobile applications.'
+  s.license             = { :type => 'Commercial', :text => 'See http://www.helpshift.com/terms/' }
+  s.homepage            = 'http://www.helpshift.com/'
+  s.author              = { 'Helpshift' => 'support@helpshift.com' }
+  s.source              = { :http => 'https://d3e51fp79zp4el.cloudfront.net/library/ios/v5.5/helpshift-sdk-ios-v5.5.1.zip', :type => :zip}
+  s.platform            = :ios, '7.0'
+  s.source_files        = 'helpshift-sdk-ios-v5.5.1/*.h'
+  s.resources           = ["helpshift-sdk-ios-v5.5.1/HsUIResourceBundle.bundle", "helpshift-sdk-ios-v5.5.1/HSLocalization/*.lproj", "helpshift-sdk-ios-v5.5.1/HSThemes/*.plist"]
+  s.preserve_paths      = 'helpshift-sdk-ios-v5.5.1/libHelpshift-bitcode.a', 'helpshift-sdk-ios-v5.5.1/HSLocalization/*.lproj', 'helpshift-sdk-ios-v5.5.1/HSThemes/*.plist'
+  s.frameworks          = 'CoreGraphics', 'QuartzCore', 'CoreText', 'SystemConfiguration', 'CoreTelephony', 'Foundation', 'UIKit', 'Security', 'QuickLook', 'CoreLocation', 'MobileCoreServices', 'CoreSpotlight'
+  s.libraries           = 'sqlite3.0', 'z', 'Helpshift-bitcode'
+  s.xcconfig            = {'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Helpshift/helpshift-sdk-ios-v5.5.1"'}
+  s.documentation_url   = 'http://developers.helpshift.com/ios/'
+  s.requires_arc        = false
+end

--- a/Helpshift/5.5.1xcode6/Helpshift.podspec
+++ b/Helpshift/5.5.1xcode6/Helpshift.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name                = 'Helpshift'
+  s.version             = '5.5.1-xcode6'
+  s.summary             = 'Customer service helpdesk for mobile applications.'
+  s.license             = { :type => 'Commercial', :text => 'See http://www.helpshift.com/terms/' }
+  s.homepage            = 'http://www.helpshift.com/'
+  s.author              = { 'Helpshift' => 'support@helpshift.com' }
+  s.source              = { :http => 'https://d3e51fp79zp4el.cloudfront.net/library/ios/v5.5/helpshift-sdk-ios-v5.5.1.zip', :type => :zip}
+  s.platform            = :ios, '7.0'
+  s.source_files        = 'helpshift-sdk-ios-v5.5.1/*.h'
+  s.resources           = ["helpshift-sdk-ios-v5.5.1/HsUIResourceBundle.bundle", "helpshift-sdk-ios-v5.5.1/HSLocalization/*.lproj", "helpshift-sdk-ios-v5.5.1/HSThemes/*.plist"]
+  s.preserve_paths      = 'helpshift-sdk-ios-v5.5.1/libHelpshift-xcode6.a', 'helpshift-sdk-ios-v5.5.1/HSLocalization/*.lproj', 'helpshift-sdk-ios-v5.5.1/HSThemes/*.plist'
+  s.frameworks          = 'CoreGraphics', 'QuartzCore', 'CoreText', 'SystemConfiguration', 'CoreTelephony', 'Foundation', 'UIKit', 'Security', 'QuickLook', 'CoreLocation', 'MobileCoreServices', 'CoreSpotlight'
+  s.libraries           = 'sqlite3.0', 'z', 'Helpshift-xcode6'
+  s.xcconfig            = {'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/Helpshift/helpshift-sdk-ios-v5.5.1"'}
+  s.documentation_url   = 'http://developers.helpshift.com/ios/'
+  s.requires_arc        = false
+end


### PR DESCRIPTION
Since pod trunk push cant update an existing podspec, opening a pull request to merge the updated podpsec for version 5.5.0 and 5.5.1
