### PR TITLE
[Fix] Signals 6.0.0 platforms specification

### DIFF
--- a/Specs/c/a/d/Signals/6.0.0/Signals.podspec.json
+++ b/Specs/c/a/d/Signals/6.0.0/Signals.podspec.json
@@ -14,6 +14,7 @@
   },
   "platforms": {
     "ios": "8.0",
+    "osx": "10.9",
     "tvos": "9.0",
     "watchos": "2.0"
   },


### PR DESCRIPTION
For some reason, this wasn't picked up when the spec was serialized into JSON.

This pod has had macOS 10.9 compatibility for as long it's been on CocoaPods, and this is still in the podspec at github: [Signals.podspec#L12](https://github.com/artman/Signals/blob/f35cfe7a6228c329bffd45f01a3706e29b7d5ebf/Signals.podspec#L12)

This patch fixes this error by adding the missing line back.

Without it, the following error occurs when trying to depend on Signals in an osx project:

```md
- ERROR | [OSX] unknown: Encountered an unknown error (The platform of the target `App` (macOS 10.13) is not compatible with `Signals (6.0.0)`, which does not support `osx`.) during validation.
```

fixes: https://github.com/artman/Signals/issues/75