### PR TITLE
Fix broken lib source in FairBidSDK 2.3.0

### DIFF
--- a/Specs/c/7/2/FairBidSDK/2.3.0/FairBidSDK.podspec.json
+++ b/Specs/c/7/2/FairBidSDK/2.3.0/FairBidSDK.podspec.json
@@ -10,7 +10,7 @@
   "authors": "Fyber",
   "social_media_url": "https://www.facebook.com/fybernv/",
   "source": {
-    "http": "https://d2jks9au6e6w94.cloudfront.net/sdk/ios/FairBid-iOS-SDK-2.3.0.zip"
+    "http": "https://cdn2.inner-active.mobi/fairbid-sdk/ios/FairBid-iOS-SDK-2.3.0.zip"
   },
   "platforms": {
     "ios": "8.0"


### PR DESCRIPTION
the CDN source is broken/unavailable. Changing the source to a working one (same host as newer version of the SDK)