### PR TITLE
Update GoogleMobileAdsMediationVungle.podspec.json

### DIFF
--- a/Specs/6/8/7/GoogleMobileAdsMediationVungle/6.3.0.0/GoogleMobileAdsMediationVungle.podspec.json
+++ b/Specs/6/8/7/GoogleMobileAdsMediationVungle/6.3.0.0/GoogleMobileAdsMediationVungle.podspec.json
@@ -16,7 +16,7 @@
     "VungleAdapter-6.3.0.0/VungleAdapter.framework"
   ],
   "dependencies": {
-    "VungleSDK-iOS": "6.3.0",
+    "VungleSDK-iOS": "~> 6.3.0",
     "Google-Mobile-Ads-SDK": ">= 7.14.0"
   },
   "preserve_paths": [


### PR DESCRIPTION
Hi,

Vungle has released 6.3.1 (Sep, 19) with "iOS 12 Compatibility" and 6.3.2  with "Support for iOS 12":
https://github.com/Vungle/iOS-SDK/blob/master/CHANGELOG.md.

In our experience targeting iOS12 with 6.3.0 really makes problems (crashes).
Looks like 6.3.2 (with 6.3.0 adapter) fixed that.