### PR TITLE
Deprecate old versions of LayoutKit

### DIFF
--- a/Specs/LayoutKit/0.2.0/LayoutKit.podspec.json
+++ b/Specs/LayoutKit/0.2.0/LayoutKit.podspec.json
@@ -19,5 +19,6 @@
   "source_files": "Classes",
   "resources": "Assets",
   "public_header_files": "Classes/**/*.h",
-  "frameworks": "UIKit"
+  "frameworks": "UIKit",
+  "deprecated": true
 }

--- a/Specs/LayoutKit/0.2.1/LayoutKit.podspec.json
+++ b/Specs/LayoutKit/0.2.1/LayoutKit.podspec.json
@@ -19,5 +19,6 @@
   "source_files": "Classes",
   "resources": "Assets",
   "public_header_files": "Classes/**/*.h",
-  "frameworks": "UIKit"
+  "frameworks": "UIKit",
+  "deprecated": true
 }


### PR DESCRIPTION
It doesn't look like it is possible to do this via `pod trunk deprecate` command (it doesn't take a version argument).
