### PR TITLE
Update AEConsole.podspec.json

### DIFF
--- a/Specs/9/4/f/AEConsole/0.2.2/AEConsole.podspec.json
+++ b/Specs/9/4/f/AEConsole/0.2.2/AEConsole.podspec.json
@@ -21,7 +21,7 @@
   "source_files": "Sources/*.swift",
   "dependencies": {
     "AELog": [
-      "~> 0.2"
+      "0.2.4"
     ]
   }
 }


### PR DESCRIPTION
When I trying install pod 'AEConsole', '0.2.2', it required dependencie "AELog": "~> 0.2", what also include 3.0.0 version for Swift 3.0
But i need just 0.2.2 for Swit 2.3