### PR TITLE
Update FBAudienceNetwork.podspec.json

### DIFF
--- a/Specs/2/1/5/FBAudienceNetwork/6.14.0/FBAudienceNetwork.podspec.json
+++ b/Specs/2/1/5/FBAudienceNetwork/6.14.0/FBAudienceNetwork.podspec.json
@@ -46,10 +46,10 @@
     "z"
   ],
   "user_target_xcconfig": {
-    "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "i386 arm64"
+    "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "i386"
   },
   "pod_target_xcconfig": {
-    "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "i386 arm64"
+    "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "i386"
   },
   "vendored_frameworks": "Static/FBAudienceNetwork.xcframework",
   "requires_arc": true,


### PR DESCRIPTION
Removing unintentionally added config that excludes arm64 slice for simulator targets.