### PR TITLE
Update Dynamic-Yield-iOS-SDK.podspec.json

### DIFF
--- a/Specs/3/9/1/Dynamic-Yield-iOS-SDK/3.7.9/Dynamic-Yield-iOS-SDK.podspec.json
+++ b/Specs/3/9/1/Dynamic-Yield-iOS-SDK/3.7.9/Dynamic-Yield-iOS-SDK.podspec.json
@@ -11,7 +11,7 @@
     "DynamicYield": "iossupport@dynamicyield.com"
   },
   "source": {
-    "http": "https://dy-mobile-sdk.s3.amazonaws.com/ios/3.7.9/DYApi.zip"
+    "http": "https://dy-mobile-sdk.dynamicyield.com/ios/3.7.9/DYApi.zip"
   },
   "documentation_url": "https://www.dynamicyield.com",
   "platforms": {


### PR DESCRIPTION
DynamicYield Customers can’t download SDK using CocoaPods, since the URL was retired. Updating the SDK url.