### PR TITLE
The download URL is deprecated

### DIFF
--- a/Specs/8/1/2/google-cast-sdk/2.7.1/google-cast-sdk.podspec.json
+++ b/Specs/8/1/2/google-cast-sdk/2.7.1/google-cast-sdk.podspec.json
@@ -10,7 +10,7 @@
   "homepage": "https://developers.google.com/cast/",
   "authors": "Google, Inc.",
   "source": {
-    "http": "https://redirector.gvt1.com/edgedl/chromecast/sdk/ios/GoogleCastSDK-2.7.1-Release-ios-default.zip"
+    "http": "https://dl.google.com/dl/chromecast/sdk/ios/GoogleCastSDK-2.7.1-Release-ios-default.zip"
   },
   "platforms": {
     "ios": "6.0"


### PR DESCRIPTION
The download URL is deprecated, I propose change it to:
https://dl.google.com/dl/chromecast/sdk/ios/GoogleCastSDK-2.7.1-Release-ios-default.zip