### PR TITLE
Update !ProtoCompiler.podspec.json

### DIFF
--- a/Specs/a/a/8/!ProtoCompiler/4.30.0/!ProtoCompiler.podspec.json
+++ b/Specs/a/a/8/!ProtoCompiler/4.30.0/!ProtoCompiler.podspec.json
@@ -12,7 +12,7 @@
     "The Protocol Buffers contributors": "protobuf@googlegroups.com"
   },
   "source": {
-    "http": "https://github.com/google/protobuf/releases/download/v4.30.0/protoc-4.30.0-osx-universal_binary.zip"
+    "http": "https://github.com/google/protobuf/releases/download/v30.0/protoc-30.0-osx-universal_binary.zip"
   },
   "preserve_paths": [
     "protoc",


### PR DESCRIPTION
Sorry for the inconvenience, the link in the podspec was incorrectly generated, 
this PR fixes probotuf release link,
I have verified the new link is downloadable.