### PR TITLE
Remove CocoaPod that I accidentally uploaded to public

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-Need 'LocationCocoaPod' to be removed from Specs.
+# The CocoaPods Master Repo
+
+This repository contains the public [CocoaPods](https://github.com/CocoaPods/CocoaPods) specifications.
+
+## Links
+
+- [Specs and the Specs Repo](http://guides.cocoapods.org/making/specs-and-specs-repo.html): Learn about creating Podspec's and the Spec repo.
+- [Getting setup with Trunk](http://guides.cocoapods.org/making/getting-setup-with-trunk.html): Instructions for creating a CocoaPods user account
+
+
+## License
+
+These specifications and CocoaPods are available under the [MIT license](http://www.opensource.org/licenses/mit-license.php).
+

--- a/README.md
+++ b/README.md
@@ -1,15 +1,1 @@
-# The CocoaPods Master Repo
-
-This repository contains the public [CocoaPods](https://github.com/CocoaPods/CocoaPods) specifications.
-
-## Links
-
-- [Specs and the Specs Repo](http://guides.cocoapods.org/making/specs-and-specs-repo.html): Learn about creating Podspec's and the Spec repo.
-- [Getting setup with Trunk](http://guides.cocoapods.org/making/getting-setup-with-trunk.html): Instructions for creating a CocoaPods user account
-
-
-## License
-
-These specifications and CocoaPods are available under the [MIT license](http://www.opensource.org/licenses/mit-license.php).
-
-
+Need 'LocationCocoaPod' to be removed from Specs.


### PR DESCRIPTION
May you guys remove 'LocationCocoaPod' from Specs please.
I did below 3 commands.
pod trunk delete LocationCocoaPod 1.1.0
pod trunk delete LocationCocoaPod.podspec
pod trunk deprecate LocationCocoaPod