### PR TITLE
chore: add support for visionOS in libevent

### DIFF
--- a/Specs/0/9/9/libevent/2.1.11/libevent.podspec.json
+++ b/Specs/0/9/9/libevent/2.1.11/libevent.podspec.json
@@ -11,7 +11,8 @@
   "authors": "Niels Provos and Nick Mathewson",
   "platforms": {
     "osx": "10.13",
-    "ios": "10.0"
+    "ios": "10.0",
+    "visionos": "1.0"
   },
   "source": {
     "git": "https://github.com/libevent/libevent.git",

--- a/Specs/0/9/9/libevent/2.1.12/libevent.podspec.json
+++ b/Specs/0/9/9/libevent/2.1.12/libevent.podspec.json
@@ -11,7 +11,8 @@
   "authors": "Niels Provos and Nick Mathewson",
   "platforms": {
     "osx": "10.13",
-    "ios": "10.0"
+    "ios": "10.0",
+    "visionos": "1.0"
   },
   "source": {
     "git": "https://github.com/libevent/libevent.git",


### PR DESCRIPTION
This PR adds support for VisionOS to the `libevent` pod. This library doesn't require any changes to support VisionOS

Related: https://github.com/libevent/libevent/issues/1507

