### PR TITLE
Deprecating Google-Maps-iOS-SDK-for-Business

### DIFF
--- a/Specs/Google-Maps-iOS-SDK-for-Business/1.13.2/Google-Maps-iOS-SDK-for-Business.podspec.json
+++ b/Specs/Google-Maps-iOS-SDK-for-Business/1.13.2/Google-Maps-iOS-SDK-for-Business.podspec.json
@@ -1,8 +1,9 @@
 {
   "name": "Google-Maps-iOS-SDK-for-Business",
   "version": "1.13.2",
-  "summary": "Google Maps SDK for Business: iOS.",
-  "description": "Use the Google Maps SDK for iOS to add interactive maps, and immersive Street View panoramas, to your business app.",
+  "deprecated_in_favor_of" : "GoogleMaps",
+  "summary": "Google Maps SDK for Business: iOS. (deprecated)",
+  "description": "This podspec is deprecated. Please use the GoogleMaps pod instead.",
   "homepage": "https://developers.google.com/maps/documentation/business/mobile/ios/",
   "license": {
     "type": "Copyright",


### PR DESCRIPTION
`pod trunk deprecate` is erroring out on me, so going old school.
