### PR TITLE
RealmSwift: Removed new line char "\n" from "version"

### DIFF
--- a/Specs/9/4/5/RealmSwift/0.92.1/RealmSwift.podspec.json
+++ b/Specs/9/4/5/RealmSwift/0.92.1/RealmSwift.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RealmSwift",
-  "version": "0.92.1\n",
+  "version": "0.92.1",
   "summary": "Realm is a modern data framework & database for iOS & OS X.",
   "description": "                              The Realm database, for Swift. (If you want to use Realm from Objective-C, see the “Realm” pod.)\n\n                              Realm is a mobile database: a replacement for Core Data & SQLite. You can use it on iOS & OS X. Realm is not an ORM on top SQLite: instead it uses its own persistence engine, built for simplicity (& speed). Learn more and get help at https://realm.io\n",
   "homepage": "https://realm.io",

--- a/Specs/9/4/5/RealmSwift/0.92.2/RealmSwift.podspec.json
+++ b/Specs/9/4/5/RealmSwift/0.92.2/RealmSwift.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RealmSwift",
-  "version": "0.92.2\n",
+  "version": "0.92.2",
   "summary": "Realm is a modern data framework & database for iOS & OS X.",
   "description": "                              The Realm database, for Swift. (If you want to use Realm from Objective-C, see the “Realm” pod.)\n\n                              Realm is a mobile database: a replacement for Core Data & SQLite. You can use it on iOS & OS X. Realm is not an ORM on top SQLite: instead it uses its own persistence engine, built for simplicity (& speed). Learn more and get help at https://realm.io\n",
   "homepage": "https://realm.io",

--- a/Specs/9/4/5/RealmSwift/0.92.3/RealmSwift.podspec.json
+++ b/Specs/9/4/5/RealmSwift/0.92.3/RealmSwift.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RealmSwift",
-  "version": "0.92.3\n",
+  "version": "0.92.3",
   "summary": "Realm is a modern data framework & database for iOS & OS X.",
   "description": "                              The Realm database, for Swift. (If you want to use Realm from Objective-C, see the “Realm” pod.)\n\n                              Realm is a mobile database: a replacement for Core Data & SQLite. You can use it on iOS & OS X. Realm is not an ORM on top SQLite: instead it uses its own persistence engine, built for simplicity (& speed). Learn more and get help at https://realm.io\n",
   "homepage": "https://realm.io",

--- a/Specs/9/4/5/RealmSwift/0.92.4/RealmSwift.podspec.json
+++ b/Specs/9/4/5/RealmSwift/0.92.4/RealmSwift.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RealmSwift",
-  "version": "0.92.4\n",
+  "version": "0.92.4",
   "summary": "Realm is a modern data framework & database for iOS & OS X.",
   "description": "                              The Realm database, for Swift. (If you want to use Realm from Objective-C, see the “Realm” pod.)\n\n                              Realm is a mobile database: a replacement for Core Data & SQLite. You can use it on iOS & OS X. Realm is not an ORM on top SQLite: instead it uses its own persistence engine, built for simplicity (& speed). Learn more and get help at https://realm.io\n",
   "homepage": "https://realm.io",

--- a/Specs/9/4/5/RealmSwift/0.93.0/RealmSwift.podspec.json
+++ b/Specs/9/4/5/RealmSwift/0.93.0/RealmSwift.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RealmSwift",
-  "version": "0.93.0\n",
+  "version": "0.93.0",
   "summary": "Realm is a modern data framework & database for iOS & OS X.",
   "description": "                              The Realm database, for Swift. (If you want to use Realm from Objective-C, see the “Realm” pod.)\n\n                              Realm is a mobile database: a replacement for Core Data & SQLite. You can use it on iOS & OS X. Realm is not an ORM on top SQLite: instead it uses its own persistence engine, built for simplicity (& speed). Learn more and get help at https://realm.io\n",
   "homepage": "https://realm.io",

--- a/Specs/9/4/5/RealmSwift/0.93.1/RealmSwift.podspec.json
+++ b/Specs/9/4/5/RealmSwift/0.93.1/RealmSwift.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RealmSwift",
-  "version": "0.93.1\n",
+  "version": "0.93.1",
   "summary": "Realm is a modern data framework & database for iOS & OS X.",
   "description": "                              The Realm database, for Swift. (If you want to use Realm from Objective-C, see the “Realm” pod.)\n\n                              Realm is a mobile database: a replacement for Core Data & SQLite. You can use it on iOS & OS X. Realm is not an ORM on top SQLite: instead it uses its own persistence engine, built for simplicity (& speed). Learn more and get help at https://realm.io\n",
   "homepage": "https://realm.io",

--- a/Specs/9/4/5/RealmSwift/0.93.2/RealmSwift.podspec.json
+++ b/Specs/9/4/5/RealmSwift/0.93.2/RealmSwift.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RealmSwift",
-  "version": "0.93.2\n",
+  "version": "0.93.2",
   "summary": "Realm is a modern data framework & database for iOS & OS X.",
   "description": "                              The Realm database, for Swift. (If you want to use Realm from Objective-C, see the “Realm” pod.)\n\n                              Realm is a mobile database: a replacement for Core Data & SQLite. You can use it on iOS & OS X. Realm is not an ORM on top SQLite: instead it uses its own persistence engine, built for simplicity (& speed). Learn more and get help at https://realm.io\n",
   "homepage": "https://realm.io",


### PR DESCRIPTION
New line char causes an error over NXRM. Removed new line "\n" from version.
CDN: *****-repository-cocoapods-proxy URL couldn't be downloaded: https://*******/repository/cocoapods-proxy/Specs/9/4/5/RealmSwift/0.92.1/RealmSwift.podspec.json Response: 500

javax.servlet.ServletException: java.lang.IllegalArgumentException: Illegal character in path at index 22: pods/RealmSwift/0.92.1
/https/api.github.com/repos/realm/realm-cocoa/tarball/v0.92.1.tar.gz