### PR TITLE
Mopub 5.13.0 SDK Support for iOS 9.0

### DIFF
--- a/Specs/9/8/0/mopub-ios-sdk/5.13.0/mopub-ios-sdk.podspec.json
+++ b/Specs/9/8/0/mopub-ios-sdk/5.13.0/mopub-ios-sdk.podspec.json
@@ -19,7 +19,7 @@
   },
   "requires_arc": true,
   "platforms": {
-    "ios": "10.0"
+    "ios": "9.0"
   },
   "frameworks": [
     "AVFoundation",


### PR DESCRIPTION
Following up on this critical fix: https://github.com/mopub/mopub-ios-sdk/issues/313
Can we at least release a version that fixes the UIWebView issue for iOS 9.0 before dropping the support?
iOS 9 is still supported on Xcode 11 FYI.
@chauduyphanvu