### PR TITLE
Add scripts and CircleCI config for updating CDN indexes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,81 @@
+version: 2.1
+
+orbs:
+  queue: eddiewebb/queue@1.1.2
+
+commands:
+  checkout-indexes:
+    steps:
+      - run:
+          name: Checkout
+          command: |
+            mkdir -p ~/.ssh
+
+            echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
+
+            if [ -e "/home/circleci/project/.git" ]
+            then
+              cd "/home/circleci/project"
+              git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
+
+              echo "Fetching indexes ..."
+              git fetch origin indexes
+
+              echo "Resetting to origin/indexes"
+              git reset --hard origin/indexes
+            else
+              mkdir -p "/home/circleci/project"
+              cd "/home/circleci/project"
+              echo "Cloning indexes ..."
+              git clone "$CIRCLE_REPOSITORY_URL" --single-branch --branch indexes .
+            fi
+
+            echo "Fetching '$CIRCLE_BRANCH' ..."
+            git fetch origin "$CIRCLE_BRANCH"
+
+jobs:
+  update-indexes:
+    docker:
+       - image: circleci/ruby:2.4.1
+    steps:
+      - queue/until_front_of_line
+      - restore_cache:
+          keys:
+            - spec-indexes-source-{{ .Branch }}-{{ .Revision }}
+            - spec-indexes-source-{{ .Branch }}-
+            - spec-indexes-source-
+      - checkout-indexes
+      - run:
+          name: Git config
+          command: |
+            git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
+            git config --global user.name "$CIRCLE_USERNAME"
+      - add_ssh_keys:
+          fingerprints:
+            - "39:12:25:06:c2:71:00:c6:7c:fe:40:a6:e7:0e:18:ed"
+      - run:
+          name: Merge latest changes into indexes branch
+          command: |
+            git merge --no-ff --log --no-edit "$CIRCLE_SHA1"
+            echo 'export MERGE_COMMIT="$(git rev-parse HEAD)"' >> $BASH_ENV
+      - run:
+          name: Generate indexes for the merge commit
+          command: ./Scripts/add_incremental_index.sh "$MERGE_COMMIT"
+      - run:
+          name: Commit and push the new indexes
+          command: |
+            git add -A
+            git commit --allow-empty -m "Updated indexes from $MERGE_COMMIT"
+            git push origin indexes
+      - save_cache:
+          key: spec-indexes-source-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ".git"
+
+workflows:
+  update-indexes:
+    jobs:
+      - update-indexes:
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,9 @@ jobs:
       - queue/until_front_of_line
       - restore_cache:
           keys:
-            - spec-indexes-source-{{ .Branch }}-{{ .Revision }}
-            - spec-indexes-source-{{ .Branch }}-
-            - spec-indexes-source-
+            - indexes-source-{{ .Branch }}-{{ .Revision }}
+            - indexes-source-{{ .Branch }}-
+            - indexes-source-
       - checkout-indexes
       - run:
           name: Git config
@@ -56,20 +56,21 @@ jobs:
           fingerprints:
             - "39:12:25:06:c2:71:00:c6:7c:fe:40:a6:e7:0e:18:ed"
       - run:
-          name: Merge latest changes into indexes branch without committing
+          name: Rebase latest changes
           command: |
-            git merge --no-ff --no-commit "$CIRCLE_SHA1"
+            echo 'export LAST_INDEXED_COMMIT="$(git rev-parse @~)"' >> $BASH_ENV
+            git rebase "$CIRCLE_SHA1"
       - run:
-          name: Generate indexes for the merge commit
+          name: Generate indexes for the changes
           command: |
-            ./Scripts/add_incremental_index.sh $INDEXES_BRANCH $CIRCLE_SHA1 | xargs git add
+            ./Scripts/add_incremental_index.sh origin/$INDEXES_BRANCH $CIRCLE_SHA1 | tee /dev/tty | xargs git add
       - run:
-          name: Commit and push the changes
+          name: Amend commit and force push the changes
           command: |
-            git commit --allow-empty -m "Merge $CIRCLE_SHA1 and update indexes"
-            git push origin $INDEXES_BRANCH
+            git commit --amend --date="$(date -R)" --no-edit --quiet
+            git push origin $INDEXES_BRANCH --force-with-lease
       - save_cache:
-          key: spec-indexes-source-{{ .Branch }}-{{ .Revision }}
+          key: indexes-source-{{ .Branch }}-{{ .Revision }}
           paths:
             - ".git"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,18 +57,16 @@ jobs:
             - "39:12:25:06:c2:71:00:c6:7c:fe:40:a6:e7:0e:18:ed"
       - run:
           name: Rebase latest changes
-          command: |
-            echo 'export LAST_INDEXED_COMMIT="$(git rev-parse @~)"' >> $BASH_ENV
-            git rebase "$CIRCLE_SHA1"
+          command: git rebase "$CIRCLE_SHA1"
       - run:
           name: Generate indexes for the changes
           command: |
-            ./Scripts/add_incremental_index.sh origin/$INDEXES_BRANCH $CIRCLE_SHA1 | tee /dev/tty | xargs git add
+            ./Scripts/add_incremental_index.sh "origin/$INDEXES_BRANCH" "$CIRCLE_SHA1" | tee /dev/tty | xargs git add
       - run:
           name: Amend commit and force push the changes
           command: |
             git commit --amend --date="$(date -R)" --no-edit --quiet
-            git push origin $INDEXES_BRANCH --force-with-lease
+            git push origin "$INDEXES_BRANCH" --force-with-lease
       - save_cache:
           key: indexes-source-{{ .Branch }}-{{ .Revision }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,25 +18,27 @@ commands:
               cd "/home/circleci/project"
               git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
 
-              echo "Fetching indexes ..."
-              git fetch origin indexes
+              echo "Fetching $INDEXES_BRANCH ..."
+              git fetch --force origin "$INDEXES_BRANCH:remotes/origin/$INDEXES_BRANCH"
 
-              echo "Resetting to origin/indexes"
-              git reset --hard origin/indexes
+              echo "Resetting to origin/$INDEXES_BRANCH"
+              git reset --hard "origin/$INDEXES_BRANCH"
             else
               mkdir -p "/home/circleci/project"
               cd "/home/circleci/project"
-              echo "Cloning indexes ..."
-              git clone "$CIRCLE_REPOSITORY_URL" --single-branch --branch indexes .
+              echo "Cloning $INDEXES_BRANCH ..."
+              git clone "$CIRCLE_REPOSITORY_URL" --single-branch --branch "$INDEXES_BRANCH" .
             fi
 
             echo "Fetching '$CIRCLE_BRANCH' ..."
-            git fetch origin "$CIRCLE_BRANCH"
+            git fetch --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
 
 jobs:
   update-indexes:
     docker:
        - image: circleci/ruby:2.4.1
+    environment:
+      INDEXES_BRANCH: indexes
     steps:
       - queue/until_front_of_line
       - restore_cache:
@@ -54,19 +56,18 @@ jobs:
           fingerprints:
             - "39:12:25:06:c2:71:00:c6:7c:fe:40:a6:e7:0e:18:ed"
       - run:
-          name: Merge latest changes into indexes branch
+          name: Merge latest changes into indexes branch without committing
           command: |
-            git merge --no-ff --log --no-edit "$CIRCLE_SHA1"
-            echo 'export MERGE_COMMIT="$(git rev-parse HEAD)"' >> $BASH_ENV
+            git merge --no-ff --no-commit "$CIRCLE_SHA1"
       - run:
           name: Generate indexes for the merge commit
-          command: ./Scripts/add_incremental_index.sh "$MERGE_COMMIT"
-      - run:
-          name: Commit and push the new indexes
           command: |
-            git add -A
-            git commit --allow-empty -m "Updated indexes from $MERGE_COMMIT"
-            git push origin indexes
+            ./Scripts/add_incremental_index.sh $INDEXES_BRANCH $CIRCLE_SHA1 | xargs git add
+      - run:
+          name: Commit and push the changes
+          command: |
+            git commit --allow-empty -m "Merge $CIRCLE_SHA1 and update indexes"
+            git push origin $INDEXES_BRANCH
       - save_cache:
           key: spec-indexes-source-{{ .Branch }}-{{ .Revision }}
           paths:

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -1,0 +1,7 @@
+## Scripts
+
+The two scripts are a part of updating CocoaPods to work with a CDN instead of only via
+`git` repos.
+
+- [`add_indexes.sh`](add_indexes.sh) - Adds an index for every Pod, this should probably only need to be used once.
+- [`add_incremental_index.sh`](add_incremental_index.sh) - Uses git to update only Pods which have changed in the given commit.

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -4,4 +4,4 @@ The two scripts are a part of updating CocoaPods to work with a CDN instead of o
 `git` repos.
 
 - [`add_indexes.sh`](add_indexes.sh) - Adds an index for every Pod, this should probably only need to be used once.
-- [`add_incremental_index.sh`](add_incremental_index.sh) - Uses git to update only Pods which have changed in the given commit.
+- [`add_incremental_index.sh`](add_incremental_index.sh) - Uses git to update only Pods which have changed in the given commit range.

--- a/Scripts/add_incremental_index.sh
+++ b/Scripts/add_incremental_index.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -eo pipefail
+
+COMMIT="$1"
+
+# Get the changed files from the given commit
+
+CHANGED_FILES=$(git diff --name-only $COMMIT~ $COMMIT Specs)
+
+# Cut paths down to `Specs/9/f/e/MessagingSDK/1.3.9`
+# Insert `1.3.9` in sorted order into `Specs/9/f/e/MessagingSDK/index.txt` if not already present
+
+echo "$CHANGED_FILES" | cut -d / -f 1,2,3,4,5,6 | xargs -I {} \
+    bash -c 'POD_INDEX="$(dirname "{}")/index.txt" ; touch $POD_INDEX ; \
+             basename "{}" | sort -o "$POD_INDEX" -m -u - "$POD_INDEX"'
+
+# Cut paths down to `Specs/9/f/e/MessagingSDK`
+# Insert `MessagingSDK` in sorted order into all_pods.txt if not already present
+
+echo "$CHANGED_FILES" | cut -d / -f 5 | xargs -I {} \
+    bash -c 'echo "{}" | sort -o all_pods.txt -m -u - all_pods.txt'

--- a/Scripts/add_incremental_index.sh
+++ b/Scripts/add_incremental_index.sh
@@ -1,21 +1,23 @@
 #!/bin/bash
 set -eo pipefail
 
-COMMIT="$1"
+FIRST_COMMIT="$1"
+SECOND_COMMIT="$2"
 
-# Get the changed files from the given commit
+# Get the changed files from the given commits
 
-CHANGED_FILES=$(git diff --name-only $COMMIT~ $COMMIT Specs)
+CHANGED_FILES=$(git diff --name-only $FIRST_COMMIT...$SECOND_COMMIT Specs)
 
 # Cut paths down to `Specs/9/f/e/MessagingSDK/1.3.9`
 # Insert `1.3.9` in sorted order into `Specs/9/f/e/MessagingSDK/index.txt` if not already present
 
 echo "$CHANGED_FILES" | cut -d / -f 1,2,3,4,5,6 | xargs -I {} \
     bash -c 'POD_INDEX="$(dirname "{}")/index.txt" ; touch $POD_INDEX ; \
-             basename "{}" | sort -o "$POD_INDEX" -m -u - "$POD_INDEX"'
+             basename "{}" | sort -o "$POD_INDEX" -m -u - "$POD_INDEX" && echo "$POD_INDEX"'
 
-# Cut paths down to `Specs/9/f/e/MessagingSDK`
+# Cut paths down to `MessagingSDK`
 # Insert `MessagingSDK` in sorted order into all_pods.txt if not already present
 
 echo "$CHANGED_FILES" | cut -d / -f 5 | xargs -I {} \
     bash -c 'echo "{}" | sort -o all_pods.txt -m -u - all_pods.txt'
+echo "all_pods.txt"

--- a/Scripts/add_indexes.sh
+++ b/Scripts/add_indexes.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eo pipefail
+
+# Loops through all known Podspec roots, then creates an index.txt in that folder
+# with the contents of an ls.
+find Specs -mindepth 4 -maxdepth 4 -type d -not -wholename '**/.git/**/*' -print | \
+  xargs -I {} bash -c 'cd "{}"; ls -1 | grep -v "index.txt" > index.txt'
+
+# Loops through all known Podspec folders and pipes their name into a single all_pods.txt 
+# in the root.
+find Specs -mindepth 4 -maxdepth 4 -type d -not -wholename '**/.git/**/*' | \
+  cut -d / -f 5 | sort > all_pods.txt

--- a/Scripts/add_indexes.sh
+++ b/Scripts/add_indexes.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 # Loops through all known Podspec roots, then creates an index.txt in that folder
 # with the contents of an ls.
 find Specs -mindepth 4 -maxdepth 4 -type d -not -wholename '**/.git/**/*' -print | \
-  xargs -I {} bash -c 'cd "{}"; ls -1 | grep -v "index.txt" > index.txt'
+  xargs -I {} bash -c 'ls -1 "{}" | grep -v "index.txt" > "{}"/index.txt'
 
 # Loops through all known Podspec folders and pipes their name into a single all_pods.txt 
 # in the root.


### PR DESCRIPTION
This PR adds the required scripts and CircleCI config to add CDN indexes to an `indexes` branch on every commit to master. I have adapted @orta's draft changes from https://github.com/orta/Specs/pull/1.

closes https://github.com/CocoaPods/CocoaPods/issues/8359.

On every push to master, here is what the new CircleCI job does:

1. It checks if there are any `update-indexes` jobs running. If there are, it will wait for up to 10 minutes for them to complete. It uses https://github.com/eddiewebb/circleci-queue for the waiting.
2. Now the `indexes` branch will be cloned (if no cache) or fetched and checked out (if cached).
3. The changes on master which triggered this build are now merged into `indexes` using `git merge`.
4. `./Scripts/add_incremental_index.sh` is run on the files changed merge commit just made.
5. The resulting changes are pushed to `indexes`.

Builds take 1:30-2 minutes so running on every push seem reasonable. It has been running successfully on my fork for pushes to `master`. The CircleCI builds are [here](https://circleci.com/gh/jtreanor/Specs/tree/master) and the `indexes` branch is [here](https://github.com/jtreanor/Specs/commits/indexes).

A few things will need to be changed before merging:

- It currently uses my SSH key to push. This will need to be changed to something with push access. A Github access token could possibly be used instead.
- CircleCI should be enabled for the repo. This uses CircleCI 2.1 configuration so `Enable pipelines` and `Opt-in to orb publishing, use of uncertified orbs, and use of third-party orbs.` will need to be enabled in the settings.
- A new `indexes` branch will need to be pushed with the initial indexes (generated with `add_indexes.sh`).


