### PR TITLE
Add index for all deprecated pods

### DIFF
--- a/Scripts/create_pods_and_versions_index.rb
+++ b/Scripts/create_pods_and_versions_index.rb
@@ -1,16 +1,19 @@
 #!/usr/bin/env ruby
 
-shards = {}
+require 'set'
 
-Dir['Specs/*/*/*/*/*'].each do |dir|
+# create a hash like this: { '2_2_2' => { 'DfPodTest' => ['0.0.1', '0.0.2'] } }
+shards = Dir['Specs/*/*/*/*/*'].each_with_object({}) do |dir, result|
   dir_components = dir.split('/')
   pod, version = dir_components[-2, 2]
   shard = dir_components[1..-3].join('_')
-  shards[shard] ||= {}
-  shards[shard][pod] ||= []
-  shards[shard][pod] << version
+  result[shard] ||= {}
+  result[shard][pod] ||= []
+  result[shard][pod] << version
 end
 
+# write all `all_pods_versions_2_2_2.txt` files that are structured like so:
+# DfPodTest/0.0.1/0.0.2
 shards.each do |shard, pods_versions|
   File.open("#{ARGV[0]}/all_pods_versions_#{shard}.txt", 'w') do |file|
     pods_versions.keys.sort.each do |pod|
@@ -20,8 +23,22 @@ shards.each do |shard, pods_versions|
   end
 end
 
+# write a list of all pods, separated by newline
 File.open("#{ARGV[0]}/all_pods.txt", 'w') do |file|
   shards.values.map(&:keys).flatten.sort.each do |pod|
+    file.puts pod
+  end
+end
+
+# get a list of all deprecated pods by looking for the following string within the JSON:
+# "deprecated": true
+deprecations = `grep -lr '"deprecated": true' Specs`
+               .split("\n")
+               .map { |f| f.split('/')[4] }
+
+# write a list of all deprecated pods, separated by newline
+File.open("#{ARGV[0]}/deprecated_pods.txt", 'w') do |file|
+  Set.new(deprecations).to_a.sort.each do |pod|
     file.puts pod
   end
 end


### PR DESCRIPTION
This PR, to be accompanied with an additive change to `Pod::CDNSource` creates a list of all the deprecated pods. More info to come.