### PR TITLE
Fix paths to PMNibLinkableView and PMSqueezableView

### DIFF
--- a/Specs/7/8/0/PMNibLinkableView/0.1.0/PMNibLinkableView.podspec.json
+++ b/Specs/7/8/0/PMNibLinkableView/0.1.0/PMNibLinkableView.podspec.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "summary": "PMNibLinkableView gives view described in separate xib ability to be loaded in other xib or storyboard without creating it manually in code",
   "description": "PMNibLinkableView gives view described in separate xib ability to be loaded in other xib or storyboard without creating it manually in code.",
-  "homepage": "https://github.com/PerpetuumLab/PMNibLinkableView",
+  "homepage": "https://github.com/MadBrains/PMNibLinkableView",
   "license": {
     "type": "MIT",
     "file": "LICENSE"
@@ -12,7 +12,7 @@
     "Antol": "antol.peshkov@gmail.com"
   },
   "source": {
-    "git": "https://github.com/PerpetuumLab/PMNibLinkableView.git",
+    "git": "https://github.com/MadBrains/PMNibLinkableView.git",
     "tag": "0.1.0"
   },
   "social_media_url": "https://twitter.com/AntolPeshkov",

--- a/Specs/f/3/1/PMSqueezableView/0.1.0/PMSqueezableView.podspec.json
+++ b/Specs/f/3/1/PMSqueezableView/0.1.0/PMSqueezableView.podspec.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "summary": "Allows you to squeeze view and change sorounding constraints if needed",
   "description": "Allows you to squeeze view and change sorounding constraints if needed.\nSimple integration through category without subclassing.",
-  "homepage": "https://github.com/PerpetuumLab/PMSqueezableView",
+  "homepage": "https://github.com/MadBrains/PMSqueezableView",
   "license": {
     "type": "MIT",
     "file": "LICENSE"
@@ -12,7 +12,7 @@
     "Antol": "antol.peshkov@gmail.com"
   },
   "source": {
-    "git": "https://github.com/PerpetuumLab/PMSqueezableView.git",
+    "git": "https://github.com/MadBrains/PMSqueezableView.git",
     "tag": "0.1.0"
   },
   "platforms": {

--- a/Specs/f/3/1/PMSqueezableView/0.2.0/PMSqueezableView.podspec.json
+++ b/Specs/f/3/1/PMSqueezableView/0.2.0/PMSqueezableView.podspec.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "summary": "Allows you to squeeze view and change sorounding constraints if needed",
   "description": "Allows you to squeeze view and change sorounding constraints if needed.\nSimple integration through category without subclassing.",
-  "homepage": "https://github.com/PerpetuumLab/PMSqueezableView",
+  "homepage": "https://github.com/MadBrains/PMSqueezableView",
   "license": {
     "type": "MIT",
     "file": "LICENSE"
@@ -12,7 +12,7 @@
     "Antol": "antol.peshkov@gmail.com"
   },
   "source": {
-    "git": "https://github.com/PerpetuumLab/PMSqueezableView.git",
+    "git": "https://github.com/MadBrains/PMSqueezableView.git",
     "tag": "0.2.0"
   },
   "platforms": {


### PR DESCRIPTION
Fix paths to PMNibLinkableView and PMSqueezableView sources after company name change in github from PerpetuumLab to MadBrains, which broke paths.