### PR TITLE
Update Qualtrics.podspec to match M1 support.

### DIFF
--- a/Specs/c/9/7/Qualtrics/2.6.1/Qualtrics.podspec.json
+++ b/Specs/c/9/7/Qualtrics/2.6.1/Qualtrics.podspec.json
@@ -14,12 +14,6 @@
   "source": {
     "http": "https://s3-us-west-2.amazonaws.com/si-mobile-sdks/ios/2.6.1/Qualtrics.zip"
   },
-  "user_target_xcconfig": {
-    "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "arm64"
-  },
-  "pod_target_xcconfig": {
-    "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "arm64"
-  },
   "ios": {
     "vendored_frameworks": "Qualtrics.xcframework"
   }


### PR DESCRIPTION
According to the official release notes, version **2.4.0** added the actual support for building to arm64 based simulators. However, this .podspec attempts to exclude the arm64 architecture, so installing this CocoaPod inadvertently causes builds to fail. We should be able to remove these flags from the podspec since the support is already there as of version **2.6.1**.