### PR TITLE
Rename GooglePlaces to GooglePlacesAPI

### DIFF
--- a/Specs/GooglePlaces/1.0.1/GooglePlaces.podspec.json
+++ b/Specs/GooglePlaces/1.0.1/GooglePlaces.podspec.json
@@ -1,5 +1,5 @@
 {
-  "name": "GooglePlaces",
+  "name": "GooglePlacesAPI",
   "version": "1.0.1",
   "summary": "Swift Wrapper on Google Places API",
   "description": "Swift Wrapper on Google Places API\nhttps://developers.google.com/places/web-service/",
@@ -24,7 +24,7 @@
     "Source/Core/**/*.*",
     "Source/Google Places API/**/*.*"
   ],
-  "module_name": "GooglePlaces",
+  "module_name": "GooglePlacesAPI",
   "dependencies": {
     "Alamofire": [
       "~> 3.0"

--- a/Specs/GooglePlaces/1.0.2/GooglePlaces.podspec.json
+++ b/Specs/GooglePlaces/1.0.2/GooglePlaces.podspec.json
@@ -1,5 +1,5 @@
 {
-  "name": "GooglePlaces",
+  "name": "GooglePlacesAPI",
   "version": "1.0.2",
   "summary": "Swift Wrapper on Google Places API",
   "description": "Swift Wrapper on Google Places API\nhttps://developers.google.com/places/web-service/",
@@ -24,7 +24,7 @@
     "Source/Core/**/*.*",
     "Source/Google Places API/**/*.*"
   ],
-  "module_name": "GooglePlaces",
+  "module_name": "GooglePlacesAPI",
   "dependencies": {
     "Alamofire": [
       "~> 3.0"

--- a/Specs/GooglePlaces/1.0.3/GooglePlaces.podspec.json
+++ b/Specs/GooglePlaces/1.0.3/GooglePlaces.podspec.json
@@ -1,5 +1,5 @@
 {
-  "name": "GooglePlaces",
+  "name": "GooglePlacesAPI",
   "version": "1.0.3",
   "summary": "Swift Wrapper on Google Places API",
   "description": "Swift Wrapper on Google Places API\nhttps://developers.google.com/places/web-service/",
@@ -24,7 +24,7 @@
     "Source/Core/**/*.*",
     "Source/Google Places API/**/*.*"
   ],
-  "module_name": "GooglePlaces",
+  "module_name": "GooglePlacesAPI",
   "dependencies": {
     "Alamofire": [
       "~> 3.0"

--- a/Specs/GooglePlaces/1.0.4/GooglePlaces.podspec.json
+++ b/Specs/GooglePlaces/1.0.4/GooglePlaces.podspec.json
@@ -1,5 +1,5 @@
 {
-  "name": "GooglePlaces",
+  "name": "GooglePlacesAPI",
   "version": "1.0.4",
   "summary": "Swift Wrapper on Google Places API",
   "description": "Swift Wrapper on Google Places API\nhttps://developers.google.com/places/web-service/",
@@ -24,7 +24,7 @@
     "Source/Core/**/*.*",
     "Source/Google Places API/**/*.*"
   ],
-  "module_name": "GooglePlaces",
+  "module_name": "GooglePlacesAPI",
   "dependencies": {
     "Alamofire": [
       "~> 3.0"


### PR DESCRIPTION
As required by Google. I'd like to rename my pod `GooglePlaces` to `GooglePlacesAPI`.

I thought about [deprecating](https://guides.cocoapods.org/syntax/podspec.html#deprecated) this Pod. However, I believe the old pod name still conflicts with Google's coming one.

So I think make this PR to rename the name is the right way.

Any other better solution? Thanks 
