### PR TITLE
I want to use on VideoSDK not Share Utility

### DIFF
--- a/Specs/e/f/b/ZoomVideoSDK/1.3.3/ZoomVideoSDK.podspec.json
+++ b/Specs/e/f/b/ZoomVideoSDK/1.3.3/ZoomVideoSDK.podspec.json
@@ -29,10 +29,6 @@
     {
       "name": "ZoomVideoSDK",
       "vendored_frameworks": "zoom-video-sdk-iOS/ZoomVideoSDK.xcframework"
-    },
-    {
-      "name": "ZoomVideoSDKScreenShare",
-      "vendored_frameworks": "zoom-video-sdk-iOS/ZoomVideoSDKScreenShare.xcframework"
     }
   ]
 }


### PR DESCRIPTION
I want to use only video sdk and not interested in VideoSDKScreenShare. Right now the VideoSDKScreenShare is not compiling because of compiler errors.