### PR TITLE
Hotfix: XIB missing from resources in FyberSDK's 8.9.0 podspec

### DIFF
--- a/Specs/6/c/3/FyberSDK/8.9.0/FyberSDK.podspec.json
+++ b/Specs/6/c/3/FyberSDK/8.9.0/FyberSDK.podspec.json
@@ -19,7 +19,7 @@
   "documentation_url": "https://developer.fyber.com/",
   "source_files": "Fyber_iOS_SDK_v.8.9.0/fyber-sdk-lib/*.h",
   "vendored_libraries": "Fyber_iOS_SDK_v.8.9.0/fyber-sdk-lib/libFyberSDK-*.a",
-  "resources": "Fyber_iOS_SDK_v.8.9.0/fyber-sdk-lib/Resources/**/*.{png,json}",
+  "resources": "Fyber_iOS_SDK_v.8.9.0/fyber-sdk-lib/Resources/**/*.{png,xib}",
   "preserve_paths": "Fyber_iOS_SDK_v.8.9.0/fyber-sdk-lib/**",
   "frameworks": [
     "CoreGraphics",


### PR DESCRIPTION
Hi,
We forgot to add `.xib` to the list of files under `resources` which results in having black screen when showing these interfaces...

Could you please exceptionally merge? This would avoid us having to bump the version of the entire SDK just because of the podspec

Thanks a lot!