### PR TITLE
Deprecate TeadsSdk v5.1.0

### DIFF
--- a/Specs/f/2/1/TeadsSDK/5.1.0/TeadsSDK.podspec.json
+++ b/Specs/f/2/1/TeadsSDK/5.1.0/TeadsSDK.podspec.json
@@ -46,5 +46,7 @@
       ]
     }
   ],
-  "swift_version": "5.3"
+  "swift_version": "5.3",
+  "deprecated": true,
+  "deprecated_in_favor_of": "5.1.1"
 }


### PR DESCRIPTION
Hello I am part of the Teads iOS team and we would like to deprecate the 5.1.0 version in favor of the 5.1.1

Thank you very much