### PR TITLE
Update KandyCPaaSMobileSDK.podspec.json

### DIFF
--- a/Specs/7/7/f/KandyCPaaSMobileSDK/2.1.0/KandyCPaaSMobileSDK.podspec.json
+++ b/Specs/7/7/f/KandyCPaaSMobileSDK/2.1.0/KandyCPaaSMobileSDK.podspec.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "KandyWebRTC": [
-
+      "0.72"
     ]
   },
   "libraries": [


### PR DESCRIPTION
We needed to change one of  our current podspec's dependency version (KandyWebRTC) , and we are not able to increment our version number because of our customer deployment procedures.

We've tried to use the below commands:
```
pod trunk delete KandyCPaaSMobileSDK 2.1.0
pod trunk push
```

When we tried the delete command it gave an html error but it removes the version, however when we push the edited podspec with same version instead of showing the new podspec file , cocoapods shows our previous podspec. 
So basically we are not able to replace our existing podspec file for a spesific version, we've searched through stackoverflow and github and saw that only way to do it is creating a pull request.

