### PR TITLE
Jazz migrated to Bluemix Toolchain

### DIFF
--- a/Specs/1/8/e/IBMMobileFirstPlatformFoundationJSONStore/7.1.1/IBMMobileFirstPlatformFoundationJSONStore.podspec.json
+++ b/Specs/1/8/e/IBMMobileFirstPlatformFoundationJSONStore/7.1.1/IBMMobileFirstPlatformFoundationJSONStore.podspec.json
@@ -9,7 +9,7 @@
   "description": "Contains JSONStoreFramework for IBM MobileFirst Platform Foundation",
   "homepage": "http://ibm.com",
   "source": {
-    "git": "https://hub.jazz.net/git/imflocalsdk/imf-client-sdks",
+    "git": "https://git.ng.bluemix.net/imfsdkt/imf-client-sdks.git",
     "tag": "IBMMobileFirstPlatformFoundationJSONStore_7.1.1"
   },
   "platforms": {


### PR DESCRIPTION
We are not able to pod install with IBMMobileFirstPlatformFoundationJSONStore for 7.1 as IBMMobileFirstPlatformFoundationJSONStore.podspec is still pointing to Jazz server.


Please do this change in all IBM Foundation Frameworks podspec also.