### PR TITLE
All that's needed for Netlify deployment (complementary to Core#541)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 .rbenv-version
 .idea
+_site

--- a/Scripts/create_indices.sh
+++ b/Scripts/create_indices.sh
@@ -4,5 +4,6 @@ set -eo pipefail
 
 mkdir _site || true
 
-find Specs -mindepth 5 -maxdepth 5 -type d | cut -c13- | sort > _site/all_pods_versions.txt
+ruby Scripts/create_pods_and_versions_index.rb > _site/all_pods_versions.txt
+gzip < _site/all_pods_versions.txt > _site/all_pods_versions.gz
 cp Scripts/netlify_redirects.txt _site/_redirects

--- a/Scripts/create_indices.sh
+++ b/Scripts/create_indices.sh
@@ -5,3 +5,4 @@ set -eo pipefail
 mkdir _site || true
 
 find Specs -mindepth 5 -maxdepth 5 -type d | cut -c13- | sort > _site/all_pods_versions.txt
+cp Scripts/netlify_redirects.txt _site/_redirects

--- a/Scripts/create_indices.sh
+++ b/Scripts/create_indices.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -x
-set -eo pipefail
-
-mkdir _site || true
-
-ruby Scripts/create_pods_and_versions_index.rb > _site/all_pods_versions.txt
-gzip < _site/all_pods_versions.txt > _site/all_pods_versions.gz
-cp Scripts/netlify_redirects.txt _site/_redirects

--- a/Scripts/create_indices.sh
+++ b/Scripts/create_indices.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -x
+set -eo pipefail
+
+mkdir _site || true
+
+find Specs -mindepth 5 -maxdepth 5 -type d | cut -c13- | sort > _site/all_pods_versions.txt

--- a/Scripts/create_pods_and_versions_index.rb
+++ b/Scripts/create_pods_and_versions_index.rb
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+pods_and_versions = {}
+
+Dir['Specs/*/*/*/*/*'].each do |dir|
+  pod, version = dir.split('/')[-2, 2]
+  pods_and_versions[pod] ||= []
+  pods_and_versions[pod] << version
+end
+
+pods_and_versions.keys.sort.each do |pod|
+  row = [pod] + pods_and_versions[pod].sort
+  puts row.join('/')
+end

--- a/Scripts/netlify_deploy.sh
+++ b/Scripts/netlify_deploy.sh
@@ -4,5 +4,5 @@ set -eo pipefail
 
 mkdir _site || true
 
-ruby Scripts/create_pods_and_versions_index.rb | gzip > _site/all_pods_versions.txt
+ruby Scripts/create_pods_and_versions_index.rb | gzip > _site/all_pods_versions.gz
 cp Scripts/netlify_redirects.txt _site/_redirects

--- a/Scripts/netlify_deploy.sh
+++ b/Scripts/netlify_deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -x
+set -eo pipefail
+
+mkdir _site || true
+
+ruby Scripts/create_pods_and_versions_index.rb | gzip > _site/all_pods_versions.txt
+cp Scripts/netlify_redirects.txt _site/_redirects

--- a/Scripts/netlify_redirects.txt
+++ b/Scripts/netlify_redirects.txt
@@ -1,0 +1,2 @@
+/Specs/*               https://raw.githubusercontent.com/CocoaPods/Specs/master/Specs/:splat
+/CocoaPods-version.yml https://raw.githubusercontent.com/CocoaPods/Specs/master/Specs/CocoaPods-version.yml

--- a/Scripts/netlify_redirects.txt
+++ b/Scripts/netlify_redirects.txt
@@ -1,2 +1,2 @@
 /Specs/*               https://raw.githubusercontent.com/CocoaPods/Specs/master/Specs/:splat
-/CocoaPods-version.yml https://raw.githubusercontent.com/CocoaPods/Specs/master/Specs/CocoaPods-version.yml
+/CocoaPods-version.yml https://raw.githubusercontent.com/CocoaPods/Specs/master/CocoaPods-version.yml

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "Scripts/netlify_deploy.sh"
+  publish = "_site"


### PR DESCRIPTION
This PR is complementary to [Core#541](https://github.com/CocoaPods/Core/pull/541). 

After this change is merged, someone with access to the CocoaPods org should enable it on Netlify but other than turning a switch, it'll work due to the config/scripts being in the repo.

The scripts do 2 things:
1. Generate the compact index as explained in the core PR.
2. Set up the redirects to GitHub CDN for the podspec URLs themselves.

[Example of a Netlify build](https://app.netlify.com/sites/cocoapods-specs/deploys/5ce4fec8cddca50009b98cd5). It's currently not auto-building, but when merged into master, it will be.
