### PR TITLE
Fixed tag in libwebp.podspec.json

### DIFF
--- a/Specs/1/9/2/libwebp/1.0.0/libwebp.podspec.json
+++ b/Specs/1/9/2/libwebp/1.0.0/libwebp.podspec.json
@@ -10,7 +10,7 @@
   },
   "source": {
     "git": "https://chromium.googlesource.com/webm/libwebp",
-    "tag": "v0.6.1"
+    "tag": "v1.0.0"
   },
   "compiler_flags": "-D_THREAD_SAFE",
   "requires_arc": false,


### PR DESCRIPTION
Fixing a bug in the latest `libwebp` podspec, where the `"version": "1.0.0"` doesn't match the `"tag": "v1.0.0"`