### PR TITLE
Update MASFoundation.podspec.json

### DIFF
--- a/Specs/0/b/8/MASFoundation/2.1.00/MASFoundation.podspec.json
+++ b/Specs/0/b/8/MASFoundation/2.1.00/MASFoundation.podspec.json
@@ -12,7 +12,7 @@
     "file": "LICENSE.md"
   },
   "platforms": {
-    "ios": "12.0"
+    "ios": "9.0"
   },
   "requires_arc": true,
   "source": {


### PR DESCRIPTION
The deployment target of the framework was edited in podspec by mistake although the deployment target is still 9.0.
So would like to revert this change.