### PR TITLE
Deprecate CancelForPromiseKit

### DIFF
--- a/Specs/8/8/e/CancelForPromiseKit/1.0.0/CancelForPromiseKit.podspec.json
+++ b/Specs/8/8/e/CancelForPromiseKit/1.0.0/CancelForPromiseKit.podspec.json
@@ -1,5 +1,6 @@
 {
   "name": "CancelForPromiseKit",
+  "deprecated": true,
   "version": "1.0.0",
   "source": {
     "git": "https://github.com/dougzilla32/CancelForPromiseKit.git",


### PR DESCRIPTION
This cancellation support is being added directly to PromiseKit 7, so the CancelForPromiseKit project is no longer needed.