### PR TITLE
Fix PromiseKit 4.1.8

### DIFF
--- a/Specs/a/f/1/PromiseKit/4.1.8/PromiseKit.podspec.json
+++ b/Specs/a/f/1/PromiseKit/4.1.8/PromiseKit.podspec.json
@@ -27,6 +27,7 @@
     "watchos": "2.0",
     "tvos": "9.0"
   },
+  "pushed_with_swift_version": "3.0",
   "subspecs": [
     {
       "name": "Accounts",
@@ -143,27 +144,27 @@
     {
       "name": "CorePromise",
       "source_files": [
-        "Sources/when.swift",
-        "Sources/DispatchQueue+Promise.swift",
-        "Sources/race.swift",
-        "Sources/join.swift",
-        "Sources/Zalgo.swift",
-        "Sources/Error.swift",
         "Sources/after.swift",
-        "Sources/Promise+Properties.swift",
-        "Sources/State.swift",
-        "Sources/wrap.swift",
-        "Sources/Promise.swift",
-        "Sources/Promise+AnyPromise.swift",
         "Sources/AnyPromise.swift",
+        "Sources/DispatchQueue+Promise.swift",
+        "Sources/Error.swift",
+        "Sources/join.swift",
+        "Sources/Promise+AnyPromise.swift",
+        "Sources/Promise+Properties.swift",
+        "Sources/Promise.swift",
+        "Sources/race.swift",
+        "Sources/State.swift",
+        "Sources/when.swift",
+        "Sources/wrap.swift",
+        "Sources/Zalgo.swift",
         "Sources/{after,AnyPromise,GlobalState,dispatch_promise,hang,join,PMKPromise,when}.m",
-        "Sources/AnyPromise.h",
         "Sources/AAA-CocoaPods-Hack.h",
+        "Sources/AnyPromise.h",
         "Sources/PromiseKit.h"
       ],
       "public_header_files": [
-        "Sources/AnyPromise.h",
         "Sources/AAA-CocoaPods-Hack.h",
+        "Sources/AnyPromise.h",
         "Sources/PromiseKit.h"
       ],
       "preserve_paths": [
@@ -209,18 +210,19 @@
     {
       "name": "Foundation",
       "source_files": [
-        "Extensions/Foundation/Sources/NSURLSession+AnyPromise.h",
-        "Extensions/Foundation/Sources/NSNotificationCenter+Promise.swift",
-        "Extensions/Foundation/Sources/NSNotificationCenter+AnyPromise.m",
         "Extensions/Foundation/Sources/afterlife.swift",
-        "Extensions/Foundation/Sources/NSTask+AnyPromise.h",
-        "Extensions/Foundation/Sources/NSURLSession+Promise.swift",
-        "Extensions/Foundation/Sources/NSURLSession+AnyPromise.m",
-        "Extensions/Foundation/Sources/NSObject+Promise.swift",
         "Extensions/Foundation/Sources/NSNotificationCenter+AnyPromise.h",
+        "Extensions/Foundation/Sources/NSNotificationCenter+AnyPromise.m",
+        "Extensions/Foundation/Sources/NSNotificationCenter+Promise.swift",
+        "Extensions/Foundation/Sources/NSObject+Promise.swift",
+        "Extensions/Foundation/Sources/NSTask+AnyPromise.h",
+        "Extensions/Foundation/Sources/NSTask+AnyPromise.m",
+        "Extensions/Foundation/Sources/NSURLSession+AnyPromise.h",
+        "Extensions/Foundation/Sources/NSURLSession+AnyPromise.m",
+        "Extensions/Foundation/Sources/NSURLSession+Promise.swift",
         "Extensions/Foundation/Sources/PMKFoundation.h",
         "Extensions/Foundation/Sources/Process+Promise.swift",
-        "Extensions/Foundation/Sources/NSTask+AnyPromise.m"
+        "Extensions/Foundation/Sources/URLDataPromise.swift"
       ],
       "dependencies": {
         "PromiseKit/CorePromise": [
@@ -329,11 +331,11 @@
       },
       "osx": {
         "source_files": [
-          "Extensions/Social/Sources/SLRequest+AnyPromise.m",
-          "Extensions/Social/Sources/SLRequest+Promise.swift",
           "Extensions/Social/Sources/PMKSocial.h",
+          "Extensions/Social/Sources/SLComposeViewController+Promise.swift",
           "Extensions/Social/Sources/SLRequest+AnyPromise.h",
-          "Extensions/Social/Sources/SLComposeViewController+Promise.swift"
+          "Extensions/Social/Sources/SLRequest+AnyPromise.m",
+          "Extensions/Social/Sources/SLRequest+Promise.swift"
         ],
         "frameworks": "Social"
       },
@@ -387,25 +389,27 @@
       "name": "UIKit",
       "tvos": {
         "source_files": [
-          "Extensions/UIKit/Sources/UIViewController+AnyPromise.m",
+          "Extensions/UIKit/Sources/PMKAlertController.swift",
           "Extensions/UIKit/Sources/PMKUIKit.h",
           "Extensions/UIKit/Sources/UIView+AnyPromise.h",
+          "Extensions/UIKit/Sources/UIView+AnyPromise.m",
           "Extensions/UIKit/Sources/UIView+Promise.swift",
           "Extensions/UIKit/Sources/UIViewController+AnyPromise.h",
-          "Extensions/UIKit/Sources/UIView+AnyPromise.m",
-          "Extensions/UIKit/Sources/PMKAlertController.swift"
+          "Extensions/UIKit/Sources/UIViewController+AnyPromise.m",
+          "Extensions/UIKit/Sources/UIViewController+Promise.swift"
         ],
         "frameworks": "UIKit"
       },
       "ios": {
         "source_files": [
-          "Extensions/UIKit/Sources/UIViewController+AnyPromise.m",
+          "Extensions/UIKit/Sources/PMKAlertController.swift",
           "Extensions/UIKit/Sources/PMKUIKit.h",
           "Extensions/UIKit/Sources/UIView+AnyPromise.h",
+          "Extensions/UIKit/Sources/UIView+AnyPromise.m",
           "Extensions/UIKit/Sources/UIView+Promise.swift",
           "Extensions/UIKit/Sources/UIViewController+AnyPromise.h",
-          "Extensions/UIKit/Sources/UIView+AnyPromise.m",
-          "Extensions/UIKit/Sources/PMKAlertController.swift"
+          "Extensions/UIKit/Sources/UIViewController+AnyPromise.m",
+          "Extensions/UIKit/Sources/UIViewController+Promise.swift"
         ],
         "frameworks": "UIKit"
       },


### PR DESCRIPTION
So TIFU, well actually a few days ago.

I pushed to trunk disabling the lint because someone asked me to push an old version (4.1.8) that I hadn't previously pushed because it was only a fix for Carthage users. The old version required Xcode 8 to lint, and I didn't have it to hand.

Rather than say no (which would have made more sense) I was like, oh why not, what can go wrong?

It went wrong. Please merge this fix.